### PR TITLE
✨ Adds milliseconds to the timeline

### DIFF
--- a/packages/reactotron-app/App/Shared/Timestamp.js
+++ b/packages/reactotron-app/App/Shared/Timestamp.js
@@ -1,26 +1,19 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import moment from 'moment'
-import Colors from '../Theme/Colors'
+import React from "react"
+import PropTypes from "prop-types"
+import moment from "moment"
+import Colors from "../Theme/Colors"
+import { format } from "date-fns"
 
 const Styles = {
-  container: {
-    margin: 0,
-    padding: 0
-  },
-  left: {
-    color: Colors.foregroundDark
-  },
-  right: {
-    color: Colors.foreground
-  }
+  container: { margin: 0, padding: 0 },
+  left: { color: Colors.highlight },
+  right: { color: Colors.foreground },
 }
 
 const Timestamp = props => {
-  const date = moment(props.date)
-  const left = date.format('h:mm')
-  // const right = date.format('ss.SS')
-  const right = date.format(':ss')
+  const date = props.date
+  const left = format(date, "h:mm:")
+  const right = format(date, "ss.SS")
   const containerStyles = { ...Styles.container, ...props.style }
 
   return (
@@ -33,7 +26,7 @@ const Timestamp = props => {
 
 Timestamp.propTypes = {
   date: PropTypes.object.isRequired,
-  style: PropTypes.object
+  style: PropTypes.object,
 }
 
 export default Timestamp

--- a/packages/reactotron-app/package.json
+++ b/packages/reactotron-app/package.json
@@ -79,6 +79,7 @@
   "dependencies": {
     "color": "^2.0.0",
     "css-modules-require-hook": "^4.2.2",
+    "date-fns": "^1.29.0",
     "electron-debug": "^1.4.0",
     "font-awesome": "^4.7.0",
     "mobx": "^2.5.1",

--- a/packages/reactotron-app/yarn.lock
+++ b/packages/reactotron-app/yarn.lock
@@ -1827,6 +1827,10 @@ date-fns@^1.23.0:
   version "1.28.5"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
+date-fns@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"


### PR DESCRIPTION
## Overview

The time isn't as granular as it should be on the timeline.  It's meaningful to see if something took 1ms or 99ms.

This came up in #614 but I coincidentally experienced this last week too.

## Screenshots

![image](https://user-images.githubusercontent.com/68273/37287782-fba63790-25db-11e8-8ead-730e5c706437.png)

## Other Notes

Moving from the heavyweight `moment` to lightweight `date-fns`.  Calling `moment()` incurs some significant overhead surprisingly!

I also made the `h:mm:` part a little darker than it was before.

Fixes #614 