### PR TITLE
Updated based on the RN 0.49 breaking change

### DIFF
--- a/docs/quick-start-react-native.md
+++ b/docs/quick-start-react-native.md
@@ -50,7 +50,11 @@ import Reactotron, {
     .connect()
 ```
 
-Finally, we import this on startup in `App.js` (Create React Native App) or `index.ios.js` and `index.android.js` (react-native-cli) on line 1:
+Finally, we import this on startup in
+- `App.js` (Create React Native App) or
+- `index.ios.js` and `index.android.js` (react-native < 0.49) or
+- `index.js` (react-native 0.49+)
+on line 1:
 
 ```js
 import './ReactotronConfig'

--- a/docs/quick-start-react-native.md
+++ b/docs/quick-start-react-native.md
@@ -78,7 +78,10 @@ Pretty underwhelming huh?
 
 Let's do some classic programming.
 
-Open up `App.js` (Create React Native App) or `index.ios.js` / `index.android.js` (react-native-cli).
+Open up
+- `App.js` (Create React Native App) or
+- `index.ios.js` and `index.android.js` (react-native < 0.49) or
+- `index.js` (react-native 0.49+)
 
 Right after the line you just added in the previous step lets put this:
 


### PR DESCRIPTION
From RN 0.49 the starting point is unified, so no index.android or index.is, just index.js.