### PR TITLE
Adds better image support

### DIFF
--- a/packages/reactotron-app/App/Commands/DisplayCommand.js
+++ b/packages/reactotron-app/App/Commands/DisplayCommand.js
@@ -37,7 +37,7 @@ class DisplayCommand extends Component {
         {value && <Content value={value} />}
         {image && (
           <div style={Styles.imageContainer}>
-            <img style={Styles.image} src={image.uri} />
+            <img style={Styles.image} src={image} />
           </div>
         )}
       </Command>

--- a/packages/reactotron-app/App/Commands/DisplayCommand.js
+++ b/packages/reactotron-app/App/Commands/DisplayCommand.js
@@ -26,6 +26,14 @@ class DisplayCommand extends Component {
     const { command } = this.props
     const { payload, important } = command
     const { name, value, image, preview } = payload
+    let imageUrl
+    if (image) {
+      if (typeof image === "string") {
+        imageUrl = image
+      } else {
+        imageUrl = image.uri
+      }
+    } 
 
     return (
       <Command
@@ -35,9 +43,9 @@ class DisplayCommand extends Component {
         preview={preview}
       >
         {value && <Content value={value} />}
-        {image && (
+        {imageUrl && (
           <div style={Styles.imageContainer}>
-            <img style={Styles.image} src={image} />
+            <img style={Styles.image} src={imageUrl} />
           </div>
         )}
       </Command>

--- a/packages/reactotron-react-native/reactotron-react-native.d.ts
+++ b/packages/reactotron-react-native/reactotron-react-native.d.ts
@@ -7,13 +7,22 @@ declare module "reactotron-react-native" {
     reactotronVersion?: string
     environment?: string
   }
+  
+  export interface ReactotronImageOptions {
+    uri: string
+    preview?: string
+    filename?: string
+    width?: number
+    height?: number
+    caption?: string
+  }
 
   export interface ReactotronDisplayOptions {
     name: string
     value?: any
     preview?: string
     important?: boolean
-    image?: string
+    image?: string | ReactotronImageOptions
   }
 
   export interface ReactotronStackFrame {
@@ -139,6 +148,13 @@ declare module "reactotron-react-native" {
      * Prints a custom display message.
      */
     display(options: ReactotronDisplayOptions): void
+
+    /**
+     * Displays an image.
+     * 
+     * @param options The image options.
+     */
+    image(options: ReactotronImageOptions): void
   }
 
   var instance: Reactotron


### PR DESCRIPTION
@GantMan pointed out some problems with the displaying of images.

The typings for `display` was wrong.  it said `image` was a string.  it was actually an object.

It makes sense to want to just show a string, so this adds supports for both.

I also added the missing typings for `image()`.

