### PR TITLE
[reactotron-mst] Actions that send a null value blow up the RNEvent check

### DIFF
--- a/packages/reactotron-mst/src/reactotron-mst.ts
+++ b/packages/reactotron-mst/src/reactotron-mst.ts
@@ -43,7 +43,7 @@ import {
 const dotPath = (fullPath: string, o: any) => path(split(".", fullPath), o)
 const isNilOrEmpty = (value: any) => isNil(value) || isEmpty(value)
 const isReactNativeEvent = (value: any) =>
-  has("nativeEvent", value) && has("target", value) && has("type", value)
+  value !== null && has("nativeEvent", value) && has("target", value) && has("type", value)
 
 /**
  * Sadly, this protects calls from endless stack traces.  We have to filter


### PR DESCRIPTION
A simple escape hatch when the value is null... if it is null it obviously isn't a RN Event.