### PR TITLE
✨ Adds custom commands

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -122,7 +122,7 @@ the state like this:
   }))
 ```
 
-This will `nav` mutable. Note this is what you want to do when using 
+This will `nav` mutable. Note this is what you want to do when using
 [react-navigation's default reducer](https://github.com/react-community/react-navigation/blob/master/docs/guides/Redux-Integration.md).
 
 
@@ -139,4 +139,31 @@ You have control over Socket.IO and can pass through settings to control that in
       reconnectionAttempts: 5
     }
   })
+```
+
+## Custom Commands
+
+Need a custom Reactotron plugin but don't have time to write one?
+
+In the Reactotron App, you can press `command+.` (mac) or  `ctrl+.` (windows/linux) to send a custom command.
+
+These commands can be using for things like:
+
+* clearing async storage
+* triggering an api call
+* calling functions on hard-to-reach places
+* sending info back to reactotron app
+
+Writing your own Reactotron middleware makes this happen.  Check out this example:
+
+```js
+import Reactotron from 'reactotron-react-native'
+
+Reactotron.use(tron => ({
+  onCommand({ type, payload }) {
+    if (type === 'custom') {
+      tron.display({ name: 'ECHO', preview: payload })
+    }
+  },
+}))
 ```

--- a/packages/reactotron-app/App/Dialogs/SendCustomDialog.js
+++ b/packages/reactotron-app/App/Dialogs/SendCustomDialog.js
@@ -1,0 +1,172 @@
+import React, { Component } from 'react'
+import ReactDOM from 'react-dom'
+import { ModalPortal, ModalBackground, ModalDialog } from 'react-modal-dialog'
+import { inject, observer } from 'mobx-react'
+import AppStyles from '../Theme/AppStyles'
+import Colors from '../Theme/Colors'
+import { shell } from 'electron'
+
+const ESCAPE_KEYSTROKE = 'Esc'
+const ESCAPE_HINT = 'Cancel'
+const ENTER_KEYSTROKE = 'Enter'
+const ENTER_HINT = 'Send'
+const DIALOG_TITLE = 'Custom Command'
+
+const INPUT_PLACEHOLDER = ''
+const FIELD_LABEL = 'command'
+
+const Styles = {
+  dialog: {
+    borderRadius: 4,
+    padding: 4,
+    width: 450,
+    backgroundColor: Colors.background,
+    color: Colors.foreground
+  },
+  examples: {},
+  example: {
+    padding: 0,
+    margin: '0 0 0 40px',
+    color: Colors.bold
+  },
+  container: {
+    ...AppStyles.Layout.vbox
+  },
+  keystrokes: {
+    ...AppStyles.Layout.hbox,
+    alignSelf: 'center',
+    paddingTop: 10,
+    paddingBottom: 20,
+    fontSize: 13
+  },
+  hotkey: {
+    padding: '0 10px'
+  },
+  keystroke: {
+    backgroundColor: Colors.backgroundHighlight,
+    color: Colors.foreground,
+    padding: '4px 8px',
+    borderRadius: 4
+  },
+  header: {
+    ...AppStyles.Layout.vbox,
+    padding: '1em 2em 0em'
+  },
+  body: {
+    ...AppStyles.Layout.vbox,
+    padding: '1em 2em 4em'
+  },
+  moreInfo: {
+    paddingTop: '1em',
+    fontSize: 12,
+    color: Colors.foreground
+  },
+  title: {
+    margin: 0,
+    padding: 0,
+    textAlign: 'left',
+    fontWeight: 'normal',
+    fontSize: 24,
+    color: Colors.heading
+  },
+  subtitle: {
+    color: Colors.foreground,
+    textAlign: 'left',
+    padding: 0,
+    margin: 0
+  },
+  fieldLabel: {
+    color: Colors.heading,
+    fontSize: 13,
+    textTransform: 'uppercase'
+  },
+  textField: {
+    borderTop: 0,
+    borderLeft: 0,
+    borderRight: 0,
+    borderBottom: `1px solid ${Colors.line}`,
+    fontSize: 23,
+    color: Colors.foregroundLight,
+    lineHeight: '40px',
+    backgroundColor: 'inherit'
+  },
+  link: {
+    textDecoration: 'none',
+    color: 'white',
+    cursor: 'pointer'
+  }
+}
+
+const INSTRUCTIONS = <p>Sends a custom command to your app.</p>
+
+@inject('session')
+@observer
+class SendCustomDialog extends Component {
+  handleChange = e => {
+    const { session } = this.props
+    session.ui.setCustomMessage(e.target.value)
+  }
+
+  componentDidUpdate () {
+    const field = ReactDOM.findDOMNode(this.field)
+
+    field && field.focus()
+  }
+
+  onMoreInfo = e => {
+    shell.openExternal(
+      'https://github.com/infinitered/reactotron/blob/master/docs/tips.md#custom-commands'
+    )
+    e.preventDefault()
+  }
+
+  render () {
+    const { ui } = this.props.session
+    if (!ui.showSendCustomDialog) return null
+
+    return (
+      <ModalPortal>
+        <ModalBackground onClose={ui.closeSendCustomDialog}>
+          <ModalDialog style={Styles.dialog}>
+            <div style={Styles.container}>
+              <div style={Styles.header}>
+                <h1 style={Styles.title}>{DIALOG_TITLE}</h1>
+                <div style={Styles.subtitle}>{INSTRUCTIONS}</div>
+              </div>
+              <div style={Styles.body}>
+                <label style={Styles.fieldLabel}>{FIELD_LABEL}</label>
+                <input
+                  placeholder={INPUT_PLACEHOLDER}
+                  style={Styles.textField}
+                  type='text'
+                  ref={node => (this.field = node)}
+                  value={ui.customMessage}
+                  onKeyPress={this.handleKeyPress}
+                  onChange={this.handleChange}
+                />
+                <small style={Styles.moreInfo}>
+                  See{' '}
+                  <a style={Styles.link} onClick={this.onMoreInfo}>
+                    this tip
+                  </a>{' '}
+                  for creating your own middleware.
+                </small>
+              </div>
+
+              <div style={Styles.keystrokes}>
+                <div style={Styles.hotkey}>
+                  <span style={Styles.keystroke}>{ESCAPE_KEYSTROKE}</span> {ESCAPE_HINT}
+                </div>
+                <div style={Styles.hotkey}>
+                  <span style={Styles.keystroke}>{ENTER_KEYSTROKE}</span> {ENTER_HINT}
+                </div>
+              </div>
+            </div>
+          </ModalDialog>
+        </ModalBackground>
+      </ModalPortal>
+    )
+  }
+}
+
+export default SendCustomDialog

