### PR TITLE
Converted `App/Dialogs` to stateless components where applicable

### DIFF
--- a/packages/reactotron-app/App/Dialogs/FilterTimelineDialog.js
+++ b/packages/reactotron-app/App/Dialogs/FilterTimelineDialog.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { ModalPortal, ModalBackground, ModalDialog } from 'react-modal-dialog'
 import { inject, observer } from 'mobx-react'
 import AppStyles from '../Theme/AppStyles'
@@ -128,11 +128,7 @@ const Styles = {
   }
 }
 
-@inject('session')
-@observer
-class FilterTimelineDialog extends Component {
-  render () {
-    const { session } = this.props
+const FilterTimelineDialog = inject('session')(observer(({ session }) => {
     const { ui } = session
     if (!ui.showFilterTimelineDialog) return null
 
@@ -175,7 +171,6 @@ class FilterTimelineDialog extends Component {
         </ModalBackground>
       </ModalPortal>
     )
-  }
-}
+}))
 
 export default FilterTimelineDialog

--- a/packages/reactotron-app/App/Dialogs/HelpDialog.js
+++ b/packages/reactotron-app/App/Dialogs/HelpDialog.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { ModalPortal, ModalBackground, ModalDialog } from 'react-modal-dialog'
 import { inject, observer } from 'mobx-react'
 import AppStyles from '../Theme/AppStyles'
@@ -82,65 +82,54 @@ const Styles = {
   }
 }
 
-@inject('session')
-@observer
-class StateDispatchDialog extends Component {
-  handleChange = (e) => {
-    const { session } = this.props
-    session.ui.actionToDispatch = e.target.value
-  }
+const StateDispatchDialog = inject('session')(observer(({ session }) => {
+  if (!session.ui.showHelpDialog) return null
 
-  render () {
-    const { ui } = this.props.session
-    const open = ui.showHelpDialog
-    if (!open) return null
-
-    return (
-      <ModalPortal>
-        <ModalBackground onClose={ui.closeHelpDialog}>
-          <ModalDialog style={Styles.dialog}>
-            <div style={Styles.container}>
-              <div style={Styles.header}>
-                <h1 style={Styles.title}>{DIALOG_TITLE}</h1>
-                <p style={Styles.subtitle}>
-                  {INSTRUCTIONS}
-                </p>
+  return (
+    <ModalPortal>
+      <ModalBackground onClose={session.ui.closeHelpDialog}>
+        <ModalDialog style={Styles.dialog}>
+          <div style={Styles.container}>
+            <div style={Styles.header}>
+              <h1 style={Styles.title}>{DIALOG_TITLE}</h1>
+              <p style={Styles.subtitle}>
+                {INSTRUCTIONS}
+              </p>
+            </div>
+            <div style={Styles.body}>
+              <div style={Styles.group}>Working With State</div>
+              <div style={Styles.helpShortcut}>
+                <div style={Styles.helpLabel}>{Keystroke.modifierName} + F</div>
+                <div style={Styles.helpDetail}>find keys or values</div>
               </div>
-              <div style={Styles.body}>
-                <div style={Styles.group}>Working With State</div>
-                <div style={Styles.helpShortcut}>
-                  <div style={Styles.helpLabel}>{Keystroke.modifierName} + F</div>
-                  <div style={Styles.helpDetail}>find keys or values</div>
-                </div>
-                <div style={Styles.helpShortcut}>
-                  <div style={Styles.helpLabel}>{Keystroke.modifierName} + N</div>
-                  <div style={Styles.helpDetail}>new subscription</div>
-                </div>
-                <div style={Styles.helpShortcut}>
-                  <div style={Styles.helpLabel}>{Keystroke.modifierName} + D</div>
-                  <div style={Styles.helpDetail}>dispatch an action</div>
-                </div>
-                <div style={Styles.group}>Miscellaneous</div>
-                <div style={Styles.helpShortcut}>
-                  <div style={Styles.helpLabel}>{Keystroke.modifierName} + K</div>
-                  <div style={Styles.helpDetail}>klear!</div>
-                </div>
-                <div style={Styles.helpShortcut}>
-                  <div style={Styles.helpLabel}>{Keystroke.modifierName} + /</div>
-                  <div style={Styles.helpDetail}>toggle help</div>
-                </div>
+              <div style={Styles.helpShortcut}>
+                <div style={Styles.helpLabel}>{Keystroke.modifierName} + N</div>
+                <div style={Styles.helpDetail}>new subscription</div>
               </div>
-              <div style={Styles.keystrokes}>
-                <div style={Styles.hotkey}>
-                  <span style={Styles.keystroke}>{ESCAPE_KEYSTROKE}</span> {ESCAPE_HINT}
-                </div>
+              <div style={Styles.helpShortcut}>
+                <div style={Styles.helpLabel}>{Keystroke.modifierName} + D</div>
+                <div style={Styles.helpDetail}>dispatch an action</div>
+              </div>
+              <div style={Styles.group}>Miscellaneous</div>
+              <div style={Styles.helpShortcut}>
+                <div style={Styles.helpLabel}>{Keystroke.modifierName} + K</div>
+                <div style={Styles.helpDetail}>klear!</div>
+              </div>
+              <div style={Styles.helpShortcut}>
+                <div style={Styles.helpLabel}>{Keystroke.modifierName} + /</div>
+                <div style={Styles.helpDetail}>toggle help</div>
               </div>
             </div>
-          </ModalDialog>
-        </ModalBackground>
-      </ModalPortal>
-    )
-  }
-}
+            <div style={Styles.keystrokes}>
+              <div style={Styles.hotkey}>
+                <span style={Styles.keystroke}>{ESCAPE_KEYSTROKE}</span> {ESCAPE_HINT}
+              </div>
+            </div>
+          </div>
+        </ModalDialog>
+      </ModalBackground>
+    </ModalPortal>
+  )
+}))
 
 export default StateDispatchDialog

