### PR TITLE
Change 'Hide Others' accelerator to standard macOS shortcut

### DIFF
--- a/packages/reactotron-app/main.development.js
+++ b/packages/reactotron-app/main.development.js
@@ -42,7 +42,7 @@ app.on('ready', () => {
         { label: 'About Reactotron', selector: 'orderFrontStandardAboutPanel:' },
         { type: 'separator' },
         { label: 'Hide Reactotron', accelerator: 'Command+H', selector: 'hide:' },
-        { label: 'Hide Others', accelerator: 'Command+Shift+H', selector: 'hideOtherApplications:' },
+        { label: 'Hide Others', accelerator: 'Command+Option+H', selector: 'hideOtherApplications:' },
         { label: 'Show All', selector: 'unhideAllApplications:' },
         { type: 'separator' },
         { label: 'Quit', accelerator: 'Command+Q', click () { app.quit() } }


### PR DESCRIPTION
I just started use Reactotron and I'm digging it! I noticed this inconsistency, so I thought I'd send over a PR.

The old Electron accelerator for the `Hide Others` command was `Command+Shift+H`, but this change makes the accelerator the conventional `Option+Command+H`. See [Apple's docs][as]:

> To view the front app but hide all other apps, press Command-Option-H.

As another example, compare [Chrome's shortcut][ch] with [Reactotron's][ro].

Thanks for the neat project!

[as]: https://support.apple.com/en-us/HT201236
[ch]: https://www.dropbox.com/s/0v3flw2m2kda7pf/chrome-hide-others.png?raw=1
[ro]: https://www.dropbox.com/s/5fwsrear8eis4k8/reactotron-hide-others.png?raw=1