### PR TITLE
Cleanup the entire serialized message on the server side

### DIFF
--- a/packages/reactotron-core-server/src/index.js
+++ b/packages/reactotron-core-server/src/index.js
@@ -118,6 +118,7 @@ class Server {
       // when we receive a command from the client
       socket.on('message', incoming => {
         const message = JSON.parse(incoming)
+        repair(message)
         const { type, important, payload } = message
         this.messageId++
         const date = new Date()
@@ -129,7 +130,6 @@ class Server {
           date
         }
 
-        repair(payload)
         // for client intros
         if (type === 'client.intro') {
           // find them in the partial connection list


### PR DESCRIPTION
It would be super confusing if we didn't cleanup important and everything came over as important.