### PR TITLE
Improves text selections.

### DIFF
--- a/packages/reactotron-app/App/Commands/ApiResponseCommand.js
+++ b/packages/reactotron-app/App/Commands/ApiResponseCommand.js
@@ -51,7 +51,9 @@ const Styles = {
   url: {
     wordBreak: 'break-all',
     color: Colors.constant,
-    paddingBottom: 10
+    paddingBottom: 10,
+    WebkitUserSelect: 'text',
+    cursor: 'text'
   },
   headerTitle: {
     margin: 0,

--- a/packages/reactotron-app/App/Shared/MakeTable.js
+++ b/packages/reactotron-app/App/Shared/MakeTable.js
@@ -19,7 +19,9 @@ const Styles = {
     paddingRight: 10,
     wordBreak: 'break-all',
     textAlign: 'left',
-    color: Colors.foregroundDark
+    color: Colors.foregroundDark,
+    WebkitUserSelect: 'text',
+    cursor: 'text'
   },
   value: {
     flex: 1,
@@ -48,7 +50,7 @@ export function colorForValue (value) {
 
 const makeRow = ([key, value]) => {
   const textValue = textForValue(value)
-  const valueStyle = merge(Styles.value, { color: colorForValue(value) })
+  const valueStyle = merge(Styles.value, { color: colorForValue(value), WebkitUserSelect: 'text', cursor: 'text' })
 
   return (
     <div key={key} style={Styles.row}>


### PR DESCRIPTION
You can now select a column in a row by itself:

![image](https://cloud.githubusercontent.com/assets/68273/23828754/c14e8018-06a9-11e7-9ba2-c8547a0dcb73.png)

You can now select the URL too:

![image](https://cloud.githubusercontent.com/assets/68273/23828757/e430afc0-06a9-11e7-8308-a98aa16fa9fe.png)
