### PR TITLE
updated main page description on react native networking plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ Reactotron on the left, demo React Native app on the right.
 * [Open in editor](./docs/plugin-open-in-editor.md)
 * [Image Overlays](./docs/plugin-overlay.md)
 * [Async Storage](./docs/plugin-async-storage.md)
+* [Networking](./docs/plugin-networking.md)
 * Integrating with [Redux](./docs/plugin-redux.md)
 * Integrating with [Redux Saga](./docs/plugin-redux-saga.md)
 * Networking monitoring with [Apisauce](./docs/plugin-apisauce.md)
@@ -49,7 +50,6 @@ Reactotron on the left, demo React Native app on the right.
 #### Coming Soon
 
 * API Docs
-* Integrating with Fetch
 * Creating your own plugins
 * The JSON interface between client & server (coming soon...)
 * What's Inside This Repo?


### PR DESCRIPTION
The main page right now says the integration with Fetch for react native is not yet implemented, however a previously merged Pull Request #368 implements it and adds the corresponding page for implementation. If someone starts by reading the main readme file as is, it may give the impression the feature is not yet available to work when it is, I personally tested it myself a bit before making the change