### PR TITLE
Better custom commands RFC example + a few other minor fixes

### DIFF
--- a/packages/demo-react-native/App/Components/Button.js
+++ b/packages/demo-react-native/App/Components/Button.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Text, TouchableOpacity } from 'react-native'
 import Styles from './Styles/ButtonStyles'
 import { merge } from 'ramda'

--- a/packages/demo-react-native/App/Components/Repo.js
+++ b/packages/demo-react-native/App/Components/Repo.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Animated, Easing, TouchableWithoutFeedback, View, Text, Image } from 'react-native'
 import Styles from './Styles/RepoStyles'
 import Button from './Button'

--- a/packages/demo-react-native/App/Config/ReactotronConfig.js
+++ b/packages/demo-react-native/App/Config/ReactotronConfig.js
@@ -28,4 +28,7 @@ if (__DEV__) {
   Reactotron.clear()
 }
 
+const testUnreg = Reactotron.onCustomCommand('test', () => { console.log('I WORK!') })
+Reactotron.onCustomCommand('test2', () => { testUnreg() })
+
 console.tron = Reactotron

--- a/packages/demo-react-native/App/Sagas/index.js
+++ b/packages/demo-react-native/App/Sagas/index.js
@@ -1,4 +1,4 @@
-import { takeEvery, takeLatest } from 'redux-saga'
+import { all, takeEvery, takeLatest } from 'redux-saga/effects'
 import * as Startup from '../Redux/StartupRedux'
 import * as Repo from '../Redux/RepoRedux'
 import * as Error from '../Redux/ErrorRedux'
@@ -19,10 +19,10 @@ const api = ApiSauce.create({
 // api.addMonitor(console.tron.apisauce)
 
 export default function * rootSaga () {
-  yield [
+  yield all([
     takeEvery(Startup.Types.Startup, startup),
     takeLatest(Repo.Types.Request, requestRepo, api),
     takeEvery(Error.Types.Saga, sagaError),
     takeEvery(Error.Types.Put, putError)
-  ]
+  ])
 }

--- a/packages/reactotron-app/App/Stores/SessionStore.js
+++ b/packages/reactotron-app/App/Stores/SessionStore.js
@@ -46,6 +46,7 @@ class Session {
   @observable connections = []
   // Selected Connection
   @observable selectedConnection = null
+  @observable customCommands = []
 
   commandsManager = new Commands()
 
@@ -179,6 +180,15 @@ class Session {
 
       this.commandsManager.all.clear()
       this.commandsManager.all.push(...newCommands)
+    } else if (command.type === 'customCommand.register') {
+      this.customCommands.push(command.payload)
+    } else if (command.type === 'customCommand.unregister') {
+      const newCustomCommands = pipe(
+        dotPath('customCommands'),
+        reject(c => c.id === command.payload.id),
+      )(this)
+      this.customCommands.clear()
+      this.customCommands.push(...newCustomCommands)
     } else {
       this.commandsManager.addCommand(command)
     }

--- a/packages/reactotron-react-native/src/plugins/storybook-switcher.js
+++ b/packages/reactotron-react-native/src/plugins/storybook-switcher.js
@@ -44,7 +44,7 @@ StorybookSwitcher.propTypes = {
   /**
    * A component that houses the storybook stories.
    */
-  storybookUi: PropTypes.element,
+  storybookUi: PropTypes.func,
   /**
    * An emitter which can be subscribed to to listen for events.
    */


### PR DESCRIPTION
Pointed at connection filtering because that was my base branch when I decided to see what I could come up with for this... so these changes should be merged after that PR is merged.

Things I did:
- [x] Setup basic custom command registration/unregistration
- [x] Setup calling registered commands
- [x] Ship commands over the wire when commands are register/unregistered
- [x] Update an observable with the list of available commands
- [x] Fix random warnings in the demo app
- [x] Test that registered custom commands work with the current custom command dialog

Things I didn't do:
- [ ] Setup the Reactotron UI to show the available commands
- [ ] Correctly name the commit message (rfp instead of rfc? What was I thinking?)
- [ ] Make all the code clean and conform to standards (see TODOs in code)