### PR TITLE
✨ Adds more precision and shows delta times

### DIFF
--- a/packages/reactotron-app/App/Commands/ApiResponseCommand.js
+++ b/packages/reactotron-app/App/Commands/ApiResponseCommand.js
@@ -143,7 +143,7 @@ class ApiResponseCommand extends Component {
     const summary = { 'Status Code': status, Method: method, 'Duration (ms)': duration }
 
     return (
-      <Command command={command} title={COMMAND_TITLE} duration={duration} preview={preview}>
+      <Command {...this.props} title={COMMAND_TITLE} duration={duration} preview={preview}>
         <div style={Styles.container}>
           <div style={Styles.url}>{url}</div>
 

--- a/packages/reactotron-app/App/Commands/AsyncStorageValuesCommand.js
+++ b/packages/reactotron-app/App/Commands/AsyncStorageValuesCommand.js
@@ -48,7 +48,7 @@ class AsyncStorageValuesCommand extends Component {
     const { preview, value = [] } = command.payload
     const rows = mapIndexed(this.renderItem, value)
     return (
-      <Command command={command} title={COMMAND_TITLE} preview={preview}>
+      <Command {...this.props} title={COMMAND_TITLE} preview={preview}>
         <div style={Styles.watches}>{rows.length > 0 ? rows : 'Empty storage.'}</div>
       </Command>
     )

--- a/packages/reactotron-app/App/Commands/BenchmarkReportCommand.js
+++ b/packages/reactotron-app/App/Commands/BenchmarkReportCommand.js
@@ -109,7 +109,7 @@ class BenchmarkReportCommand extends Component {
     const preview = `${title} in ${duration}ms`
 
     return (
-      <Command command={command} title={COMMAND_TITLE} duration={duration} preview={preview}>
+      <Command {...this.props} title={COMMAND_TITLE} duration={duration} preview={preview}>
         <div style={Styles.reportTitle}>{title}</div>
         {mapIndexed(
           (step, idx) => makeStep(step, idx, idx === steps.length - 2, duration),

--- a/packages/reactotron-app/App/Commands/ClientIntroCommand.js
+++ b/packages/reactotron-app/App/Commands/ClientIntroCommand.js
@@ -20,7 +20,7 @@ class ClientIntroCommand extends Component {
     const preview = payload.name
 
     return (
-      <Command command={command} title={COMMAND_TITLE} preview={preview}>
+      <Command {...this.props} title={COMMAND_TITLE} preview={preview}>
         {makeTable(payload)}
       </Command>
     )

--- a/packages/reactotron-app/App/Commands/DisplayCommand.js
+++ b/packages/reactotron-app/App/Commands/DisplayCommand.js
@@ -1,35 +1,35 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import Command from '../Shared/Command'
-import Content from '../Shared/Content'
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+import Command from "../Shared/Command"
+import Content from "../Shared/Content"
 
-const COMMAND_TITLE = 'DISPLAY'
+const COMMAND_TITLE = "DISPLAY"
 
 const Styles = {
   imageContainer: {},
   image: {
-    maxWidth: '100%',
-    maxHeight: '100%'
-  }
+    maxWidth: "100%",
+    maxHeight: "100%",
+  },
 }
 
 class DisplayCommand extends Component {
   static propTypes = {
-    command: PropTypes.object.isRequired
+    command: PropTypes.object.isRequired,
   }
 
-  shouldComponentUpdate (nextProps) {
+  shouldComponentUpdate(nextProps) {
     return this.props.command.id !== nextProps.command.id
   }
 
-  render () {
+  render() {
     const { command } = this.props
     const { payload, important } = command
     const { name, value, image, preview } = payload
 
     return (
       <Command
-        command={command}
+        {...this.props}
         title={name || COMMAND_TITLE}
         important={important}
         preview={preview}

--- a/packages/reactotron-app/App/Commands/ImageCommand.js
+++ b/packages/reactotron-app/App/Commands/ImageCommand.js
@@ -41,7 +41,7 @@ class DisplayCommand extends Component {
     const dimensions = width && height && `${width} x ${height}`
 
     return (
-      <Command command={command} title={COMMAND_TITLE} important={important} preview={preview}>
+      <Command {...this.props} title={COMMAND_TITLE} important={important} preview={preview}>
         <div style={Styles.imageContainer}>
           <img style={Styles.image} src={uri} />
           {caption && <div style={Styles.caption}>{caption}</div>}

--- a/packages/reactotron-app/App/Commands/LogCommand.js
+++ b/packages/reactotron-app/App/Commands/LogCommand.js
@@ -388,7 +388,7 @@ class LogCommand extends Component {
     let preview = this.getPreview(message)
 
     return (
-      <Command command={command} title={title} preview={preview}>
+      <Command {...this.props} title={title} preview={preview}>
         <div style={containerTypes}>
           {!stack && <Content value={message} />}
           {stack && <div style={Styles.errorMessage}>{message}</div>}

--- a/packages/reactotron-app/App/Commands/SagaTaskCompleteCommand.js
+++ b/packages/reactotron-app/App/Commands/SagaTaskCompleteCommand.js
@@ -140,7 +140,7 @@ class SagaTaskCompleteCommand extends Component {
     const effectTitle = `${children.length} Effect${children.length === 1 ? '' : 's'}`
 
     return (
-      <Command command={command} title={COMMAND_TITLE} preview={preview}>
+      <Command {...this.props} title={COMMAND_TITLE} preview={preview}>
         <div style={Styles.effects}>
           <div style={Styles.effectTitle}>
             <div style={Styles.triggerType}>{description || triggerType}</div>

--- a/packages/reactotron-app/App/Commands/StateActionCompleteCommand.js
+++ b/packages/reactotron-app/App/Commands/StateActionCompleteCommand.js
@@ -30,7 +30,7 @@ class StateActionComplete extends Component {
     const preview = `${name}`
 
     return (
-      <Command command={command} title={COMMAND_TITLE} duration={ms} preview={preview}>
+      <Command {...this.props} title={COMMAND_TITLE} duration={ms} preview={preview}>
         <div style={Styles.container}>
           <div style={Styles.name}>{name}</div>
           <Content value={action} />

--- a/packages/reactotron-app/App/Commands/StateKeysResponseCommand.js
+++ b/packages/reactotron-app/App/Commands/StateKeysResponseCommand.js
@@ -110,7 +110,7 @@ class StateKeysResponseCommand extends Component {
     const pathText = path || ROOT_TEXT
 
     return (
-      <Command command={command} title={COMMAND_TITLE} startsOpen>
+      <Command {...this.props} title={COMMAND_TITLE} startsOpen>
         <div style={Styles.container}>
           <div style={Styles.path}>
             <span style={Styles.pathLabel}>{PATH_LABEL}</span> {pathText}

--- a/packages/reactotron-app/App/Commands/StateValuesChangeCommand.js
+++ b/packages/reactotron-app/App/Commands/StateValuesChangeCommand.js
@@ -47,7 +47,7 @@ class StateValuesChangeCommand extends Component {
     const preview = join(' ', phrase)
 
     return (
-      <Command command={command} title={COMMAND_TITLE} preview={preview}>
+      <Command {...this.props} title={COMMAND_TITLE} preview={preview}>
         <div style={Styles.container}>
           {hasChanged && <Content value={changed} />}
           {hasAdded && <Content value={added} />}

--- a/packages/reactotron-app/App/Commands/StateValuesResponseCommand.js
+++ b/packages/reactotron-app/App/Commands/StateValuesResponseCommand.js
@@ -38,7 +38,7 @@ class StateValuesResponseCommand extends Component {
     const pathText = path || ROOT_TEXT
 
     return (
-      <Command command={command} title={COMMAND_TITLE} startsOpen>
+      <Command {...this.props} title={COMMAND_TITLE} startsOpen>
         <div style={Styles.container}>
           <div style={Styles.path}>
             <span style={Styles.pathLabel}>{PATH_LABEL}</span> {pathText}

--- a/packages/reactotron-app/App/Commands/UnknownCommand.js
+++ b/packages/reactotron-app/App/Commands/UnknownCommand.js
@@ -19,7 +19,7 @@ class UnknownCommand extends Component {
     const { payload, type } = command
 
     return (
-      <Command command={command} title={COMMAND_TITLE} preview={type}>
+      <Command {...this.props} title={COMMAND_TITLE} preview={type}>
         <ObjectTree object={{ payload }} />
       </Command>
     )

--- a/packages/reactotron-app/App/Foundation/Timeline.js
+++ b/packages/reactotron-app/App/Foundation/Timeline.js
@@ -1,44 +1,47 @@
-import React, { Component } from 'react'
-import { inject, observer } from 'mobx-react'
-import getCommandComponent from '../Commands'
-import TimelineHeader from './TimelineHeader'
-import { map, isNil } from 'ramda'
-import AppStyles from '../Theme/AppStyles'
-import Empty from '../Foundation/EmptyState'
+import React, { Component } from "react"
+import { inject, observer } from "mobx-react"
+import getCommandComponent from "../Commands"
+import TimelineHeader from "./TimelineHeader"
+import { map, addIndex, isNil } from "ramda"
+import AppStyles from "../Theme/AppStyles"
+import Empty from "../Foundation/EmptyState"
+import ApiResponseCommand from "../Commands/ApiResponseCommand"
+
+const mapIndexed = addIndex(map)
 
 const Styles = {
   container: {
     ...AppStyles.Layout.vbox,
     margin: 0,
-    flex: 1
+    flex: 1,
   },
   commands: {
     margin: 0,
     padding: 0,
-    overflowY: 'auto',
-    overflowX: 'hidden'
+    overflowY: "auto",
+    overflowX: "hidden",
   },
 
   categoryLabel: {
-    color: '#606060',
+    color: "#606060",
     paddingLeft: 20,
     fontSize: 12,
-    paddingTop: 10
+    paddingTop: 10,
   },
 
   loadMore: {
-    color: '#606060',
-    textAlign: 'center',
+    color: "#606060",
+    textAlign: "center",
     padding: 20,
-    fontSize: 16
-  }
+    fontSize: 16,
+  },
 }
 
-@inject('session')
+@inject("session")
 @observer
 class Timeline extends Component {
   // fires when we will update
-  componentWillUpdate () {
+  componentWillUpdate() {
     const node = this.refs.commands
     // http://blog.vjeux.com/2013/javascript/scroll-position-with-react.html
     // remember our height, position, and if we're at the top
@@ -48,7 +51,7 @@ class Timeline extends Component {
   }
 
   // fires after we did update
-  componentDidUpdate () {
+  componentDidUpdate() {
     // should we be pinned to top, let's not auto-scroll
     if (this.isPinned) return
     const node = this.refs.commands
@@ -57,22 +60,39 @@ class Timeline extends Component {
     node.scrollTop = this.scrollTop + node.scrollHeight - this.scrollHeight
   }
 
-  renderEmpty () {
+  renderEmpty() {
     return (
-      <Empty icon='reorder' title='No Activity'>
+      <Empty icon="reorder" title="No Activity">
         <p>Once your app connects and starts sending events, they will appear here.</p>
       </Empty>
     )
   }
 
-  renderItem = command => {
+  renderItem = (command, index) => {
     const CommandComponent = getCommandComponent(command)
     if (isNil(CommandComponent)) return null
 
-    return <CommandComponent key={command.messageId} command={command} />
+    // grab the commands (heads up --- they're in reverse order for display purposes)
+    const { commands = [] } = this.props.session
+
+    // is this the bottom one?
+    const isLast = index == commands.length - 1
+
+    // find the one before it
+    const previousCommand = isLast ? null : commands[index + 1]
+
+    // if we have a previous one, calculate the time difference
+    const diff =
+      previousCommand &&
+      previousCommand.date &&
+      command.date &&
+      command.date.getTime() - previousCommand.date.getTime()
+    const deltaTime = isLast ? 0 : diff
+
+    return <CommandComponent deltaTime={deltaTime} key={command.messageId} command={command} />
   }
 
-  render () {
+  render() {
     const { session } = this.props
     const { commands } = session
     const isEmpty = commands.length === 0
@@ -81,8 +101,8 @@ class Timeline extends Component {
       <div style={Styles.container}>
         <TimelineHeader onFilter={this.onFilter} />
         {isEmpty && this.renderEmpty()}
-        <div style={Styles.commands} ref='commands'>
-          {map(this.renderItem, commands)}
+        <div style={Styles.commands} ref="commands">
+          {mapIndexed(this.renderItem, commands)}
         </div>
       </div>
     )

--- a/packages/reactotron-app/App/Shared/Command.js
+++ b/packages/reactotron-app/App/Shared/Command.js
@@ -16,7 +16,7 @@ const Styles = {
     ...AppStyles.Layout.hbox,
     marginTop: 0,
     alignItems: 'flex-start',
-    borderBottom: `1px solid ${Colors.line}`
+    borderBottom: `1px solid ${Colors.line}`,
   },
   containerOpen: {
     backgroundColor: Colors.backgroundSubtleLight
@@ -81,7 +81,7 @@ const Styles = {
     animation: 'fade-up 0.25s',
     willChange: 'transform opacity',
     padding: '0 40px 30px 40px'
-  }
+  },
 }
 
 @observer
@@ -119,7 +119,7 @@ class Command extends Component {
     const { command, children, title, preview } = this.props
     const { important, type } = command
     const isDisplay = type === 'display'
-    const { date } = command
+    const { date, deltaTime } = command
     const titleTextStyle = merge(Styles.titleText, important ? Styles.titleTextInverse : {})
     const topRowStyle = Styles.topRow
     const timestampStyle = Styles.timestamp
@@ -129,7 +129,7 @@ class Command extends Component {
       <div style={containerStyles}>
         <div style={Styles.body}>
           <div style={topRowStyle} onClick={this.handleToggleOpen}>
-            <Timestamp date={date} style={timestampStyle} />
+            <Timestamp date={date} style={timestampStyle} deltaTime={deltaTime} />
             <div style={Styles.title}>
               <span style={titleTextStyle}>
                 {isDisplay && (

--- a/packages/reactotron-app/App/Shared/Command.js
+++ b/packages/reactotron-app/App/Shared/Command.js
@@ -116,10 +116,10 @@ class Command extends Component {
 
   render () {
     const { isOpen } = this.state
-    const { command, children, title, preview } = this.props
+    const { command, children, title, preview, deltaTime } = this.props
     const { important, type } = command
     const isDisplay = type === 'display'
-    const { date, deltaTime } = command
+    const { date } = command
     const titleTextStyle = merge(Styles.titleText, important ? Styles.titleTextInverse : {})
     const topRowStyle = Styles.topRow
     const timestampStyle = Styles.timestamp

--- a/packages/reactotron-app/App/Shared/Timestamp.js
+++ b/packages/reactotron-app/App/Shared/Timestamp.js
@@ -5,27 +5,38 @@ import Colors from "../Theme/Colors"
 import { format } from "date-fns"
 
 const Styles = {
-  container: { margin: 0, padding: 0 },
+  container: { margin: 0, padding: 0, position: "relative" },
   left: { color: Colors.highlight },
   right: { color: Colors.foreground },
+  delta: {
+    color: Colors.tag,
+    fontSize: `0.7rem`,
+    position: "absolute",
+    top: -12,
+    right: 0,
+    left: 0,
+  },
 }
 
 const Timestamp = props => {
   const date = props.date
   const left = format(date, "h:mm:")
-  const right = format(date, "ss.SS")
+  const right = format(date, "ss.SSS")
   const containerStyles = { ...Styles.container, ...props.style }
+  const delta = props.deltaTime ? `+${props.deltaTime} ms` : ""
 
   return (
-    <span style={containerStyles}>
+    <div style={containerStyles}>
       <span style={Styles.left}>{left}</span>
       <span style={Styles.right}>{right}</span>
-    </span>
+      <span title='Since last Reactotron message' style={Styles.delta}>{delta}</span>
+    </div>
   )
 }
 
 Timestamp.propTypes = {
   date: PropTypes.object.isRequired,
+  deltaTime: PropTypes.number,
   style: PropTypes.object,
 }
 

--- a/packages/reactotron-core-client/src/reactotron-core-client.ts
+++ b/packages/reactotron-core-client/src/reactotron-core-client.ts
@@ -77,6 +77,11 @@ export class Client {
   isReady = false
 
   /**
+   * The last time we sent a message.
+   */
+  lastMessageDate = new Date()
+
+  /**
    * Starts a timer and returns a function you can call to stop it and return the elapsed time.
    */
   startTimer = () => start()
@@ -185,10 +190,17 @@ export class Client {
       return
     }
 
+    // set the timing info
+    const date = new Date()
+    const deltaTime = date.getTime() - this.lastMessageDate.getTime()
+    this.lastMessageDate = date
+
     const fullMessage = {
       type,
       payload,
       important: !!important,
+      date: date.toISOString(),
+      deltaTime,
     }
 
     const serializedMessage = serialize(fullMessage)

--- a/packages/reactotron-core-server/src/reactotron-core-server.ts
+++ b/packages/reactotron-core-server/src/reactotron-core-server.ts
@@ -127,19 +127,29 @@ export default class Server {
         }
       })
 
+      const extractOrCreateDate = (dateString?: string) => {
+        if (!dateString) return new Date()
+        try {
+          return new Date(Date.parse(dateString))
+        } catch {
+          return new Date()
+        }
+      }
+
       // when we receive a command from the client
       socket.on("message", incoming => {
         const message = JSON.parse(incoming as string)
         repair(message)
-        const { type, important, payload } = message
+        const { type, important, payload, deltaTime = 0 } = message
         this.messageId++
-        const date = new Date()
+
         const fullCommand = {
           type,
           important,
           payload,
           messageId: this.messageId,
-          date,
+          date: extractOrCreateDate(message.date),
+          deltaTime,
         }
 
         // for client intros


### PR DESCRIPTION
## Overview

Improves timestamp information.

## Screenshot

![image](https://user-images.githubusercontent.com/68273/37345300-ffd90cd0-26a2-11e8-8118-bdaa2bc49902.png)

## Details

3 changes here:

1. Display 3 digits (up from 2) of milliseconds in the time.
2. Display a smaller time delta in timeline. Time since last Reactotron message.  Since it's relative, I made it small because it won't always matter.
3. Moving timestamps **from the server to the client** for better accuracy.  We can now see small changes like 1ms and 2ms.  I'm shocked this made such a big difference! And shocked again that this is shocking news to me.

Thanks for the tips @petermjones!
