### PR TITLE
Marks reactotron-app as private so we don't send to npm.

### DIFF
--- a/packages/reactotron-app/package.json
+++ b/packages/reactotron-app/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "reactotron-app",
   "productName": "Reactotron",
   "version": "1.10.0",


### PR DESCRIPTION
Lerna won't publish private modules.   We ship binaries and don't need to live on npm for this package.