### PR TITLE
Storybook now has UI in Reactotron!

### DIFF
--- a/packages/reactotron-app/App/Foundation/Native.js
+++ b/packages/reactotron-app/App/Foundation/Native.js
@@ -65,6 +65,20 @@ const Styles = {
   overlayPreview: {
     maxWidth: '100%',
     maxHeight: '100%'
+  },
+  button: {
+    height: 30,
+    padding: "0 15px",
+    fontSize: 13,
+    marginRight: 4,
+    backgroundColor: Colors.subtleLine,
+    borderRadius: 2,
+    border: `1px solid ${Colors.backgroundSubtleDark}`,
+    cursor: "pointer",
+    color: Colors.foregroundDark,
+  },
+  buttonActive: {
+    color: Colors.bold
   }
 }
 
@@ -335,6 +349,17 @@ class Native extends Component {
       <div style={Styles.container}>
         <NativeHeader />
         <div style={Styles.content}>
+          <div style={Styles.sectionTitle}>Storybook</div>
+          <button
+            style={
+              this.props.session.ui.isStorybookShown
+                ? { ...Styles.button, ...Styles.buttonActive }
+                : Styles.button
+            }
+            onClick={this.props.session.ui.toggleStorybook}
+          >
+            Toggle
+          </button>
           <div style={Styles.sectionTitle}>Overlay Image</div>
           <div style={Styles.backups}>
             <div

--- a/packages/reactotron-app/App/Stores/UiStore.js
+++ b/packages/reactotron-app/App/Stores/UiStore.js
@@ -61,6 +61,9 @@ class UI {
   // hide the sidebar
   @observable isSidebarVisible = true
 
+  // If storybook is shown or not
+  @observable isStorybookShown = false
+
   /**
    * The current search phrase used to narrow down visible commands.
    */
@@ -458,6 +461,15 @@ class UI {
    * Sets the properties of the overlay shown on the React Native app.
    */
   @action setOverlay = props => this.server.send("overlay", props)
+
+  /**
+   * Toggles storybook
+   */
+  @action toggleStorybook = () => {
+    this.isStorybookShown = !this.isStorybookShown
+
+    this.server.send("storybook", this.isStorybookShown)
+  }
 }
 
 export default UI

--- a/packages/reactotron-react-native/src/plugins/storybook.js
+++ b/packages/reactotron-react-native/src/plugins/storybook.js
@@ -15,11 +15,9 @@ export default () => reactotron => {
      * @param {object} command The Reactotron command object.
      */
     onCommand: command => {
-      if (command.type !== 'custom') return
+      if (command.type !== 'storybook') return
       // relay this payload on to the emitter
-      const splitCommand = command.payload.split(':')
-      if (splitCommand[0].toLowerCase() !== 'storybook') return
-      emitter.emit('storybook', splitCommand[1].toLowerCase() === 'true')
+      emitter.emit('storybook', command.payload)
     },
 
     features: {


### PR DESCRIPTION
This adds a really basic UI for the storybook toggle feature. Its dirty. It should be cleaned up which I will do on another day. Just getting this out there to be looked at/judged by others.

**Is this a breaking change?** eh... is it really breaking if you never told anyone the feature was there in the first place?

**What does it look like?** 
![screen shot 2018-04-26 at 10 07 16 pm](https://user-images.githubusercontent.com/14151327/39340891-9de4da12-499e-11e8-89b3-063dd048f92e.png)

**Is the active state 100% in line with the actual state of if storybook is shown in the app?!?** No. State sync between client and server is not always the most straight forward thing. Could we make this better? Yes... but we should do it in a more efficient manner then just solving it in one offs for everything we are starting to need to keep in sync between client and server I think.