### PR TITLE
Update download links in installation docs

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -4,11 +4,11 @@ Reactotron comes in two versions.  A desktop version (available on macOS, Linux,
 
 ### Via Direct Download
 
-[Download macOS App](https://github.com/infinitered/reactotron/releases/download/v1.11.2/Reactotron.app.zip) from GitHub release and drop the Reactotron.app to the Applications folder.
+[Download macOS App](https://github.com/infinitered/reactotron/releases/download/v1.13.0/Reactotron.app.zip) from GitHub release and drop the Reactotron.app to the Applications folder.
 
-[Download 32 bit Linux App](https://github.com/infinitered/reactotron/releases/download/v1.11.2/Reactotron-linux-ia32.zip) or [64 bit Linux App](https://github.com/infinitered/reactotron/releases/download/v1.11.2/Reactotron-linux-x64.zip).
+[Download 32 bit Linux App](https://github.com/infinitered/reactotron/releases/download/v1.13.0/Reactotron-linux-ia32.zip) or [64 bit Linux App](https://github.com/infinitered/reactotron/releases/download/v1.13.0/Reactotron-linux-x64.zip).
 
-[Download 32 bit Windows App](https://github.com/infinitered/reactotron/releases/download/v1.11.2/Reactotron-win32-ia32.zip) or [64 bit Windows App](https://github.com/infinitered/reactotron/releases/download/v1.11.2/Reactotron-win32-x64.zip)
+[Download 32 bit Windows App](https://github.com/infinitered/reactotron/releases/download/v1.13.0/Reactotron-win32-ia32.zip) or [64 bit Windows App](https://github.com/infinitered/reactotron/releases/download/v1.13.0/Reactotron-win32-x64.zip)
 
 ### Via Homebrew
 


### PR DESCRIPTION
It looks like this wasn't updated with the last release.