### PR TITLE
🐛 Fix async storage

### DIFF
--- a/packages/reactotron-app/App/Commands/AsyncStorageMutationCommand.js
+++ b/packages/reactotron-app/App/Commands/AsyncStorageMutationCommand.js
@@ -1,0 +1,74 @@
+import { observer } from "mobx-react"
+import PropTypes from "prop-types"
+import { addIndex, is, map } from "ramda"
+import React, { Component } from "react"
+import Command from "../Shared/Command"
+import { textForValue } from "../Shared/MakeTable"
+import Content from "../Shared/Content"
+import AppStyles from "../Theme/AppStyles"
+import Colors from "../Theme/Colors"
+
+const COMMAND_TITLE = "ASYNC STORAGE"
+
+@observer
+class AsyncStorageMutationCommand extends Component {
+  static propTypes = {
+    command: PropTypes.object.isRequired,
+  }
+
+  render() {
+    const { command } = this.props
+    const { action, data = {} } = command.payload
+    let preview = action
+    if (action === "setItem" || action === "removeItem" || action === "mergeItem") {
+      preview = `${action}: ${data.key}`
+    }
+    return (
+      <Command {...this.props} title={COMMAND_TITLE} preview={preview}>
+        <div style={Styles.watches}>
+          <Content value={data} />
+        </div>
+      </Command>
+    )
+  }
+}
+
+const Styles = {
+  container: {
+    ...AppStyles.Layout.vbox,
+    margin: 0,
+    flex: 1,
+  },
+  items: {
+    margin: 0,
+    padding: 0,
+    overflowY: "auto",
+    overflowX: "hidden",
+  },
+  item: {
+    ...AppStyles.Layout.hbox,
+    padding: "5px",
+    justifyContent: "space-between",
+  },
+  itemLeft: {
+    minWidth: 215,
+    maxWidth: 215,
+    wordBreak: "break-all",
+  },
+  key: {
+    color: Colors.constant,
+    WebkitUserSelect: "text",
+    cursor: "text",
+  },
+  value: {
+    flex: 1,
+    wordBreak: "break-all",
+    WebkitUserSelect: "text",
+    cursor: "text",
+  },
+  title: {
+    color: Colors.tag,
+  },
+}
+
+export default AsyncStorageMutationCommand

--- a/packages/reactotron-app/App/Commands/index.js
+++ b/packages/reactotron-app/App/Commands/index.js
@@ -10,6 +10,7 @@ import DisplayCommand from './DisplayCommand'
 import ImageCommand from './ImageCommand'
 import SagaTaskCompleteCommand from './SagaTaskCompleteCommand'
 import AsyncStorageValuesCommand from './AsyncStorageValuesCommand'
+import AsyncStorageMutationCommand from './AsyncStorageMutationCommand'
 
 export default command => {
   const { type } = command
@@ -39,6 +40,8 @@ export default command => {
       return SagaTaskCompleteCommand
     case 'asyncStorage.values.change':
       return AsyncStorageValuesCommand
+    case 'asyncStorage.mutation':
+      return AsyncStorageMutationCommand
     default: {
       return null
     }


### PR DESCRIPTION
The `AsyncStorage` plugin wasn't properly working for a few versions of this beta.

I went to take a look at this today, and it was really complicated.

I rewrote it to display mutations only now.  Whenever a key is changed via `setItem` and friends (there's like 7 of 'em), we log out what the change is going to be as opposed to the strange race condition we had in there to see what the new values have become.

What's missing from this PR is:  the ability to ship everything in async storage up to Reactotron.

This will be useful for displaying the entire state of async storage as a tree.

That feature is coming next.