--- a/packages/reactotron-app/App/Foundation/HelpKeystrokes.js
+++ b/packages/reactotron-app/App/Foundation/HelpKeystrokes.js
@@ -9,7 +9,7 @@ const Styles = {
     color: Colors.foreground
   },
   helpLabel: {
-    width: 160
+    width: 180
   },
   key: {
     color: Colors.foregroundLight,
@@ -120,7 +120,13 @@ const HelpKeystrokes = () => (
         </div>
         <div style={Styles.helpShortcut}>
           <div style={Styles.helpLabel}>
-            <Key text={Keystroke.modifierName} />+<Key text='Backspace' />
+            <Key text={Keystroke.modifierName} />+<Key text='.' />
+          </div>
+          <div style={Styles.helpDetail}>send a custom command</div>
+        </div>
+        <div style={Styles.helpShortcut}>
+          <div style={Styles.helpLabel}>
+            <Key text={Keystroke.modifierName} />+<Key text='BKSP' />
           </div>
           <div style={Styles.helpDetail}>clear the timeline</div>
         </div>

--- a/packages/reactotron-app/App/Foundation/VisualRoot.js
+++ b/packages/reactotron-app/App/Foundation/VisualRoot.js
@@ -8,6 +8,7 @@ import HelpDialog from '../Dialogs/HelpDialog'
 import StateWatchDialog from '../Dialogs/StateWatchDialog'
 import RenameStateDialog from '../Dialogs/RenameStateDialog'
 import FilterTimelineDialog from '../Dialogs/FilterTimelineDialog'
+import SendCustomDialog from '../Dialogs/SendCustomDialog'
 import Subscriptions from './Subscriptions'
 import Backups from './Backups'
 import Native from './Native'
@@ -90,6 +91,7 @@ export default class VisualRoot extends Component {
         <StateWatchDialog />
         <RenameStateDialog />
         <FilterTimelineDialog />
+        <SendCustomDialog />
       </div>
     )
   }

--- a/packages/reactotron-app/App/Stores/UiStore.js
+++ b/packages/reactotron-app/App/Stores/UiStore.js
@@ -48,6 +48,12 @@ class UI {
   // show the watch panel?
   @observable showWatchPanel = false
 
+  /** The message we are currently composing to send to the client. */
+  @observable customMessage = ''
+
+  // show the send custom message dialog
+  @observable showSendCustomDialog = false
+
   // show the timeline search
   @observable isTimelineSearchVisible = false
 
@@ -81,6 +87,7 @@ class UI {
     Mousetrap.bind(`${Keystroke.mousetrap}+4`, this.switchTab.bind(this, 'native'))
     Mousetrap.bind(`${Keystroke.mousetrap}+?`, this.switchTab.bind(this, 'help'))
     Mousetrap.bind(`${Keystroke.mousetrap}+f`, this.showTimelineSearch)
+    Mousetrap.bind(`${Keystroke.mousetrap}+.`, this.openSendCustomDialog)
   }
 
   @action
@@ -149,7 +156,8 @@ class UI {
       this.showStateFindDialog ||
       this.showStateDispatchDialog ||
       this.showFilterTimelineDialog ||
-      this.showRenameStateDialog
+      this.showRenameStateDialog ||
+      this.showSendCustomDialog
     )
   }
 
@@ -169,6 +177,8 @@ class UI {
       this.submitStateWatch()
     } else if (this.showRenameStateDialog) {
       this.submitRenameState()
+    } else if (this.showSendCustomDialog) {
+      this.submitCurrentMessage()
     }
   }
 
