### PR TITLE
Coerces undefined to null for errors. :(

### DIFF
--- a/packages/reactotron-core-client/src/plugins/logger.js
+++ b/packages/reactotron-core-client/src/plugins/logger.js
@@ -4,10 +4,30 @@
 export default () => reactotron => {
   return {
     features: {
-      log: (message, important = false) => reactotron.send('log', { level: 'debug', message }, !!important),
-      debug: (message, important = false) => reactotron.send('log', { level: 'debug', message }, !!important),
-      warn: message => reactotron.send('log', { level: 'warn', message }, true),
-      error: (message, stack) => reactotron.send('log', { level: 'error', message, stack }, true)
+      log: (message, important = false) =>
+        reactotron.send(
+          'log',
+          { level: 'debug', message: message || null },
+          !!important
+        ),
+      debug: (message, important = false) =>
+        reactotron.send(
+          'log',
+          { level: 'debug', message: message || null },
+          !!important
+        ),
+      warn: message =>
+        reactotron.send(
+          'log',
+          { level: 'warn', message: message || null },
+          true
+        ),
+      error: (message, stack) =>
+        reactotron.send(
+          'log',
+          { level: 'error', message: message || null, stack: stack || null },
+          true
+        )
     }
   }
 }


### PR DESCRIPTION
Part of the new serialization changes `undefined` values to `~~~ undefined ~~~` strings.  

Because of this, logging errors with no stacks would come across as `stack: '~~~ undefined ~~~'` which causes an exception on the app.  Sending it into a tail spin.

This PR is a emergency fix.  I'll be overhauling this in 2.0.

Side note:  null vs undefined strikes again. classic JavaScript.  Nowadays there's just too many better options that deal with this. Flow, TypeScript, Elm, PureScript.  All better options than the honour system.

