### PR TITLE
react-native networking option to skip requests based on URL.

### DIFF
--- a/docs/plugin-networking.md
+++ b/docs/plugin-networking.md
@@ -23,10 +23,13 @@ You're done.
 
 ## Advanced Usage
 
-`networking()` also accepts an object with an `ignoreContentTypes` key.  The value is a regular expression which, when matched against the `Content-Type` response header, will prevent the data from being displayed in Reactotron.  You typically want to do this for images (which is the default).
+`networking()` also accepts an object with two options:
+- `ignoreContentTypes`: a regular expression which, when matched against the `Content-Type` response header, will prevent the data from being displayed in Reactotron.  You typically want to do this for images (which is the default).
+- `skipRequestUrls`: a regular expression which, when matched against the URL of the XHR, will prevent the request from being tracked in Reactotron. Can be useful for ignoring noisy logging requests.
 
 ```js
 networking({
-  ignoreContentTypes: /^(image)\/.*$/i
+  ignoreContentTypes: /^(image)\/.*$/i,
+  skipRequestUrls: /\/(logs|symbolicate)$/,
 })
 ```

--- a/docs/plugin-networking.md
+++ b/docs/plugin-networking.md
@@ -25,11 +25,11 @@ You're done.
 
 `networking()` also accepts an object with two options:
 - `ignoreContentTypes`: a regular expression which, when matched against the `Content-Type` response header, will prevent the data from being displayed in Reactotron.  You typically want to do this for images (which is the default).
-- `skipRequestUrls`: a regular expression which, when matched against the URL of the XHR, will prevent the request from being tracked in Reactotron. Can be useful for ignoring noisy logging requests.
+- `ignoreUrls`: a regular expression which, when matched against the URL of the XHR, will prevent the request from being tracked in Reactotron. Can be useful for ignoring noisy logging requests.
 
 ```js
 networking({
   ignoreContentTypes: /^(image)\/.*$/i,
-  skipRequestUrls: /\/(logs|symbolicate)$/,
+  ignoreUrls: /\/(logs|symbolicate)$/,
 })
 ```

--- a/packages/reactotron-react-native/reactotron-react-native.d.ts
+++ b/packages/reactotron-react-native/reactotron-react-native.d.ts
@@ -29,6 +29,7 @@ declare module 'reactotron-react-native' {
 
   export interface ReactotronUseReactNativeNetworking {
     ignoreContentTypes?: RegExpConstructor
+    skipRequestUrls?: RegExpConstructor
   }
 
   export interface ReactotronUseReactNativeEditor {

--- a/packages/reactotron-react-native/reactotron-react-native.d.ts
+++ b/packages/reactotron-react-native/reactotron-react-native.d.ts
@@ -29,7 +29,7 @@ declare module 'reactotron-react-native' {
 
   export interface ReactotronUseReactNativeNetworking {
     ignoreContentTypes?: RegExpConstructor
-    skipRequestUrls?: RegExpConstructor
+    ignoreUrls?: RegExpConstructor
   }
 
   export interface ReactotronUseReactNativeEditor {

--- a/packages/reactotron-react-native/src/plugins/networking.js
+++ b/packages/reactotron-react-native/src/plugins/networking.js
@@ -27,6 +27,11 @@ export default (pluginConfig = {}) => reactotron => {
    * @param {*} instance - The XMLHTTPRequest instance.
    */
   function onSend (data, xhr) {
+    if (options.skipRequestUrls && test(options.skipRequestUrls, xhr._url)) {
+      xhr._skipReactotron = true
+      return
+    }
+
     // bump the counter
     reactotronCounter++
 
@@ -52,6 +57,10 @@ export default (pluginConfig = {}) => reactotron => {
    * @param {*} xhr - The XMLHttpRequest instance.
    */
   function onResponse (status, timeout, response, url, type, xhr) {
+    if (xhr._skipReactotron) {
+      return
+    }
+
     // fetch and clear the request data from the cache
     const rid = xhr._trackingName
     const cachedRequest = requestCache[rid] || {}

--- a/packages/reactotron-react-native/src/plugins/networking.js
+++ b/packages/reactotron-react-native/src/plugins/networking.js
@@ -27,7 +27,7 @@ export default (pluginConfig = {}) => reactotron => {
    * @param {*} instance - The XMLHTTPRequest instance.
    */
   function onSend (data, xhr) {
-    if (options.skipRequestUrls && test(options.skipRequestUrls, xhr._url)) {
+    if (options.ignoreUrls && test(options.ignoreUrls, xhr._url)) {
       xhr._skipReactotron = true
       return
     }


### PR DESCRIPTION
I ran into an issue where logging-related API requests from tooling generated noise in Reactotron. This was reported by someone else in https://github.com/infinitered/reactotron/issues/546, but since that issue didn't generate discussion, I thought I'd send a quick PR to see if an approach like this was reasonable.

No worries if it's not!