### PR TITLE
Adds safe recursion back in.

### DIFF
--- a/packages/reactotron-core-client/src/index.js
+++ b/packages/reactotron-core-client/src/index.js
@@ -142,7 +142,9 @@ export class Client {
     // NOTE(steve): socket.io is going away shortly, so there will
     // be no need to deserialize as we'll be sending text over the
     // wire.
-    const actualPayload = JSON.parse(serialize(payload))
+    const actualPayload = this.options.safeRecursion
+      ? JSON.parse(serialize(payload))
+      : payload
 
     // send this command
     this.socket.emit('command', {


### PR DESCRIPTION
I'd removed this switch when I reworked the serialization.  There are some cases where you still might want this.  For example, we have a `select()` in one of our `redux-saga` sagas that is `const everything = select(state => state)`.  That's our bad, but our reducer data is so heavy (10 mb), that it takes 8 seconds to serialize this.

Yes, that's the project's problem, but Reactotron should not stall the app like that if there's a way we can opt-out.

(I'll be fixing the app, but this PR brings our switch back at least)