### PR TITLE
Sets a smaller pingTimeout to play nice with RN Android.

### DIFF
--- a/packages/reactotron-core-server/src/index.js
+++ b/packages/reactotron-core-server/src/index.js
@@ -67,7 +67,7 @@ class Server {
     const { onCommand, onConnect, onDisconnect } = this.options
 
     // start listening
-    this.io = socketIO(port)
+    this.io = socketIO(port, { pingTimeout: 30000 })
 
     // register events
     this.io.on('connection', socket => {


### PR DESCRIPTION
On React Native Android, long running timers [are a bad thing](https://github.com/facebook/react-native/issues/12981).

This is short term fix for #432.

