### PR TITLE
Update readme with brew reinstall instructions

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -26,7 +26,7 @@ brew cask install reactotron
 
 To update an existing installation of reactotron via brew, type:
 
-``
+```
 brew cask reinstall reactotron
 ```
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -24,6 +24,12 @@ Then simply type:
 brew cask install reactotron
 ```
 
+To update an existing installation of reactotron via brew, type:
+
+``
+brew cask reinstall reactotron
+```
+
 # Install the CLI
 
 If you like to kick it old-school and use the terminal, Reactotron is available via [NPM](https://www.npmjs.com/).


### PR DESCRIPTION
Minor update to the README file that helps users know what to do when they want to update the reactotron installation via HomeBrew