### PR TITLE
💥 Changes .log() to work like console.log()

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -79,10 +79,10 @@ console.tron.log('Sweet Freedom!')
 
 ### Fancy Console Magic :tophat: :sparkles:
 
-You can add an important indicator light on any log by adding `true` as a second parameter.  _E.g._
+You can add an important indicator light by calling `logImportant`.  _E.g._
 ```js
 // or Reactotron.log
-console.tron.log('I am important', true)
+console.tron.logImportant('I am important')
 ```
 
 Additionally, you can access a more advanced message and indicator with `display`.

--- a/packages/reactotron-core-client/src/plugins/logger.ts
+++ b/packages/reactotron-core-client/src/plugins/logger.ts
@@ -4,8 +4,14 @@
 export default () => reactotron => {
   return {
     features: {
-      log: (message, important = false) =>
-        reactotron.send("log", { level: "debug", message }, !!important),
+      log: (...args) => {
+        const content = (args && args.length === 1) ? args[0] : args
+        reactotron.send("log", { level: "debug", message: content }, false)
+      },
+      logImportant: (...args) => {
+        const content = (args && args.length === 1) ? args[0] : args
+        reactotron.send("log", { level: "debug", message: content }, true)
+      },
       debug: (message, important = false) =>
         reactotron.send("log", { level: "debug", message }, !!important),
       warn: message => reactotron.send("log", { level: "warn", message }, true),

--- a/packages/reactotron-react-native/reactotron-react-native.d.ts
+++ b/packages/reactotron-react-native/reactotron-react-native.d.ts
@@ -1,4 +1,4 @@
-declare module 'reactotron-react-native' {
+declare module "reactotron-react-native" {
   export interface ReactotronConfigureOptions {
     name?: string
     host?: string
@@ -112,20 +112,28 @@ declare module 'reactotron-react-native' {
     /**
      * Prints a value such a string, object, or array.
      *
-     * Examples:
+     * This is the same as console.log, except it sends it to the Reactotron app.
      *
-     * ```js
-     *   .log('hi')
-     *   .log({ objects: 'can', go: 'here' })
-     *   .log([1,2,3], true)
-     * ```
-     *
-     * @param {value} The value to launch.
-     * @param {important} If true, the value will be highlighted.
-     *
+     * @param value Anything you'd like to log.
      */
-    log(value: any, important?: boolean): void
-    error(value: any): void
+    log(...value: any[]): void
+
+    /**
+     * Prints a value such a string, object, or array.  It prints it highlighted
+     * within the Reactotron app so it's visually easy to recognize.  Great if you
+     * have a lot of messages flowing.
+     *
+     * @param value The value to log.
+     */
+    logImportant(...value: any[]): void
+
+    /**
+     * Logs an error with a stack trace.
+     *
+     * @param error
+     * @param stack
+     */
+    error(error: any, stack: any): void
 
     /**
      * Prints a custom display message.


### PR DESCRIPTION
## Overview

The time has come. `console.log()` is now the interface of our `.log()`.

We can now use variadic arguments.

```js
console.tron.log(1, 2, 3, "hey", this, "lol" )
```

## Breaking Change

If you've used `.log("!!!", true)` to mark something as important, that will no longer work.  You must call `.logImportant("!!!")`.

It seems to me that this is our first breaking change since launching 1.0!  🌮 


