### PR TITLE
Fix api response command preview

### DIFF
--- a/packages/reactotron-app/App/Commands/ApiResponseCommand.js
+++ b/packages/reactotron-app/App/Commands/ApiResponseCommand.js
@@ -131,7 +131,7 @@ class ApiResponseCommand extends Component {
     const { duration } = payload
     const status = dotPath('response.status', payload)
     const url = dotPath('request.url', payload)
-    const smallUrl = pipe(replace(/^http(s):\/\/[a-zA-Z0-9.]*/i, ''), replace(/\?.*$/i, ''))(url)
+    const smallUrl = pipe(replace(/^http(s):\/\/[^\/]+/i, ''), replace(/\?.*$/i, ''))(url)
     const method = toUpper(dotPath('request.method', payload) || '')
     const requestHeaders = dotPath('request.headers', payload)
     const responseHeaders = dotPath('response.headers', payload)


### PR DESCRIPTION
For urls like `https://a-b.com/path` preview looks like `-b.com/path`