### PR TITLE
Reactotron React Native useAllIncluded

### DIFF
--- a/packages/demo-react-native/App/Config/ReactotronConfig.js
+++ b/packages/demo-react-native/App/Config/ReactotronConfig.js
@@ -24,6 +24,11 @@ if (__DEV__) {
       reconnectionAttempts: 10
     }
   })
+    .useAllIncluded({
+      trackGlobalErrors: { veto: frame => vetoTest(frame.fileName) },
+      networking: { ignoreContentTypes: /^(image)\/.*$/i },
+      asyncStorage: { ignore: ['secret'] }
+    })
     // .use(apisauce({}))
     .use(
       reactotronRedux({
@@ -31,16 +36,7 @@ if (__DEV__) {
         except: ['ignore']
       })
     )
-    .use(
-      trackGlobalErrors({
-        veto: frame => vetoTest(frame.fileName)
-      })
-    )
-    .use(networking({ ignoreContentTypes: /^(image)\/.*$/i }))
-    .use(openInEditor())
     .use(sagaPlugin())
-    .use(overlay())
-    .use(asyncStorage({ ignore: ['secret'] }))
     .connect()
 
   console.tron = Reactotron

--- a/packages/reactotron-react-native/src/index.js
+++ b/packages/reactotron-react-native/src/index.js
@@ -2,11 +2,19 @@
 // FIRST PARTY
 // -----------
 
-export trackGlobalErrors from './plugins/track-global-errors'
-export openInEditor from './plugins/open-in-editor'
-export overlay from './plugins/overlay'
-export asyncStorage from './plugins/async-storage'
-export networking from './plugins/networking'
+import trackGlobalErrors from './plugins/track-global-errors'
+import openInEditor from './plugins/open-in-editor'
+import overlay from './plugins/overlay'
+import asyncStorage from './plugins/async-storage'
+import networking from './plugins/networking'
+
+export {
+  trackGlobalErrors,
+  openInEditor,
+  overlay,
+  asyncStorage,
+  networking
+}
 
 // ------------
 // SECOND PARTY
@@ -40,6 +48,18 @@ const DEFAULTS = {
 // -----------
 // Create the default reactotron.
 const reactotron = createClient(DEFAULTS)
+
+// -------------
+// PLUGIN HELPER
+// -------------
+reactotron.useAllIncluded = options => {
+  return reactotron
+            .use(trackGlobalErrors(options.trackGlobalErrors || {}))
+            .use(openInEditor(options.openInEditor || {}))
+            .use(overlay())
+            .use(asyncStorage(options.asyncStorage || {}))
+            .use(networking(options.networking || {}))
+}
 
 // send it back
 export default reactotron


### PR DESCRIPTION
This is for all those devs out there that feel like having 5 use statments just to wire up Reactotron React Native "is just a bit over the top".

See demo for a example of using this.

This is 100% backward compatible since Reactotron React Native is still exporting each individual plugin