### PR TITLE
✨ sends the storybook command to every new connection

### DIFF
--- a/packages/reactotron-app/App/Stores/SessionStore.js
+++ b/packages/reactotron-app/App/Stores/SessionStore.js
@@ -36,7 +36,6 @@ const COMMON_MATCHING_PATHS = [
   path(["payload", "triggerType"]),
   path(["payload", "description"]),
   path(["payload", "request", "url"]),
-  path(["payload", "request", "url"]),
 ]
 
 class Session {
@@ -247,6 +246,10 @@ class Session {
 
     this.server.on("command", this.handleCommand)
     this.server.on("connectionEstablished", this.handleConnectionsChange)
+
+    // resend the storybook state to newly arriving connections
+    this.server.on("connectionEstablished", connection => this.ui.sendStorybookState(connection.clientId))
+
     this.server.on("disconnect", this.handleConnectionsChange)
 
     this.stateBackupStore = new StateBackupStore(this.server)

--- a/packages/reactotron-app/App/Stores/UiStore.js
+++ b/packages/reactotron-app/App/Stores/UiStore.js
@@ -435,19 +435,33 @@ class UI {
     this.server.send("storybook", this.isStorybookShown)
   }
 
+  /**
+   * Turn on storybook for the current client.
+   */
   @action
   enableStorybook = () => {
     if (this.isStorybookShown) return
     this.isStorybookShown = true
-    this.server.send("storybook", this.isStorybookShown)
+    this.sendStorybookState()
   }
 
+  /**
+   * Turn off storybook for the current client.
+   */
   @action
   disableStorybook = () => {
     if (!this.isStorybookShown) return
     this.isStorybookShown = false
-    this.server.send("storybook", this.isStorybookShown)
+    this.sendStorybookState()
   }
+
+  /**
+   * Sends the current storybook state to the app.
+   */
+  sendStorybookState = clientId => {
+    this.server.send("storybook", this.isStorybookShown, clientId)
+  }
+
 }
 
 export default UI


### PR DESCRIPTION
If we're using the storybook HOC, doing a client reload will pop it out storybook mode.

This ensures the right state is always pushed when we connect.