### PR TITLE
Shows the URL in the API preview area.

### DIFF
--- a/packages/reactotron-app/App/Commands/ApiResponseCommand.js
+++ b/packages/reactotron-app/App/Commands/ApiResponseCommand.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import Command from '../Shared/Command'
 import { dotPath, isNilOrEmpty } from 'ramdasauce'
-import { toUpper, equals, isNil } from 'ramda'
+import { pipe, toUpper, equals, isNil, replace } from 'ramda'
 import makeTable from '../Shared/MakeTable'
 import Colors from '../Theme/Colors'
 import AppStyles from '../Theme/AppStyles'
@@ -129,13 +129,17 @@ class ApiResponseCommand extends Component {
     const { duration } = payload
     const status = dotPath('response.status', payload)
     const url = dotPath('request.url', payload)
+    const smallUrl = pipe(
+      replace(/^http(s):\/\/[a-zA-Z0-9.]*/i, ''),
+      replace(/\?.*$/i, ''),
+    )(url)
     const method = toUpper(dotPath('request.method', payload) || '')
     const requestHeaders = dotPath('request.headers', payload)
     const responseHeaders = dotPath('response.headers', payload)
     const requestBody = getRequestText(dotPath('request.data', payload))
     const responseBody = dotPath('response.body', payload)
     const requestParams = dotPath('request.params', payload)
-    const subtitle = `${status} ${method} in ${duration || '?'}ms`
+    const subtitle = `${method} ${smallUrl}`
     const preview = subtitle
     const summary = { 'Status Code': status, 'Method': method, 'Duration (ms)': duration }
 

--- a/packages/reactotron-app/App/Shared/Command.js
+++ b/packages/reactotron-app/App/Shared/Command.js
@@ -61,7 +61,9 @@ const Styles = {
     WebkitBoxOrient: 'vertical',
     textOverflow: 'ellipsis',
     display: '-webkit-box',
-    flex: 1
+    flex: 1,
+    wordBreak: 'break-all',
+
   },
   duration: {
     color: Colors.foregroundDark,


### PR DESCRIPTION
URL is more important than response code & duration.  If it's an error, it'll show up red anyway.

![image](https://cloud.githubusercontent.com/assets/68273/23828732/fdbae51a-06a8-11e7-91b7-385713bad038.png)
