### PR TITLE
Fix for a networking issue: response body replaced by blob metadata since RN 0.54

### DIFF
--- a/packages/reactotron-react-native/src/plugins/networking.js
+++ b/packages/reactotron-react-native/src/plugins/networking.js
@@ -111,7 +111,11 @@ export default (pluginConfig = {}) => reactotron => {
         // Disable reason: FileReader should be in global scope since RN 0.54
         // eslint-disable-next-line no-undef
         const bReader = new FileReader()
-        bReader.addEventListener('loadend', () => sendResponse(bReader.result))
+        const brListener = () => {
+          sendResponse(bReader.result)
+          bReader.removeEventListener('loadend', brListener)
+        }
+        bReader.addEventListener('loadend', brListener)
         bReader.readAsText(response)
       } else {
         sendResponse(response)

--- a/packages/reactotron-react-native/src/plugins/networking.js
+++ b/packages/reactotron-react-native/src/plugins/networking.js
@@ -80,6 +80,7 @@ export default (pluginConfig = {}) => reactotron => {
       (xhr.responseHeaders && xhr.responseHeaders['Content-Type']) ||
       ''
 
+    const sendResponse = responseBodyText => {
       let body = `~~~ skipped ~~~`
       if (responseBodyText && responseBodyText.length) {
         try {


### PR DESCRIPTION
RN supports Blobs since 0.54, it changed some things in the networking stack, since then Reactotron networking plugin shows blob metadata instead of responses body in the "Response" tab of a request.

This can easily be reproduced by using this repro: https://github.com/psegalen/rn-android-blob-failure

This PR aims to fix this issue by getting the actual blob body when a server response has a "blob" type.