### PR TITLE
📌 Pinning to older @types/node for now

### DIFF
--- a/packages/reactotron-app/package.json
+++ b/packages/reactotron-app/package.json
@@ -37,6 +37,7 @@
   "homepage": "https://github.com/reactotron/reactotron#readme",
   "devDependencies": {
     "@types/ws": "^4.0.1",
+    "@types/node": "^8.10.11",
     "asar": "^0.14.3",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.1",

--- a/packages/reactotron-app/yarn.lock
+++ b/packages/reactotron-app/yarn.lock
@@ -90,6 +90,10 @@
   version "8.10.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.10.tgz#fec07bc2ad549d9e6d2f7aa0fb0be3491b83163a"
 
+"@types/node@^8.10.11":
+  version "8.10.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.11.tgz#971ea8cb91adbe0b74e3fbd867dec192d5893a5f"
+
 "@types/ws@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-4.0.2.tgz#b29037627dd7ba31ec49a4f1584840422efb856f"


### PR DESCRIPTION
Seems to be an issue with the latest typings.  There's conflicts.

I'm sure it'll get sorted soon.

https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342

