### PR TITLE
Wraps up text searching

### DIFF
--- a/packages/reactotron-app/App/Dialogs/FilterTimelineDialog.js
+++ b/packages/reactotron-app/App/Dialogs/FilterTimelineDialog.js
@@ -24,9 +24,7 @@ const GROUPS = [
     items: [
       { value: 'client.intro', text: 'Connection' },
       { value: 'benchmark.report', text: 'Benchmark' },
-      { value: 'api.response', text: 'API' },
-      { value: 'query.preserve', text: 'Preserve Query Store on Clear' },
-      { value: 'query.timeline', text: 'Show Query as a Timeline' }
+      { value: 'api.response', text: 'API' }
     ]
   },
   {

--- a/packages/reactotron-app/App/Foundation/HelpKeystrokes.js
+++ b/packages/reactotron-app/App/Foundation/HelpKeystrokes.js
@@ -80,7 +80,7 @@ const HelpKeystrokes = () => (
         <div style={Styles.category}>State Goodies</div>
         <div style={Styles.helpShortcut}>
           <div style={Styles.helpLabel}>
-            <Key text={Keystroke.modifierName} />+<Key text='F' />
+            <Key text={Keystroke.modifierName} />+<Key text='K' />
           </div>
           <div style={Styles.helpDetail}>find keys or values</div>
         </div>
@@ -114,9 +114,15 @@ const HelpKeystrokes = () => (
         <div style={Styles.category}>Miscellaneous</div>
         <div style={Styles.helpShortcut}>
           <div style={Styles.helpLabel}>
-            <Key text={Keystroke.modifierName} />+<Key text='K' />
+            <Key text={Keystroke.modifierName} />+<Key text='F' />
           </div>
-          <div style={Styles.helpDetail}>klear!</div>
+          <div style={Styles.helpDetail}>search for text in timeline</div>
+        </div>
+        <div style={Styles.helpShortcut}>
+          <div style={Styles.helpLabel}>
+            <Key text={Keystroke.modifierName} />+<Key text='Backspace' />
+          </div>
+          <div style={Styles.helpDetail}>clear the timeline</div>
         </div>
       </div>
     </div>

--- a/packages/reactotron-app/App/Foundation/Timeline.js
+++ b/packages/reactotron-app/App/Foundation/Timeline.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react'
 import { inject, observer } from 'mobx-react'
 import getCommandComponent from '../Commands'
 import TimelineHeader from './TimelineHeader'
-import { map, isNil, uniq, flatten } from 'ramda'
-import { dotPath } from 'ramdasauce'
+import { map, isNil } from 'ramda'
 import AppStyles from '../Theme/AppStyles'
 import Empty from '../Foundation/EmptyState'
 
@@ -35,73 +34,9 @@ const Styles = {
   }
 }
 
-const buildTree = (L, previousTree) => {
-  if (!previousTree) {
-    previousTree = {}
-  }
-
-  return L.reduce(
-    (tree, c) =>
-      [
-        'type',
-        'payload.triggerType',
-        'payload.preview',
-        'payload.name',
-        'payload.level'
-      ].reduce((tree, key) => {
-        if (dotPath(key, c)) {
-          let root = c
-          let props = key.split('.')
-
-          props.slice(0, -1).forEach(prop => {
-            root = c[prop]
-          })
-
-          const value = root[props[props.length - 1]]
-
-          if (!tree[value]) tree[value] = []
-          tree[value].push(c)
-        }
-
-        return tree
-      }, tree),
-    previousTree
-  )
-}
-
-const getCommandsFromTree = (tree, regexp) => {
-  let keys = Object.keys(tree)
-  let commands = {}
-  for (let key of keys) {
-    if (key.match(regexp)) commands[key] = tree[key]
-  }
-
-  return commands
-}
-
-const mapl = (cb, L, limit) => {
-  if (L.length < limit) return L.map(cb)
-
-  let nL = []
-  for (let i = 0; i < limit; i++) {
-    nL.push(cb(L[i], i, L))
-  }
-
-  return nL
-}
-
 @inject('session')
 @observer
 class Timeline extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      inputValue: ''
-    }
-
-    this.lastSlice = props.session.commands.length
-    this.searchTree = buildTree(props.session.commands)
-  }
   // fires when we will update
   componentWillUpdate () {
     const node = this.refs.commands
@@ -110,32 +45,6 @@ class Timeline extends Component {
     this.scrollHeight = node.scrollHeight
     this.scrollTop = node.scrollTop
     this.isPinned = this.scrollTop === 0
-
-    let { lastSlice: current } = this
-    let { commands: next } = this.props.session
-
-    // No changes, keep tree
-    if (current === next.length) {
-      return
-    }
-
-    const { session } = this.props
-    // Command list was reset, rebuild tree
-    if (next.length < current && session.isCommandHidden('query.preserve')) {
-      this.lastSlice = next.length
-      this.searchTree = buildTree(next, {})
-      return
-    }
-
-    if (this.rebuildDelay) {
-      clearTimeout(this.rebuildDelay)
-    }
-
-    this.rebuildDelay = setTimeout(() => {
-      this.lastSlice = next.length
-      this.searchTree = buildTree(next.slice(0, next.length - current), this.searchTree)
-      this.forceUpdate()
-    }, 200)
   }
 
   // fires after we did update
@@ -144,7 +53,7 @@ class Timeline extends Component {
     if (this.isPinned) return
     const node = this.refs.commands
     // scroll to the place we were before
-    // TODO: this falls apart as we reach max queue size as the scrollHeigh no longer changes
+    // TODO: this falls apart as we reach max queue size as the scrollHeight no longer changes
     node.scrollTop = this.scrollTop + node.scrollHeight - this.scrollHeight
   }
 
@@ -156,18 +65,6 @@ class Timeline extends Component {
     )
   }
 