--- a/packages/reactotron-app/App/Dialogs/RenameStateDialog.js
+++ b/packages/reactotron-app/App/Dialogs/RenameStateDialog.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { ModalPortal, ModalBackground, ModalDialog } from 'react-modal-dialog'
 import { inject, observer } from 'mobx-react'
 import AppStyles from '../Theme/AppStyles'
@@ -78,62 +78,47 @@ const Styles = {
   }
 }
 
-@inject('session')
-@observer
-class RenameStateDialog extends Component {
-  constructor (props) {
-    super(props)
-    this.handleChange = this.handleChange.bind(this)
-  }
+const RenameStateDialog = inject('session')(observer(({ session }) => {
+  const { ui } = session;
+  if (!ui.showRenameStateDialog) return null
 
-  handleChange (e) {
-    const { session } = this.props
-    session.ui.backupStateName = e.target.value
-  }
-
-  render () {
-    const { ui } = this.props.session
-    const open = ui.showRenameStateDialog
-    if (!open) return null
-
-    return (
-      <ModalPortal>
-        <ModalBackground onClose={ui.closeRenameStateDialog}>
-          <ModalDialog style={Styles.dialog}>
-            <div style={Styles.container}>
-              <div style={Styles.header}>
-                <h1 style={Styles.title}>{DIALOG_TITLE}</h1>
+  return (
+    <ModalPortal>
+      <ModalBackground onClose={ui.closeRenameStateDialog}>
+        <ModalDialog style={Styles.dialog}>
+          <div style={Styles.container}>
+            <div style={Styles.header}>
+              <h1 style={Styles.title}>{DIALOG_TITLE}</h1>
+            </div>
+            <div style={Styles.body}>
+              <label style={Styles.fieldLabel}>{FIELD_LABEL}</label>
+              <input
+                autoFocus
+                placeholder={INPUT_PLACEHOLDER}
+                style={Styles.textField}
+                type='text'
+                ref='textField'
+                defaultValue={ui.backupStateName}
+                onChange={e => ui.backupStateName = e.target.value}
+              />
+            </div>
+            <div style={Styles.keystrokes}>
+              <div style={Styles.hotkey}>
+                <span style={Styles.keystroke}>{ESCAPE_KEYSTROKE}</span>
+                {' '}
+                {ESCAPE_HINT}
               </div>
-              <div style={Styles.body}>
-                <label style={Styles.fieldLabel}>{FIELD_LABEL}</label>
-                <input
-                  autoFocus
-                  placeholder={INPUT_PLACEHOLDER}
-                  style={Styles.textField}
-                  type='text'
-                  ref='textField'
-                  defaultValue={ui.backupStateName}
-                  onChange={this.handleChange}
-                />
-              </div>
-              <div style={Styles.keystrokes}>
-                <div style={Styles.hotkey}>
-                  <span style={Styles.keystroke}>{ESCAPE_KEYSTROKE}</span>
-                  {' '}
-                  {ESCAPE_HINT}
-                </div>
-                <div style={Styles.hotkey}>
-                  <span style={Styles.keystroke}>{ENTER_KEYSTROKE}</span>
-                  {' '}
-                  {ENTER_HINT}
-                </div>
+              <div style={Styles.hotkey}>
+                <span style={Styles.keystroke}>{ENTER_KEYSTROKE}</span>
+                {' '}
+                {ENTER_HINT}
               </div>
             </div>
-          </ModalDialog>
-        </ModalBackground>
-      </ModalPortal>
-    )
-  }
-}
+          </div>
+        </ModalDialog>
+      </ModalBackground>
+    </ModalPortal>
+  )
+}))
 
 export default RenameStateDialog

