### PR TITLE
AsyncStorage UI

### DIFF
--- a/docs/plugin-async-storage.md
+++ b/docs/plugin-async-storage.md
@@ -1,0 +1,32 @@
+# Async Storage
+
+Included in `reactotron-react-native` is a plugin called `asyncStorage` which allows you to track [AsyncStorage](https://facebook.github.io/react-native/docs/asyncstorage.html) on React Native.
+
+## Usage
+
+Wherever you setup your Reactotron in your app, you also add the additional plugin on the `import` line.
+
+```js
+import Reactotron, { asyncStorage } from 'reactotron-react-native'
+```
+
+Next, add it as a plugin to Reactotron.
+
+```js
+Reactotron
+  .configure()
+  .use(asyncStorage()) // <--- here we go!
+  .connect()
+```
+
+You're done.
+
+## Advanced Usage
+
+`asyncStorage()` also accepts an object with an `ignore` key.  The value is an array of strings you would like to prevent sending to Reactotron.
+
+```js
+asyncStorage({
+  ignore: ['secret']
+})
+```

--- a/packages/demo-react-native/App/Config/ReactotronConfig.js
+++ b/packages/demo-react-native/App/Config/ReactotronConfig.js
@@ -32,7 +32,7 @@ if (__DEV__) {
     .use(openInEditor())
     .use(sagaPlugin())
     .use(overlay())
-    .use(asyncStorage())
+    .use(asyncStorage({ ignore: ['secret'] }))
     .connect()
 
   console.tron = Reactotron

--- a/packages/demo-react-native/App/Containers/RootContainer.js
+++ b/packages/demo-react-native/App/Containers/RootContainer.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { ScrollView, View, Text, AsyncStorage, Alert } from 'react-native'
+import { ScrollView, View, Text, AsyncStorage } from 'react-native'
 import { connect } from 'react-redux'
 import Styles from './Styles/RootContainerStyles'
 import Button from '../Components/Button'
@@ -54,7 +54,7 @@ class RootContainer extends Component {
   }
 
   handleAsyncSet () {
-    AsyncStorage.setItem('singleSet', new Date().toISOString(), () => Alert.alert('I even call the original callback!'))
+    AsyncStorage.setItem('singleSet', new Date().toISOString(), () => console.tron.log('After setting async storage.'))
   }
 
   handleAsyncRemove () {

--- a/packages/demo-react-native/App/Sagas/StartupSagas.js
+++ b/packages/demo-react-native/App/Sagas/StartupSagas.js
@@ -1,4 +1,4 @@
-import { put, call } from 'redux-saga/effects'
+import { put } from 'redux-saga/effects'
 import { AsyncStorage } from 'react-native'
 
 function testRecursion () {

--- a/packages/demo-react-native/App/Sagas/StartupSagas.js
+++ b/packages/demo-react-native/App/Sagas/StartupSagas.js
@@ -1,4 +1,5 @@
-import { put } from 'redux-saga/effects'
+import { put, call } from 'redux-saga/effects'
+import { AsyncStorage } from 'react-native'
 
 function testRecursion () {
   if (!__DEV__) return
@@ -25,10 +26,22 @@ function testFunctionNames () {
   })
 }
 
+async function addStuffToAsyncStorage () {
+  const exists = await AsyncStorage.getItem('addedAt')
+  if (exists) return
+  await AsyncStorage.multiSet([
+    ['secret', 'should not go to reactotron.'],
+    ['not.secret', 'this should go to reactotron though'],
+    ['stringify', JSON.stringify({ hello: { nested: 100 } })],
+    ['addedAt', new Date().toISOString()]
+  ])
+}
+
 // process STARTUP actions
 export function * startup () {
   testRecursion()
   testFunctionNames()
+  addStuffToAsyncStorage()
   // we can yield promises to sagas now... if that's how you roll
   yield new Promise(resolve => { resolve() }) // eslint-disable-line
   yield put({ type: 'HELLO' })

--- a/packages/reactotron-app/App/Commands/AsyncStorageValuesCommand.js
+++ b/packages/reactotron-app/App/Commands/AsyncStorageValuesCommand.js
@@ -1,0 +1,96 @@
+import React, { Component, PropTypes } from 'react'
+import Command from '../Shared/Command'
+import ObjectTree from '../Shared/ObjectTree'
+import Colors from '../Theme/Colors'
+import AppStyles from '../Theme/AppStyles'
+import { is, addIndex, map } from 'ramda'
+import { textForValue } from '../Shared/MakeTable'
+
+const mapIndexed = addIndex(map)
+
+const COMMAND_TITLE = 'ASYNC STORAGE'
+
+class AsyncStorageValuesCommand extends Component {
+
+  static propTypes = {
+    command: PropTypes.object.isRequired
+  }
+
+  constructor (props) {
+    super(props)
+    this.renderItem = this.renderItem.bind(this)
+  }
+
+  shouldComponentUpdate (nextProps) {
+    return this.props.command.id !== nextProps.command.id
+  }
+
+  renderItem (item, idx) {
+    const [asyncStorageKey, asyncStorageValue] = item
+    const key = `item-${idx}`
+    const value = is(Object, asyncStorageValue) ? <ObjectTree object={{value: asyncStorageValue}} /> : textForValue(asyncStorageValue)
+    return (
+      <div style={Styles.item} key={key}>
+        <div style={Styles.itemLeft}>
+          <div style={Styles.key}>{asyncStorageKey}</div>
+        </div>
+        <div style={Styles.value}>
+          {value}
+        </div>
+      </div>
+    )
+  }
+
+  render () {
+    const { command } = this.props
+    const { payload = [] } = command
+    const rows = mapIndexed(this.renderItem, payload)
+    return (
+      <Command command={command} title={COMMAND_TITLE}>
+        <div style={Styles.watches}>
+          {rows}
+        </div>
+      </Command>
+    )
+  }
+}
+
+const Styles = {
+  container: {
+    ...AppStyles.Layout.vbox,
+    margin: 0,
+    flex: 1
+  },
+  items: {
+    margin: 0,
+    padding: 0,
+    overflowY: 'auto',
+    overflowX: 'hidden'
+  },
+  item: {
+    ...AppStyles.Layout.hbox,
+    padding: '5px',
+    justifyContent: 'space-between'
+  },
+  itemLeft: {
+    minWidth: 215,
+    maxWidth: 215,
+    wordBreak: 'break-all'
+  },
+  key: {
+    color: Colors.constant,
+    WebkitUserSelect: 'text',
+    cursor: 'text'
+  },
+  value: {
+    flex: 1,
+    wordBreak: 'break-all',
+    WebkitUserSelect: 'text',
+    cursor: 'text'
+  },
+  title: {
+    color: Colors.tag
+  }
+}
+
+export default AsyncStorageValuesCommand

--- a/packages/reactotron-app/App/Commands/index.js
+++ b/packages/reactotron-app/App/Commands/index.js
@@ -9,6 +9,7 @@ import StateValuesChangeCommand from './StateValuesChangeCommand'
 import DisplayCommand from './DisplayCommand'
 import ImageCommand from './ImageCommand'
 import SagaTaskCompleteCommand from './SagaTaskCompleteCommand'
+import AsyncStorageValuesCommand from './AsyncStorageValuesCommand'
 
 export default command => {
   const { type } = command
@@ -25,6 +26,9 @@ export default command => {
     case 'display': return DisplayCommand
     case 'image': return ImageCommand
     case 'saga.task.complete': return SagaTaskCompleteCommand
-    default: return null
+    case 'asyncStorage.values.change': return AsyncStorageValuesCommand
+    default: {
+      return null
+    }
   }
 }

--- a/packages/reactotron-app/App/Dialogs/FilterTimelineDialog.js
+++ b/packages/reactotron-app/App/Dialogs/FilterTimelineDialog.js
@@ -28,6 +28,12 @@ const GROUPS = [
     ]
   },
   {
+    name: 'Async Storage',
+    items: [
+      { value: 'asyncStorage.values.change', text: 'Changes' }
+    ]
+  },
+  {
     name: 'Redux & Sagas',
     items: [
       { value: 'state.action.complete', text: 'Action' },

--- a/packages/reactotron-core-server/src/types.js
+++ b/packages/reactotron-core-server/src/types.js
@@ -13,5 +13,7 @@ export default [
   'benchmark.report',
   'display',
   'clear',
-  'storage.updated'
+  'asyncStorage.values.request',
+  'asyncStorage.values.response',
+  'asyncStorage.values.change'
 ]

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Use it to:
 * hot swap your app's state
 * track your sagas
 * show image overlay in React Native
+* track your Async Storage in React Native
 
 You plug it into your app as a dev dependency so it adds nothing to your product builds.
 
@@ -37,6 +38,7 @@ Reactotron on the left, demo React Native app on the right.
 * [Tracking errors globally](./docs/plugin-track-global-errors.md)
 * [Open in editor](./docs/plugin-open-in-editor.md)
 * [Image Overlays](./docs/plugin-overlay.md)
+* [Async Storage](./docs/plugin-async-storage.md)
 * Integrating with [Redux](./docs/plugin-redux.md)
 * Integrating with [Redux Saga](./docs/plugin-redux-saga.md)
 * Networking monitoring with [Apisauce](./docs/plugin-apisauce.md)


### PR DESCRIPTION
Adds a basic UI for AsyncStorage.

![image](https://cloud.githubusercontent.com/assets/68273/23833576/66a73f2c-071e-11e7-962e-d9903aa2320c.png)

@rmevans9 I changed the API just a little bit.  I wanted to model the messages after the way we do `state` so we can transition into a UI that works like the state subscriptions.

I also added an ignore option on the plugin... i figured there might be heavy or secret keys in AsyncStorage we might not want to show.

Also added some docs, albeit, pretty light.