### PR TITLE
Support `exceptionPatterns` in `reactotron-redux`

### DIFF
--- a/packages/reactotron-redux/src/create-action-tracker.js
+++ b/packages/reactotron-redux/src/create-action-tracker.js
@@ -15,6 +15,7 @@ export default (reactotron, trackerOptions = {}) => {
   // assemble a crack team of options to use
   const options = merge(DEFAULTS, trackerOptions)
   const exceptions = concat([DEFAULT_REPLACER_TYPE], options.except || [])
+  const exceptionPatterns = options.exceptionPatterns || [];
 
   // the store enhancer
   return next => (reducer, initialState, enhancer) => {
@@ -39,8 +40,10 @@ export default (reactotron, trackerOptions = {}) => {
 
         var unwrappedAction = action.type === 'PERFORM_ACTION' && action.action ? action.action : action
 
+        const exceptionPattern = exceptionPatterns.reduce((prev, pattern) => pattern(unwrappedAction.type) || prev, false);
+
         // action not blacklisted?
-        if (!contains(unwrappedAction.type, exceptions)) {
+        if (!exceptionPattern && !contains(unwrappedAction.type, exceptions)) {
           // check if the app considers this important
           let important = false
           if (trackerOptions && typeof trackerOptions.isActionImportant === 'function') {

--- a/packages/reactotron-redux/src/create-action-tracker.js
+++ b/packages/reactotron-redux/src/create-action-tracker.js
@@ -1,4 +1,4 @@
-import { contains, is, concat, merge } from 'ramda'
+import { is, concat, merge } from 'ramda'
 import { DEFAULT_REPLACER_TYPE } from './replacement-reducer'
 
 const DEFAULTS = {
@@ -39,24 +39,24 @@ export default (reactotron, trackerOptions = {}) => {
 
         var unwrappedAction = action.type === 'PERFORM_ACTION' && action.action ? action.action : action
 
-        const checkException = (exception, actionType) => {
-          switch (typeof exception) {
-            case 'string':
-              return actionType === exception;
-            case 'function':
-              return exception(actionType);
-            case 'object':
-              return exception.test(actionType);
-              break;
-            default:
-              return false;
+        // if matchException is true, actionType is matched with exception
+        const matchException = (exception, actionType) => {
+          if (typeof exception === 'string') {
+            return actionType === exception
+          } else if (typeof exception === 'function') {
+            return actionType === exception
+          } else if (exception instanceof RegExp) {
+            return exception.test(actionType)
+          } else {
+            return false
           }
         }
 
-        const checkExceptions = exceptions.reduce((prev, exception) => checkExcpetion(exception, unwrappedAction.type) || prev, false);
+        const matchExceptions = exceptions.reduce((prev, exception) => matchException(exception, unwrappedAction.type) || prev, false)
 
         // action not blacklisted?
-        if (!checkExcpetions) {
+        // if matchException is true, action.type is matched with exception
+        if (!matchExceptions) {
           // check if the app considers this important
           let important = false
           if (trackerOptions && typeof trackerOptions.isActionImportant === 'function') {

--- a/packages/reactotron-redux/src/create-action-tracker.js
+++ b/packages/reactotron-redux/src/create-action-tracker.js
@@ -15,7 +15,6 @@ export default (reactotron, trackerOptions = {}) => {
   // assemble a crack team of options to use
   const options = merge(DEFAULTS, trackerOptions)
   const exceptions = concat([DEFAULT_REPLACER_TYPE], options.except || [])
-  const exceptionPatterns = options.exceptionPatterns || [];
 
   // the store enhancer
   return next => (reducer, initialState, enhancer) => {
@@ -40,10 +39,24 @@ export default (reactotron, trackerOptions = {}) => {
 
         var unwrappedAction = action.type === 'PERFORM_ACTION' && action.action ? action.action : action
 
-        const exceptionPattern = exceptionPatterns.reduce((prev, pattern) => pattern(unwrappedAction.type) || prev, false);
+        const checkException = (exception, actionType) => {
+          switch (typeof exception) {
+            case 'string':
+              return actionType === exception;
+            case 'function':
+              return exception(actionType);
+            case 'object':
+              return exception.test(actionType);
+              break;
+            default:
+              return false;
+          }
+        }
+
+        const checkExceptions = exceptions.reduce((prev, exception) => checkExcpetion(exception, unwrappedAction.type) || prev, false);
 
         // action not blacklisted?
-        if (!exceptionPattern && !contains(unwrappedAction.type, exceptions)) {
+        if (!checkExcpetions) {
           // check if the app considers this important
           let important = false
           if (trackerOptions && typeof trackerOptions.isActionImportant === 'function') {

--- a/packages/reactotron-redux/src/create-action-tracker.js
+++ b/packages/reactotron-redux/src/create-action-tracker.js
@@ -1,5 +1,6 @@
 import { is, concat, merge } from 'ramda'
 import { DEFAULT_REPLACER_TYPE } from './replacement-reducer'
+import { any } from 'ramda'
 
 const DEFAULTS = {
   // except: [] // which actions
@@ -44,7 +45,7 @@ export default (reactotron, trackerOptions = {}) => {
           if (typeof exception === 'string') {
             return actionType === exception
           } else if (typeof exception === 'function') {
-            return actionType === exception
+            return exception(actionType)
           } else if (exception instanceof RegExp) {
             return exception.test(actionType)
           } else {
@@ -52,7 +53,7 @@ export default (reactotron, trackerOptions = {}) => {
           }
         }
 
-        const matchExceptions = exceptions.reduce((prev, exception) => matchException(exception, unwrappedAction.type) || prev, false)
+        const matchExceptions = any(exception => matchException(exception, unwrappedAction.type), exceptions)
 
         // action not blacklisted?
         // if matchException is true, action.type is matched with exception


### PR DESCRIPTION
This PR adds `exceptionPatterns` which is `exception` for Function. I think this make `except` more simple.

example
```js
const REACT_NATIVE_ROUTER_FLUX = (type) => type.includes('REACT_NATIVE_ROUTER_FLUX');
const REDUX_SAGA_REQUEST = (type) => type.includes('request');

Reactotron
  .use(reactotronRedux({
    except: [],
    exceptPattern: [
      REACT_NATIVE_ROUTER_FLUX,
      REDUX_SAGA_REQUEST,
    ],
  }))
```