-  onFilter = t => {
-    if (this.filterDelay) {
-      clearTimeout(this.filterDelay)
-    }
-
-    this.filterDelay = setTimeout(() => {
-      this.setState({
-        inputValue: t
-      })
-    }, 300)
-  }
-
   renderItem = command => {
     const CommandComponent = getCommandComponent(command)
     if (isNil(CommandComponent)) return null
@@ -175,64 +72,9 @@ class Timeline extends Component {
     return <CommandComponent key={command.messageId} command={command} />
   }
 
-  renderIgnored = remaining => (
-    <div style={Styles.loadMore}>{`... there are ${remaining} older entries.`}</div>
-  )
-
-  renderQuery = tree => {
-    let regexp = new RegExp(this.state.inputValue.replace(/\s/, '.'), 'i')
-    const categories = getCommandsFromTree(tree, regexp)
-    const renderAmount = 10
-    const timelineAmount = 50
-
-    const { session } = this.props
-
-    const renderTimeline = categories =>
-      map(
-        this.renderItem,
-        uniq(
-          flatten(
-            Object.keys(categories).map(key =>
-              mapl(command => command, categories[key], timelineAmount)
-            )
-          )
-        ).sort((c1, c2) => c2.date - c1.date)
-      )
-
-    const renderCategories = categories =>
-      Object.keys(categories)
-        .map(key => [key, categories[key]])
-        .sort((c1, c2) => c2[1][0].date - c1[1][0].date)
-        .map((c, i) => {
-          const key = c[0]
-          const commands = c[1]
-
-          const cutCommands = mapl(command => command, commands, renderAmount)
-          cutCommands.sort((c1, c2) => c2.date - c1.date)
-
-          return (
-            <div key={key}>
-              <div style={Styles.categoryLabel}>
-                {key} - {commands.length} events
-              </div>
-              <div>
-                {map(this.renderItem, cutCommands)}
-                {commands.length > renderAmount
-                  ? this.renderIgnored(commands.length - renderAmount)
-                  : null}
-              </div>
-            </div>
-          )
-        })
-
-    return session.isCommandHidden('query.timeline')
-      ? renderCategories(categories)
-      : renderTimeline(categories)
-  }
-
   render () {
-    // grab the commands, but sdrawkcab
-    const commands = this.props.session.commands
+    const { session } = this.props
+    const { commands } = session
     const isEmpty = commands.length === 0
 
     return (
@@ -240,9 +82,7 @@ class Timeline extends Component {
         <TimelineHeader onFilter={this.onFilter} />
         {isEmpty && this.renderEmpty()}
         <div style={Styles.commands} ref='commands'>
-          {this.state.inputValue
-            ? this.renderQuery(this.searchTree)
-            : map(this.renderItem, commands)}
+          {map(this.renderItem, commands)}
         </div>
       </div>
     )

--- a/packages/reactotron-app/App/Foundation/TimelineHeader.js
+++ b/packages/reactotron-app/App/Foundation/TimelineHeader.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import Colors from '../Theme/Colors'
 import AppStyles from '../Theme/AppStyles'
+import { reaction } from 'mobx'
 import { inject, observer } from 'mobx-react'
 import IconFilter from 'react-icons/lib/md/filter-list'
 import IconClear from 'react-icons/lib/md/delete-sweep'
@@ -27,54 +28,33 @@ const Styles = {
     ...AppStyles.Layout.hbox,
     justifyContent: 'space-between'
   },
-  left: {
-    ...AppStyles.Layout.hbox,
-    width: 100
-  },
-  right: {
-    ...AppStyles.Layout.hbox,
-    justifyContent: 'flex-end',
-    alignItems: 'center'
-  },
-  center: {
-    ...AppStyles.Layout.vbox,
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center'
-  },
-  title: {
-    color: Colors.foregroundLight,
-    textAlign: 'center'
-  },
+  left: { ...AppStyles.Layout.hbox, width: 100 },
+  right: { ...AppStyles.Layout.hbox, justifyContent: 'flex-end', alignItems: 'center', width: 100 },
+  center: { ...AppStyles.Layout.vbox, flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { color: Colors.foregroundLight, textAlign: 'center' },
   iconSize: 32,
-  toolbarClear: {
-    ...toolbarButton
+  toolbarClear: { ...toolbarButton },
+  toolbarFilter: { ...toolbarButton, paddingRight: 8 },
+  searchContainer: {
+    position: 'relative',
+    display: 'flex',
+    paddingBottom: 10,
+    paddingTop: 4,
+    paddingRight: 10
   },
-  toolbarFilter: {
-    ...toolbarButton,
-    paddingRight: 8
-  },
+  searchLabel: { fontSize: 12, paddingLeft: 10, paddingRight: 10 },
   searchInput: {
+    borderRadius: 4,
     padding: 10,
-
+    flex: 1,
     backgroundColor: Colors.backgroundSubtleDark,
     border: 'none',
-    marginRight: 16,
     color: Colors.foregroundDark,
     fontSize: 14
   },
-
-  searchContainer: {
-    position: 'relative'
-  },
-
   searchIconSize: 28,
-  searchIcon: {
-    position: 'absolute',
-    top: 6,
-    right: 20,
-    color: Colors.foregroundDark
-  }
+  searchIcon: { paddingRight: 7, cursor: 'pointer' },
+  searchIconEnabled: { color: 'white' }
 }
 
 @inject('session')
@@ -84,8 +64,53 @@ class TimelineHeader extends Component {
     this.props.onFilter(evt.target.value)
   }
 
+  /**
+   * Moves the focus to the search input.
+   *
+   * This is called when we show the search ui.
+   */
+  setFocusToSearch = () => {
+    // unclear why i need to do this after a timeout?  is it because
+    // i'm rendering?
+    setTimeout(() => {
+      this.searchInput.focus()
+    }, 10)
+  }
+
+  componentDidMount () {
+    // when the isTimelineSearchVisible becomes `true`...
+    this.unsubscribe = reaction(
+      () => this.props.session.ui.isTimelineSearchVisible,
+      value => {
+        if (value) {
+          this.setFocusToSearch()
+        }
+      }
+    )
+  }
+
+  componentWillUnmount () {
+    this.unsubscribe && this.unsubscribe()
+  }
+
+  handleKeyDown = e => {
+    // have to do this here
+    if (e.keyCode === 27) {
+      this.props.session.ui.hideTimelineSearch()
+    }
+  }
+
   render () {
     const { ui } = this.props.session
+    const { isTimelineSearchVisible } = ui
+    const searchIconStyle = {
+      ...Styles.searchIcon,
+      ...(isTimelineSearchVisible ? Styles.searchIconEnabled : {})
+    }
+    const searchContainerStyle = {
+      ...Styles.searchContainer,
+      ...(!isTimelineSearchVisible ? { display: 'none' } : {})
+    }
 
     return (
       <div style={Styles.container}>
@@ -95,13 +120,11 @@ class TimelineHeader extends Component {
             <div style={Styles.title}>{TITLE}</div>
           </div>
           <div style={Styles.right}>
-            <div style={Styles.searchContainer}>
-              <input
-                style={Styles.searchInput}
-                onInput={this.props.onFilter ? this.getValue : undefined}
-              />
-              <IconSearch size={Styles.searchIconSize} style={Styles.searchIcon} />
-            </div>
+            <IconSearch
+              size={Styles.searchIconSize}
+              style={searchIconStyle}
+              onClick={ui.toggleTimelineSearch}
+            />
             <IconFilter
               size={Styles.iconSize}
               style={Styles.toolbarFilter}
@@ -109,6 +132,17 @@ class TimelineHeader extends Component {
             />
             <IconClear size={Styles.iconSize} style={Styles.toolbarClear} onClick={ui.reset} />
           </div>
+        </div>
+        <div style={searchContainerStyle}>
+          <p style={Styles.searchLabel}>Search</p>
+          <input
+            ref={ref => (this.searchInput = ref)}
+            style={Styles.searchInput}
+            onInput={this.props.onFilter ? this.getValue : undefined}
+            onChange={e => ui.setSearchPhrase(e.target.value)}
+            onKeyDown={this.handleKeyDown}
+            value={ui.searchPhrase}
+          />
         </div>
       </div>
     )

--- a/packages/reactotron-app/App/Stores/SessionStore.js
+++ b/packages/reactotron-app/App/Stores/SessionStore.js
@@ -1,13 +1,42 @@
 import UiStore from './UiStore'
 import { createServer } from 'reactotron-core-server'
 import { action, observable, computed, reaction, observe } from 'mobx'
-import { contains, last, isNil, reject, equals, reverse, pipe, propEq, map, fromPairs } from 'ramda'
+import {
+  contains,
+  last,
+  isNil,
+  reject,
+  equals,
+  reverse,
+  pipe,
+  propEq,
+  map,
+  fromPairs,
+  test,
+  any,
+  path
+} from 'ramda'
 import { dotPath } from 'ramdasauce'
 import shallowDiff from '../Lib/ShallowDiff'
 
 const isSubscription = propEq('type', 'state.values.change')
 const isSubscriptionCommandWithEmptyChanges = command =>
   isSubscription(command) && dotPath('payload.changes.length', command) === 0
+
+/**
+ * Functions to check a command when searching.
+ */
+const COMMON_MATCHING_PATHS = [
+  path(['type']),
+  path(['payload', 'message']),
+  path(['payload', 'preview']),
+  path(['payload', 'name']),
+  path(['payload', 'path']),
+  path(['payload', 'triggerType']),
+  path(['payload', 'description']),
+  path(['payload', 'request', 'url']),
+  path(['payload', 'request', 'url'])
+]
 
 class Session {
   // commands to exlude in the timeline
@@ -36,6 +65,38 @@ class Session {
     return !isNew
   }
 
+  /**
+   * Should we reject this command when we are searching?
+   *
+   * This will be based on the search term that user has typed in.
+   */
+  rejectCommandWhenSearching = command => {
+    // only reject when we're searching
+    if (!this.ui.isTimelineSearchVisible || !this.ui.isValidSearchPhrase) {
+      return false
+    }
+
+    // safely matching the search term regexp against something passed in
+    const matching = value =>
+      value && typeof value === 'string' && test(this.ui.searchRegexp, value)
+
+    // typical paths that might match
+    if (any(x => matching(x(command)), COMMON_MATCHING_PATHS)) {
+      return false
+    }
+
+    // A few commands have their UI represented differently than their data. This is probably
+    // not the best place for this, however, it'll be fine for now.
+    if (command.type === 'log' && (matching('debug') || matching('warning') || matching('error'))) {
+      return false
+    } else if (command.type === 'client.intro' && matching('connection')) {
+      return false
+    }
+
+    // ignore everything else
+    return true
+  }
+
   @computed
   get commands () {
     return pipe(
@@ -43,6 +104,7 @@ class Session {
       reject(isSubscriptionCommandWithEmptyChanges),
       reject(this.isSubscriptionValuesSameAsLastTime),
       reject(command => contains(command.type, this.commandsHiddenInTimeline)),
+      reject(this.rejectCommandWhenSearching),
       reverse
     )(this)
   }

--- a/packages/reactotron-app/App/Stores/UiStore.js
+++ b/packages/reactotron-app/App/Stores/UiStore.js
@@ -121,10 +121,20 @@ class UI {
     this.isTimelineSearchVisible = false
   }
 
+  @action
   showTimelineSearch = () => {
     this.isTimelineSearchVisible = false // hack to ensure the reaction on the timeline header works (sheesh.)
     this.isTimelineSearchVisible = true
     this.switchTab('timeline')
+  }
+
+  @action
+  toggleTimelineSearch = () => {
+    if (this.isTimelineSearchVisible) {
+      this.hideTimelineSearch()
+    } else {
+      this.showTimelineSearch()
+    }
   }
 
   @action

--- a/packages/reactotron-app/App/Stores/UiStore.js
+++ b/packages/reactotron-app/App/Stores/UiStore.js
@@ -1,7 +1,8 @@
-import { observable, action, asMap } from 'mobx'
+import { computed, observable, action, asMap } from 'mobx'
 import Mousetrap from '../Lib/Mousetrap.min.js'
 import { isNilOrEmpty } from 'ramdasauce'
 import Keystroke from '../Lib/Keystroke'
+import { trim } from 'ramda'
 
 /**
  * Handles UI state.
@@ -47,6 +48,14 @@ class UI {
   // show the watch panel?
   @observable showWatchPanel = false
 
+  // show the timeline search
+  @observable isTimelineSearchVisible = false
+
+  /**
+   * The current search phrase used to narrow down visible commands.
+   */
+  @observable searchPhrase = ''
+
   // additional properties that some commands may want... a way to communicate
   // from the command toolbar to the command
   commandProperties = {}
@@ -56,8 +65,8 @@ class UI {
 
     Mousetrap.prototype.stopCallback = () => false
 
-    Mousetrap.bind(`${Keystroke.mousetrap}+k`, this.reset)
-    Mousetrap.bind(`${Keystroke.mousetrap}+f`, this.openStateFindDialog)
+    Mousetrap.bind(`${Keystroke.mousetrap}+backspace`, this.reset)
+    Mousetrap.bind(`${Keystroke.mousetrap}+k`, this.openStateFindDialog)
     Mousetrap.bind(`${Keystroke.mousetrap}+shift+f`, this.openFilterTimelineDialog)
     Mousetrap.bind(`${Keystroke.mousetrap}+d`, this.openStateDispatchDialog)
     Mousetrap.bind(`${Keystroke.mousetrap}+s`, this.backupState)
@@ -70,8 +79,52 @@ class UI {
     Mousetrap.bind(`${Keystroke.mousetrap}+2`, this.switchTab.bind(this, 'subscriptions'))
     Mousetrap.bind(`${Keystroke.mousetrap}+3`, this.switchTab.bind(this, 'backups'))
     Mousetrap.bind(`${Keystroke.mousetrap}+4`, this.switchTab.bind(this, 'native'))
-    Mousetrap.bind(`${Keystroke.mousetrap}+/`, this.switchTab.bind(this, 'help'))
     Mousetrap.bind(`${Keystroke.mousetrap}+?`, this.switchTab.bind(this, 'help'))
+    Mousetrap.bind(`${Keystroke.mousetrap}+f`, this.showTimelineSearch)
+  }
+
+  @action
+  setSearchPhrase = value => {
+    this.searchPhrase = value
+  }
+
+  /**
+   * Get the scrubbed search phrase.
+   */
+  @computed
+  get cleanedSearchPhrase () {
+    return trim(this.searchPhrase || '')
+  }
+
+  /**
+   * The regular expression we will be using to search commands.
+   */
+  @computed
+  get searchRegexp () {
+    try {
+      return new RegExp(this.cleanedSearchPhrase.replace(/\s/, '.'), 'i')
+    } catch (e) {
+      return null
+    }
+  }
+
+  /**
+   * Is this search phrase useable?
+   */
+  @computed
+  get isValidSearchPhrase () {
+    return Boolean(this.searchRegexp)
+  }
+
+  @action
+  hideTimelineSearch = () => {
+    this.isTimelineSearchVisible = false
+  }
+
+  showTimelineSearch = () => {
+    this.isTimelineSearchVisible = false // hack to ensure the reaction on the timeline header works (sheesh.)
+    this.isTimelineSearchVisible = true
+    this.switchTab('timeline')
   }
 
   @action
@@ -79,14 +132,25 @@ class UI {
     this.tab = newTab
   }
 
+  @computed
+  get isModalShowing () {
+    return (
+      this.showStateWatchDialog ||
+      this.showStateFindDialog ||
+      this.showStateDispatchDialog ||
+      this.showFilterTimelineDialog ||
+      this.showRenameStateDialog
+    )
+  }
+
   @action
-  popState = () => {
+  popState = e => {
     if (this.showStateFindDialog) {
       this.closeStateFindDialog()
-    }
-    if (this.showHelpDialog) {
+    } else if (this.showHelpDialog) {
       this.closeHelpDialog()
     }
+    return false
   }
 
   @action


### PR DESCRIPTION
There were a few UI bugs corrected here:

* the title was off center
* the "no commands yet" view was being shown alongside commands
* the search input box didn't fit properly

I ended up moving the input to a line by itself and treating the toggle.

The group-by-command didn't survive the refactor.  I hope that's ok @Rhineheart .  It didn't quite feel right in a timeline.  I know you put a lot of effort into that.  <3

Much of the non-visual searching stuff now lives in mobx land and not within the react component.

![reactotron-text-search](https://user-images.githubusercontent.com/68273/32852666-b591633c-ca06-11e7-86ca-850a2c0f16ee.gif)

Also the keybinds have changed to make way for `command+f` to be text searching.  My apologies to your fingers everyone.  
