### PR TITLE
Fix native performance in 47

### DIFF
--- a/packages/reactotron-core-client/src/stopwatch.js
+++ b/packages/reactotron-core-client/src/stopwatch.js
@@ -24,9 +24,6 @@ if (hasHirezNodeTimer) {
   performanceNow = () => nativePerformance.now && nativePerformance.now()
 }
 
-// this is the interface the callers will use
-// export const performanceNow = nativePerformance ? nativePerformanceOurs : defaultPerformanceNow
-
 /**
  * Starts a lame, low-res timer.  Returns a function which when invoked,
  * gives you the number of milliseconds since passing.  ish.

--- a/packages/reactotron-core-client/src/stopwatch.js
+++ b/packages/reactotron-core-client/src/stopwatch.js
@@ -6,26 +6,26 @@ const defaultPerformanceNow = () => Date.now()
 // try to find the browser-based performance timer
 const nativePerformance = typeof window !== 'undefined' && window && (window.performance || window.msPerformance || window.webkitPerformance)
 
-// TODO: broken in 0.47, so guarded
-// if we do find it, let's setup to call it
-const nativePerformanceNow = () => nativePerformance.now && nativePerformance.now()
-
 // the function we're trying to assign
 let performanceNow = defaultPerformanceNow
 
 // accepts an already started time and returns the number of milliseconds
 let delta = started => performanceNow() - started
 
-// node will use a high rez timer
 if (hasHirezNodeTimer) {
+  // nodejs
   performanceNow = process.hrtime
   delta = started => performanceNow(started)[1] / 1000000
+} else if (global.nativePerformanceNow) {
+  // react native 47
+  performanceNow = global.nativePerformanceNow
 } else if (nativePerformance) {
-  performanceNow = nativePerformanceNow
+  // browsers + safely check for react native < 47
+  performanceNow = () => nativePerformance.now && nativePerformance.now()
 }
 
 // this is the interface the callers will use
-// export const performanceNow = nativePerformance ? nativePerformanceNow : defaultPerformanceNow
+// export const performanceNow = nativePerformance ? nativePerformanceOurs : defaultPerformanceNow
 
 /**
  * Starts a lame, low-res timer.  Returns a function which when invoked,


### PR DESCRIPTION
Fixes #494 
Continuation of #493 

In React Native 0.47, the removed `now` from `window.performance`... AND they ended up creating a global variable called `nativePerformanceNow` which happened to be the name of the variable we were using.

So a perfect storm.  lol.


