### PR TITLE
🐛 Fixes linting problem with localStorage global

### DIFF
--- a/packages/reactotron-app/package.json
+++ b/packages/reactotron-app/package.json
@@ -99,6 +99,9 @@
     "stringify-object": "^3.0.0"
   },
   "standard": {
-    "parser": "babel-eslint"
+    "parser": "babel-eslint",
+    "globals": [
+      "localStorage"
+    ]
   }
 }


### PR DESCRIPTION
Needed to whitelist the global for `localStorage` in the `standard` config.