### PR TITLE
[WIP] Errors Per a Second

### DIFF
--- a/packages/reactotron-app/App/Foundation/Sidebar.js
+++ b/packages/reactotron-app/App/Foundation/Sidebar.js
@@ -50,6 +50,9 @@ class Sidebar extends Component {
     this.handleClickNative = () => {
       this.props.session.ui.switchTab('native')
     }
+    this.handleClickStats = () => {
+      this.props.session.ui.switchTab('stats')
+    }
   }
 
   render () {
@@ -84,6 +87,12 @@ class Sidebar extends Component {
               icon='phone-iphone'
               isActive={ui.tab === 'native'}
               onClick={this.handleClickNative}
+            />
+            <SidebarButton
+              text='Stats'
+              icon='assignment'
+              isActive={ui.tab === 'stats'}
+              onClick={this.handleClickStats}
             />
           </div>
           <div style={Styles.spacer} />

--- a/packages/reactotron-app/App/Foundation/Stats.js
+++ b/packages/reactotron-app/App/Foundation/Stats.js
@@ -1,0 +1,58 @@
+import React, { Component } from "react"
+import Colors from '../Theme/Colors'
+import AppStyles from "../Theme/AppStyles"
+import { inject, observer } from "mobx-react"
+import StatsHeader from "./StatsHeader"
+
+const Styles = {
+  container: {
+    ...AppStyles.Layout.vbox,
+    margin: 0,
+    flex: 1,
+  },
+  content: {
+    paddingBottom: 20,
+    paddingLeft: 20,
+    paddingRight: 20,
+    overflowY: "scroll",
+    overflowX: "hidden",
+  },
+  label: {
+    color: Colors.heading,
+  },
+  value: {
+    color: Colors.tag,
+  },
+}
+
+@inject("session")
+@observer
+class Stats extends Component {
+  renderStat(label, value) {
+    return (
+      <div>
+        <span style={Styles.label}>{label}: </span>
+        <span style={Styles.value}>{value}</span>
+      </div>
+    )
+  }
+
+  render() {
+    const { devTracker } = this.props.session
+
+    return (
+      <div style={Styles.container}>
+        <StatsHeader />
+        <div style={Styles.content}>
+          {this.renderStat('Connected Time', devTracker.formattedTime)}
+          {this.renderStat('Total Errors', devTracker.totalErrors)}
+          {this.renderStat('Errors Per Second', devTracker.errorsPerSecond)}
+          {this.renderStat('Errors Per Minute', devTracker.errorsPerMinute)}
+          {this.renderStat('Errors Per Hour', devTracker.errorsPerHour)}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default Stats

--- a/packages/reactotron-app/App/Foundation/StatsHeader.js
+++ b/packages/reactotron-app/App/Foundation/StatsHeader.js
@@ -1,0 +1,80 @@
+import React, { Component } from "react"
+import Colors from "../Theme/Colors"
+import AppStyles from "../Theme/AppStyles"
+import { inject, observer } from "mobx-react"
+import SidebarToggleButton from "./SidebarToggleButton"
+
+const TITLE = "Stats"
+
+const toolbarButton = {
+  cursor: "pointer",
+}
+
+const Styles = {
+  container: {
+    WebkitAppRegion: "drag",
+    backgroundColor: Colors.backgroundSubtleLight,
+    borderBottom: `1px solid ${Colors.chromeLine}`,
+    color: Colors.foregroundDark,
+    boxShadow: `0px 0px 30px ${Colors.glow}`,
+  },
+  content: {
+    height: 60,
+    paddingLeft: 10,
+    paddingRight: 10,
+    ...AppStyles.Layout.hbox,
+    justifyContent: "space-between",
+  },
+  left: {
+    ...AppStyles.Layout.hbox,
+    width: 100,
+    alignItems: "center",
+  },
+  right: {
+    width: 100,
+    ...AppStyles.Layout.hbox,
+    justifyContent: "flex-end",
+    alignItems: "center",
+  },
+  center: {
+    ...AppStyles.Layout.vbox,
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  title: {
+    color: Colors.foregroundLight,
+    textAlign: "center",
+  },
+  iconSize: 32,
+  toolbarAdd: {
+    ...toolbarButton,
+  },
+}
+
+@inject("session")
+@observer
+class StatsHeader extends Component {
+  render() {
+    const { ui } = this.props.session
+
+    return (
+      <div style={Styles.container}>
+        <div style={Styles.content}>
+          <div style={Styles.left}>
+            <SidebarToggleButton
+              onClick={ui.toggleSidebar}
+              isSidebarVisible={ui.isSidebarVisible}
+            />
+          </div>
+          <div style={Styles.center}>
+            <div style={Styles.title}>{TITLE}</div>
+          </div>
+          <div style={Styles.right} />
+        </div>
+      </div>
+    )
+  }
+}
+
+export default StatsHeader

--- a/packages/reactotron-app/App/Foundation/TimelineHeader.js
+++ b/packages/reactotron-app/App/Foundation/TimelineHeader.js
@@ -124,9 +124,11 @@ class TimelineHeader extends Component {
             <div style={Styles.title}>{TITLE}</div>
             <div>
               {/* <ConnectionSelector /> */}
-              conTime: {devTracker.connectionTime}
-              currErr: {devTracker.currentErrors}
+              conTime: {devTracker.connectedSeconds}
+              currErr: {devTracker.totalErrors}
               EPS: {devTracker.errorsPerSecond}
+              EPM: {devTracker.errorsPerMinute}
+              EPH: {devTracker.errorsPerHour}
             </div>
           </div>
           <div style={Styles.right}>

--- a/packages/reactotron-app/App/Foundation/TimelineHeader.js
+++ b/packages/reactotron-app/App/Foundation/TimelineHeader.js
@@ -103,7 +103,7 @@ class TimelineHeader extends Component {
   }
 
   render () {
-    const { ui, devTracker } = this.props.session
+    const { ui } = this.props.session
     const { isTimelineSearchVisible } = ui
     const searchIconStyle = {
       ...Styles.searchIcon,
@@ -123,12 +123,7 @@ class TimelineHeader extends Component {
           <div style={Styles.center}>
             <div style={Styles.title}>{TITLE}</div>
             <div>
-              {/* <ConnectionSelector /> */}
-              conTime: {devTracker.connectedSeconds}
-              currErr: {devTracker.totalErrors}
-              EPS: {devTracker.errorsPerSecond}
-              EPM: {devTracker.errorsPerMinute}
-              EPH: {devTracker.errorsPerHour}
+              <ConnectionSelector />
             </div>
           </div>
           <div style={Styles.right}>

--- a/packages/reactotron-app/App/Foundation/TimelineHeader.js
+++ b/packages/reactotron-app/App/Foundation/TimelineHeader.js
@@ -103,7 +103,7 @@ class TimelineHeader extends Component {
   }
 
   render () {
-    const { ui } = this.props.session
+    const { ui, devTracker } = this.props.session
     const { isTimelineSearchVisible } = ui
     const searchIconStyle = {
       ...Styles.searchIcon,
@@ -123,7 +123,10 @@ class TimelineHeader extends Component {
           <div style={Styles.center}>
             <div style={Styles.title}>{TITLE}</div>
             <div>
-              <ConnectionSelector />
+              {/* <ConnectionSelector /> */}
+              conTime: {devTracker.connectionTime}
+              currErr: {devTracker.currentErrors}
+              EPS: {devTracker.errorsPerSecond}
             </div>
           </div>
           <div style={Styles.right}>

--- a/packages/reactotron-app/App/Foundation/VisualRoot.js
+++ b/packages/reactotron-app/App/Foundation/VisualRoot.js
@@ -12,6 +12,7 @@ import ConnectionSelectionDialog from '../Dialogs/ConnectionSelectionDialog'
 import Subscriptions from './Subscriptions'
 import Backups from './Backups'
 import Native from './Native'
+import Stats from './Stats'
 import Sidebar from './Sidebar'
 import Help from './Help'
 import { inject, observer } from 'mobx-react'
@@ -57,6 +58,7 @@ export default class VisualRoot extends Component {
     const showSettings = ui.tab === 'settings'
     const showBackups = ui.tab === 'backups'
     const showNative = ui.tab === 'native'
+    const showStats = ui.tab === 'stats'
 
     return (
       <div style={Styles.container}>
@@ -78,6 +80,9 @@ export default class VisualRoot extends Component {
               </div>
               <div style={showNative ? Styles.page : Styles.pageHidden}>
                 <Native />
+              </div>
+              <div style={showStats ? Styles.page : Styles.pageHidden}>
+                <Stats />
               </div>
               <div style={showSettings ? Styles.page : Styles.pageHidden}>
                 <h1>Settings</h1>

--- a/packages/reactotron-app/App/Stores/DevTrackerStore.js
+++ b/packages/reactotron-app/App/Stores/DevTrackerStore.js
@@ -1,0 +1,77 @@
+import { computed, observable, action, asMap } from "mobx"
+
+const TIME_NAME = 'devTrackerTimeConnected'
+const ERROR_NAME = 'devTrackerErrorsCount'
+
+class DevTracker {
+    @observable storedTime = 0
+    @observable currentErrors = 0
+
+    @observable sessionStarted = null
+
+    constructor() {
+        const currentDevTime = localStorage.getItem(TIME_NAME)
+        const currentErrors = localStorage.getItem(ERROR_NAME)
+
+        if (typeof currentDevTime === 'undefined' || currentDevTime === null) {
+            localStorage.setItem(TIME_NAME, 0)
+        } else {
+            this.storedTime = parseInt(currentDevTime, 10)
+        }
+
+        if (typeof currentErrors === 'undefined' || currentErrors === null) {
+            localStorage.setItem(ERROR_NAME, 0)
+        } else {
+            this.currentErrors = parseInt(currentErrors, 10)
+        }
+    }
+
+    @computed
+    get connectionTime() {
+        let currentSessionTime = 0
+
+        if (this.sessionStarted) {
+            const currentTime = new Date()
+            currentSessionTime = (currentTime.getTime() - this.sessionStarted.getTime()) / 1000
+        }
+
+        return this.storedTime + Math.floor(currentSessionTime)
+    }
+
+    @computed
+    get errorsPerSecond() {
+        const currentConnectionTime = this.connectionTime
+
+        if (currentConnectionTime === 0) return 0
+
+        return this.currentErrors / currentConnectionTime
+    }
+
+    @action
+    connectionStarted = () => {
+        if (!this.sessionStarted) {
+            this.sessionStarted = new Date()
+        }
+    }
+
+    @action
+    connectionFinished = () => {
+        if (!this.sessionStarted) return
+
+        const currentTime = new Date()
+        const connectionLength = Math.floor((currentTime.getTime() - this.sessionStarted.getTime()) / 1000)
+        this.sessionStarted = null
+
+        this.storedTime += connectionLength
+        localStorage.setItem(TIME_NAME, this.storedTime)
+    }
+
+    @action
+    addError = () => {
+        this.currentErrors += 100
+
+        localStorage.setItem(ERROR_NAME, this.currentErrors)
+    }
+}
+
+export default DevTracker

--- a/packages/reactotron-app/App/Stores/DevTrackerStore.js
+++ b/packages/reactotron-app/App/Stores/DevTrackerStore.js
@@ -31,7 +31,36 @@ class DevTracker {
     get errorsPerSecond() {
         if (this.connectedSeconds === 0) return 0
 
-        return this.totalErrors / this.connectedSeconds
+        return Math.round((this.totalErrors / this.connectedSeconds) * 100) / 100
+    }
+
+    @computed
+    get formattedTime() {
+        let timeLeft = this.connectedSeconds
+        const days = Math.floor(timeLeft / 86400)
+        timeLeft %= 86400
+        let hours = Math.floor(timeLeft / 3600)
+        timeLeft %= 3600
+        let minutes = Math.floor(timeLeft / 60)
+        let seconds = timeLeft % 60
+
+        let timeString = []
+
+        if (days > 0) {
+            timeString.push(`${days} day${days > 1 ? 's' : ''}`)
+        }
+
+        if (hours > 0) {
+            timeString.push(`${hours} hour${hours > 1 ? 's' : ''}`)
+        }
+
+        if (minutes > 0) {
+            timeString.push(`${minutes} minute${minutes > 1 ? 's' : ''}`)
+        }
+
+        timeString.push(`${seconds} second${seconds > 1 ? 's' : ''}`)
+
+        return timeString.join(', ')
     }
 
     @computed
@@ -41,7 +70,7 @@ class DevTracker {
         // If we have been connected < a minute then we don't want to try and do predictions (which would be what happens when we divide by < 1)
         const connectedMinutes = this.connectedSeconds > 60 ? this.connectedSeconds / 60 : 1
 
-        return this.totalErrors / connectedMinutes
+        return Math.round((this.totalErrors / connectedMinutes) * 100) / 100
     }
 
     @computed
@@ -51,7 +80,7 @@ class DevTracker {
         // If we have been connected < a hour then we don't want to try and do predictions (which would be what happens when we divide by < 1)
         const connectedHours = this.connectedSeconds > 3600 ? this.connectedSeconds / 60 / 60 : 1
 
-        return this.totalErrors / connectedHours
+        return Math.round((this.totalErrors / connectedHours) * 100) / 100
     }
 
     @action

--- a/packages/reactotron-app/App/Stores/UiStore.js
+++ b/packages/reactotron-app/App/Stores/UiStore.js
@@ -93,6 +93,7 @@ class UI {
     Mousetrap.bind(`${Keystroke.mousetrap}+2`, this.switchTab.bind(this, "subscriptions"))
     Mousetrap.bind(`${Keystroke.mousetrap}+3`, this.switchTab.bind(this, "backups"))
     Mousetrap.bind(`${Keystroke.mousetrap}+4`, this.switchTab.bind(this, "native"))
+    Mousetrap.bind(`${Keystroke.mousetrap}+5`, this.switchTab.bind(this, "stats"))
     Mousetrap.bind(`${Keystroke.mousetrap}+?`, this.switchTab.bind(this, "help"))
     Mousetrap.bind(`${Keystroke.mousetrap}+f`, this.showTimelineSearch)
     Mousetrap.bind(`${Keystroke.mousetrap}+.`, this.openSendCustomDialog)


### PR DESCRIPTION
This is pointed at the connection filtering branch because I rely on an event added in the PR to track when connections are started/finished.

This is a really really basic implementation of Errors Per a Second (EPS). The UI is just thrown in the header to test the functionality of tracking this information. As of right now the time connected only updates when a connection is lost but errors per a second are updated at the time of seeing an error. This can lead to slightly off EPS scores but I think that is a solvable problem.

There are a few things I think we should do still:
 - [ ] Add this to its own tab with a reset button and all
 - [x] Figure out making the connection time count up in real time so that the EPS score is also in real time
 - [x] Handle saving all the data if Reactotron is shutdown. Right now if a connection is open and you close Reactotron you lose the current sessions time so your EPS score would be skewed.
 - [ ] Clean up the code. This is 100% hacked together (It is 11:13pm and I started writing this code at 10:56ish sooo...yeah)
 - [x] Add Errors Per Minute (EPM)
 - [x] Add Errors Per Hour (EPH)
 - [ ] Other things? ¯\\\_(ツ)\_/¯