### PR TITLE
Fixes falsy values in log()

### DIFF
--- a/packages/reactotron-core-client/src/plugins/logger.js
+++ b/packages/reactotron-core-client/src/plugins/logger.js
@@ -5,29 +5,12 @@ export default () => reactotron => {
   return {
     features: {
       log: (message, important = false) =>
-        reactotron.send(
-          'log',
-          { level: 'debug', message: message || null },
-          !!important
-        ),
+        reactotron.send('log', { level: 'debug', message }, !!important),
       debug: (message, important = false) =>
-        reactotron.send(
-          'log',
-          { level: 'debug', message: message || null },
-          !!important
-        ),
-      warn: message =>
-        reactotron.send(
-          'log',
-          { level: 'warn', message: message || null },
-          true
-        ),
+        reactotron.send('log', { level: 'debug', message }, !!important),
+      warn: message => reactotron.send('log', { level: 'warn', message }, true),
       error: (message, stack) =>
-        reactotron.send(
-          'log',
-          { level: 'error', message: message || null, stack: stack || null },
-          true
-        )
+        reactotron.send('log', { level: 'error', message, stack }, true)
     }
   }
 }


### PR DESCRIPTION
Fixes #428 

```js
console.log.tron(0)
```

![image](https://cloud.githubusercontent.com/assets/68273/26417524/7117e91e-4087-11e7-8b5a-e0f7d7cf4143.png)