@@ -191,6 +201,13 @@ class UI {
     this.currentBackupState.payload.name = this.backupStateName
     this.showRenameStateDialog = false
     this.backupStateName = null
+  }
+
+  @action
+  submitCurrentMessage = () => {
+    this.sendCustomMessage(this.customMessage)
+    this.customMessage = ''
+    this.showSendCustomDialog = false
   }
 
   @action
@@ -294,6 +311,16 @@ class UI {
   }
 
   @action
+  openSendCustomDialog = () => {
+    this.showSendCustomDialog = true
+  }
+
+  @action
+  closeSendCustomDialog = () => {
+    this.showSendCustomDialog = false
+  }
+
+  @action
   reset = () => {
     this.server.commands.all.clear()
   }
@@ -320,6 +347,16 @@ class UI {
   @action
   dispatchAction = action => {
     this.server.stateActionDispatch(action)
+  }
+
+  @action
+  sendCustomMessage = value => {
+    this.server.sendCustomMessage(value)
+  }
+
+  @action
+  setCustomMessage = value => {
+    this.customMessage = value
   }
 
   @action

--- a/packages/reactotron-app/App/app.global.css
+++ b/packages/reactotron-app/App/app.global.css
@@ -56,3 +56,7 @@ a.closeButton--jss-0-1 { display: none; }
   background-color: 'white';
   width: 300px;
 }
+
+*::-webkit-input-placeholder {
+  opacity: 0.2;
+}

--- a/packages/reactotron-core-server/src/index.js
+++ b/packages/reactotron-core-server/src/index.js
@@ -254,6 +254,15 @@ class Server {
     const { file, lineNumber } = details
     this.send('editor.open', { file, lineNumber })
   }
+
+  /**
+   * Sends a custom message to the client.
+   *
+   * @param {string} value The string to send
+   */
+  sendCustomMessage (value) {
+    this.send('custom', value)
+  }
 }
 
 export default Server


### PR DESCRIPTION
Here's a quick way to send arbitrary commands to your app from Reactotron.

This can be a low-commitment way to trigger custom behaviour in your app.

Here's an example:

![reactotron-custom-commands](https://user-images.githubusercontent.com/68273/33043984-2811b4f4-ce15-11e7-9172-623b1bdb1540.gif)

When I send 'hi', it'll echo it back.

Here's the middleware that makes it happen:

```ts
console.tron.use(tron => ({
  onCommand({ type, payload }) {
    if (type === 'custom') {
      tron.display({ name: 'ECHO', preview: payload })
    }
  },
}))
```
