### PR TITLE
Skip printing images with apisauce.

### DIFF
--- a/docs/plugin-apisauce.md
+++ b/docs/plugin-apisauce.md
@@ -20,7 +20,9 @@ import apisaucePlugin from 'reactotron-apisauce'  // <--- import
 
 Reactotron
   .configure()
-  .use(apisaucePlugin()) // <-- here we go!!!
+  .use(apisaucePlugin({
+    // ignoreContentTypes: /^(image)\/.*$/i   // <--- a way to skip printing the body of some requests (default is any image)
+  })) // <-- here we go!!!
   .connect()
 ```
 

--- a/packages/demo-react-native/App/Config/ReactotronConfig.js
+++ b/packages/demo-react-native/App/Config/ReactotronConfig.js
@@ -1,5 +1,5 @@
 import Reactotron, { trackGlobalErrors, openInEditor, overlay, asyncStorage } from 'reactotron-react-native'
-import tronsauce from 'reactotron-apisauce'
+import apisauce from 'reactotron-apisauce'
 import { reactotronRedux } from 'reactotron-redux'
 import sagaPlugin from 'reactotron-redux-saga'
 import { test } from 'ramda'
@@ -11,7 +11,9 @@ const vetoTest = test(/(node_modules\/react\/)/)
 if (__DEV__) {
   Reactotron
     .configure({ name: 'React Native Demo' })
-    .use(tronsauce())
+    .use(apisauce({
+      ignoreContentTypes: /^(image)\/.*$/i
+    }))
     .use(reactotronRedux({
       isActionImportant: action => action.type === 'something.important',
       except: ['ignore']

--- a/packages/demo-react-native/App/Sagas/RepoSagas.js
+++ b/packages/demo-react-native/App/Sagas/RepoSagas.js
@@ -29,10 +29,13 @@ export function * request (api, action) {
       const entry = RS.dotPath('0', data)
       const { commit, author, html_url: url } = entry
       const { message, tree } = commit
-      const { login, avatar_url } = author
+      const { login, avatar_url: avatar } = author
       const { sha } = tree
       // record the last commit's message
-      yield put(Repo.Actions.receive(message, url, login, sha, avatar_url))
+      yield put(Repo.Actions.receive(message, url, login, sha, avatar))
+      if (avatar) {
+        yield call(api.get, avatar, null, { headers: { 'Accept': '*' } })
+      }
     } else {
       yield put(Repo.Actions.failure(`uh oh: ${problem} status: ${status}`))
     }

--- a/packages/reactotron-apisauce/rollup.config.js
+++ b/packages/reactotron-apisauce/rollup.config.js
@@ -12,6 +12,7 @@ export default {
   ],
   dest: 'dist/index.js',
   external: [
-    'ramdasauce'
+    'ramdasauce',
+    'ramda'
   ]
 }


### PR DESCRIPTION
Let's not attempt to print things like images when logging.  It really tanks performance.

![image](https://cloud.githubusercontent.com/assets/68273/23828604/3163ef14-06a5-11e7-9fbb-7d26cb279a73.png)
![image](https://cloud.githubusercontent.com/assets/68273/23828607/413c7348-06a5-11e7-9797-2b100df3615b.png)

Fixes #344 