--- a/packages/reactotron-app/App/Dialogs/StateDispatchDialog.js
+++ b/packages/reactotron-app/App/Dialogs/StateDispatchDialog.js
@@ -91,13 +91,16 @@ class StateDispatchDialog extends Component {
     session.ui.actionToDispatch = e.target.value
   }
 
+  componentDidUpdate() {
+      const field = ReactDOM.findDOMNode(this.field)
+
+      field && field.focus()
+  }
+
   render () {
     const { ui } = this.props.session
-    const open = ui.showStateDispatchDialog
-    if (!open) return null
+    if (!ui.showStateDispatchDialog) return null
 
-    // need to find a less hacky way of doing this
-    setTimeout(() => ReactDOM.findDOMNode(this.refs.dispatchField).focus(), 1)
     return (
       <ModalPortal>
         <ModalBackground onClose={ui.closeStateDispatchDialog}>
@@ -115,7 +118,7 @@ class StateDispatchDialog extends Component {
                   placeholder={INPUT_PLACEHOLDER}
                   style={Styles.dispatchField}
                   type='text'
-                  ref='dispatchField'
+                  ref={node => (this.field = node)}
                   value={ui.actionToDispatch}
                   onKeyPress={this.handleKeyPress}
                   onChange={this.handleChange}

--- a/packages/reactotron-app/App/Dialogs/StateKeysAndValuesDialog.js
+++ b/packages/reactotron-app/App/Dialogs/StateKeysAndValuesDialog.js
@@ -108,14 +108,18 @@ class StateKeysAndValuesDialog extends Component {
     }
   }
 
+  componentDidUpdate() {
+    const field = ReactDOM.findDOMNode(this.field)
+
+    field && field.focus()
+  }
+
   render () {
     const { ui } = this.props.session
     const open = ui.showStateFindDialog
     const isKeys = ui.keysOrValues === 'keys'
     if (!open) return null
 
-    // need to find a less hacky way of doing this
-    setTimeout(() => ReactDOM.findDOMNode(this.refs.textField).focus(), 1)
     return (
       <ModalPortal>
         <ModalBackground onClose={ui.closeStateFindDialog}>
@@ -133,7 +137,7 @@ class StateKeysAndValuesDialog extends Component {
                   placeholder={INPUT_PLACEHOLDER}
                   style={Styles.textField}
                   type='text'
-                  ref='textField'
+                  ref={node => (this.field = node)}
                   onKeyPress={this.handleKeyPress}
                   onChange={this.handleChange}
                 />

--- a/packages/reactotron-app/App/Dialogs/StateWatchDialog.js
+++ b/packages/reactotron-app/App/Dialogs/StateWatchDialog.js
@@ -102,13 +102,16 @@ class StateWatchDialog extends Component {
     session.ui.watchToAdd = e.target.value
   }
 
+  componentDidUpdate() {
+      const field = ReactDOM.findDOMNode(this.field)
+
+      field && field.focus()
+  }
+
   render () {
     const { ui } = this.props.session
-    const open = ui.showStateWatchDialog
-    if (!open) return null
+    if (!ui.showStateWatchDialog) return null
 
-    // need to find a less hacky way of doing this
-    setTimeout(() => ReactDOM.findDOMNode(this.refs.textField).focus(), 1)
     return (
       <ModalPortal>
         <ModalBackground onClose={ui.closeStateWatchDialog}>
@@ -126,7 +129,7 @@ class StateWatchDialog extends Component {
                   placeholder={INPUT_PLACEHOLDER}
                   style={Styles.textField}
                   type='text'
-                  ref='textField'
+                  ref={node => (this.field = node)}
                   onKeyPress={this.handleKeyPress}
                   onChange={this.handleChange}
                 />


### PR DESCRIPTION
Part of #518 

Also update some of the `setTimeout(() => ReactDOM.findDOMNode(...), 1)` calls to use React lifecycle methods and ref functions rather than string references.