### PR TITLE
✨ Adds typescript typings for reactotron-react-native

### DIFF
--- a/packages/reactotron-react-native/package.json
+++ b/packages/reactotron-react-native/package.json
@@ -18,10 +18,12 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "reactotron-react-native.d.ts"
   ],
+  "types": "./reactotron-react-native.d.ts",
   "peerDependencies": {
-    "react": ">=15.2.1 || 16.0.0-alpha.6 || 16.0.0-alpha.12",
+    "react": "^15.2.1 || 16.0.0-alpha.6 || 16.0.0-alpha.12 || 16.0.0-beta.5 || ^16.0.0",
     "react-native": ">=0.40.0"
   },
   "devDependencies": {

--- a/packages/reactotron-react-native/reactotron-react-native.d.ts
+++ b/packages/reactotron-react-native/reactotron-react-native.d.ts
@@ -1,0 +1,101 @@
+declare module 'reactotron-react-native' {
+  export interface ReactotronConfigureOptions {
+    name?: string
+    host?: string
+    port?: number
+    userAgent?: string
+    reactotronVersion?: string
+    environment?: string
+  }
+
+  export interface ReactotronDisplayOptions {
+    name: string
+    value?: any
+    preview?: string
+    important?: boolean
+    image?: string
+  }
+
+  export interface ReactotronStackFrame {
+    methodName?: string
+    lineNumber?: number
+    column?: number
+    file?: string
+  }
+
+  export interface ReactotronUseReactNativeAsync {
+    ignore: string[]
+  }
+
+  export interface ReactotronUseReactNativeNetworking {
+    ignoreContentTypes?: RegExpConstructor
+  }
+
+  export interface ReactotronUseReactNativeEditor {
+    url?: string
+  }
+
+  export interface ReactotronUseReactNativeErrors {
+    veto: (stackFrame: ReactotronStackFrame) => boolean
+  }
+
+  export interface ReactotronUseReactNativeOptions {
+    asyncStorage?: false | ReactotronUseReactNativeAsync
+    networking?: false | ReactotronUseReactNativeNetworking
+    editor?: false | ReactotronUseReactNativeEditor
+    errors?: false | ReactotronUseReactNativeErrors
+    overlay?: false
+  }
+
+  /**
+   * Reactotron.
+   */
+  export interface Reactotron {
+    /**
+     * Configure some settings such as host & port.
+     */
+    configure(options?: ReactotronConfigureOptions): Reactotron
+
+    /**
+     * Connect to the Reactotron app.
+     */
+    connect(): Reactotron
+
+    /**
+     * Use the pack of ReactNative plugins.
+     */
+    useReactNative(options?: ReactotronUseReactNativeOptions): Reactotron
+
+    /**
+     * Clears the Reactotron app.
+     */
+    clear(): void
+
+    /**
+     * Prints a value such a string, object, or array.
+     *
+     * Examples:
+     *
+     * ```js
+     *   .log('hi')
+     *   .log({ objects: 'can', go: 'here' })
+     *   .log([1,2,3], true)
+     * ```
+     *
+     * @param {value} The value to launch.
+     * @param {important} If true, the value will be highlighted.
+     *
+     */
+    log(value: any, important?: boolean): void
+    error(value: any): void
+
+    /**
+     * Prints a custom display message.
+     */
+    display(options: ReactotronDisplayOptions): void
+  }
+
+  var instance: Reactotron
+
+  export { instance as default }
+}


### PR DESCRIPTION
Adds some `TypeScript` typings to `reactotron-react-native`.  It's a stop gap since we're heading there anyway.