### PR TITLE
Fix timeline filtering for 'Subscriptions Changed'

### DIFF
--- a/packages/reactotron-app/App/Dialogs/FilterTimelineDialog.js
+++ b/packages/reactotron-app/App/Dialogs/FilterTimelineDialog.js
@@ -38,7 +38,7 @@ const GROUPS = [
     items: [
       { value: 'state.action.complete', text: 'Action' },
       { value: 'saga.task.complete', text: 'Saga' },
-      { value: 'state.values.response', text: 'Subscription Changed' }
+      { value: 'state.values.change', text: 'Subscription Changed' }
     ]
   }
 ]


### PR DESCRIPTION
As discussed in Slack the subscription changed filter is ignored (i.e. if you uncheck it, subscription changed events will still appear).

I think this should fix it but I haven't had a chance to test it yet. @skellock could you confirm it works? Otherwise tomorrow I'll try to setup the dev environment for reactotron and test it myself.