### PR TITLE
Identifies promises disguised as promises.

### DIFF
--- a/packages/demo-react-native/App/Sagas/StartupSagas.js
+++ b/packages/demo-react-native/App/Sagas/StartupSagas.js
@@ -29,5 +29,7 @@ function testFunctionNames () {
 export function * startup () {
   testRecursion()
   testFunctionNames()
+  // we can yield promises to sagas now... if that's how you roll
+  yield new Promise(resolve => { resolve() }) // eslint-disable-line
   yield put({ type: 'HELLO' })
 }

--- a/packages/reactotron-redux-saga/src/get-effect-description.js
+++ b/packages/reactotron-redux-saga/src/get-effect-description.js
@@ -7,6 +7,17 @@ import { isNilOrEmpty } from 'ramdasauce'
 /* eslint-disable no-cond-assign */
 export default effect => {
   if (!effect) return SagaConstants.UNKNOWN
+  if (effect instanceof Promise) {
+    let display
+    if (effect.name) { // a promise object with a manually set name prop for display reasons
+      display = `${SagaConstants.PROMISE}(${effect.name})`
+    } else if (effect.constructor instanceof Promise.constructor) { // an anonymous promise
+      display = SagaConstants.PROMISE
+    } else { // class which extends Promise, so output the name of the class to precise
+      display = `${SagaConstants.PROMISE}(${effect.constructor.name})`
+    }
+    return display
+  }
   if (effect.root) return effect.saga.name
   let data
   if (data = asEffect.take(effect)) return data.pattern || 'channel'

--- a/packages/reactotron-redux-saga/src/get-effect-name.js
+++ b/packages/reactotron-redux-saga/src/get-effect-name.js
@@ -3,6 +3,8 @@ import { is, asEffect } from 'redux-saga/utils'
 import * as SagaConstants from './saga-constants'
 
 export default effect => {
+  if (!effect) return SagaConstants.UNKNOWN
+  if (effect instanceof Promise) return SagaConstants.PROMISE
   if (asEffect.take(effect)) return SagaConstants.TAKE
   if (asEffect.put(effect)) return SagaConstants.PUT
   if (asEffect.call(effect)) return SagaConstants.CALL

--- a/packages/reactotron-redux-saga/src/saga-constants.js
+++ b/packages/reactotron-redux-saga/src/saga-constants.js
@@ -10,6 +10,7 @@ export const CANCEL = 'CANCEL'
 export const SELECT = 'SELECT'
 export const PARALLEL = 'PARALLEL'
 export const ITERATOR = 'ITERATOR'
+export const PROMISE = 'PROMISE' // not from redux-saga
 export const UNKNOWN = 'UNKNOWN' // not from redux-saga
 
 // monitoring statuses

--- a/packages/reactotron-redux-saga/src/saga-monitor.js
+++ b/packages/reactotron-redux-saga/src/saga-monitor.js
@@ -108,15 +108,15 @@ export default (reactotron, options) => {
         children.push({
           depth,
           effectId: sourceEffectInfo.effectId,
-          parentEffectId: sourceEffectInfo.parentEffectId,
-          name: sourceEffectInfo.name,
-          description: sourceEffectInfo.description,
+          parentEffectId: sourceEffectInfo.parentEffectId || null,
+          name: sourceEffectInfo.name || null,
+          description: sourceEffectInfo.description || null,
           duration: Math.round(sourceEffectInfo.duration),
-          status: sourceEffectInfo.status,
-          winner: sourceEffectInfo.winner,
-          loser: sourceEffectInfo.loser,
-          result: sourceEffectInfo.result,
-          extra
+          status: sourceEffectInfo.status || null,
+          winner: sourceEffectInfo.winner || null,
+          loser: sourceEffectInfo.loser || null,
+          result: sourceEffectInfo.result || null,
+          extra: extra || null
         })
 
         // rerun this function for our children


### PR DESCRIPTION
You can yield a promise directly without going thru a `call` effect.  This supports that.

![image](https://cloud.githubusercontent.com/assets/68273/23828858/5bf7f8a8-06ad-11e7-92e0-c611864d5632.png)

Fixes #346 