### PR TITLE
Fix TypeScript issue: replace RegExpConstructor to RegExp of ReactotronUseReactNativeNetworking interface

### DIFF
--- a/packages/reactotron-react-native/reactotron-react-native.d.ts
+++ b/packages/reactotron-react-native/reactotron-react-native.d.ts
@@ -37,8 +37,8 @@ declare module "reactotron-react-native" {
   }
 
   export interface ReactotronUseReactNativeNetworking {
-    ignoreContentTypes?: RegExpConstructor
-    ignoreUrls?: RegExpConstructor
+    ignoreContentTypes?: RegExp
+    ignoreUrls?: RegExp
   }
 
   export interface ReactotronUseReactNativeEditor {


### PR DESCRIPTION
As far as I read "https://raw.githubusercontent.com/Microsoft/TypeScript/master/lib/lib.es6.d.ts", RegExpConstructor always return RegExp instance, so it seems that ReactotronUseReactNativeNetworking interface should accepts generated RegExp, not Constructor class.