### PR TITLE
Don't access window if unavailable

### DIFF
--- a/packages/reactotron-react-js/src/index.js
+++ b/packages/reactotron-react-js/src/index.js
@@ -10,7 +10,7 @@ var DEFAULTS = {
   host: 'localhost',
   port: 9090,
   name: 'React JS App',
-  userAgent: window.navigator.userAgent,
+  userAgent: typeof window !== 'undefined' ? window.navigator.userAgent : '',
   reactotronVersion: 'BETA' // TODO: figure this out for realz.  why is this hard?  it must be me.
 }
 


### PR DESCRIPTION
I'm using Reactotron with the Redux plugin in a React.js app with server side rendering. 

The Redux store is configured on the client and on the server, however because reactotron-react-js attempts to access `window` on module import this fails server side. I don't plan to use Reactotron in production or on the server, but not being able to import the module at all during store configuration is problematic.

I've just added a check for window as a straightforward solution, but understand that this might not be suitable depending on what else you plan to use the userAgent for.

Hope it's helpful. 
