### PR TITLE
✨ adds prepublishOnly npm script

### DIFF
--- a/packages/reactotron-apisauce/package.json
+++ b/packages/reactotron-apisauce/package.json
@@ -8,7 +8,8 @@
     "format": "prettier --write {**,.}/*.js",
     "watch": "ava --watch",
     "coverage": "nyc ava",
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "prepublishOnly": "yarn build"
   },
   "repository": "https://github.com/reactotron/reactotron/tree/master/packages/reactotron-apisauce",
   "author": "Steve Kellock",

--- a/packages/reactotron-core-client/package.json
+++ b/packages/reactotron-core-client/package.json
@@ -16,7 +16,8 @@
     "compile": "NODE_ENV=production tsc",
     "lint": "tslint -p .",
     "rollup": "NODE_ENV=production rollup -c",
-    "test": "jest"
+    "test": "jest",
+    "prepublishOnly": "yarn build"
   },
   "author": "Steve Kellock",
   "bugs": {

--- a/packages/reactotron-core-server/package.json
+++ b/packages/reactotron-core-server/package.json
@@ -11,7 +11,8 @@
     "clean": "trash dist compiled",
     "format": "prettier --write {**,.}/*.ts && tslint -p . --fix",
     "lint": "tslint -p .",
-    "build:watch": "node watch.js"
+    "build:watch": "node watch.js",
+    "prepublishOnly": "yarn build"
   },
   "repository": "infinitered/reactotron",
   "author": "Steve Kellock",

--- a/packages/reactotron-react-js/package.json
+++ b/packages/reactotron-react-js/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "format": "prettier --write {**,.}/*.js",
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "prepublishOnly": "yarn build"
   },
   "repository": "https://github.com/reactotron/reactotron/tree/master/packages/reactotron-react-js",
   "author": "Steve Kellock",

--- a/packages/reactotron-react-native/package.json
+++ b/packages/reactotron-react-native/package.json
@@ -7,6 +7,7 @@
     "build": "rollup -c",
     "format": "prettier --write {**,.}/*.js && standard --fix",
     "lint": "standard",
+    "prepublishOnly": "yarn build",
     "build:watch": "node watch.js"
   },
   "repository": "https://github.com/reactotron/reactotron/tree/master/packages/reactotron-react-native",

--- a/packages/reactotron-redux-saga/package.json
+++ b/packages/reactotron-redux-saga/package.json
@@ -9,7 +9,8 @@
     "format": "prettier --write {**,.}/*.js && standard --fix",
     "coverage": "nyc ava",
     "build": "rollup -c ",
-    "lint": "standard"
+    "lint": "standard",
+    "prepublishOnly": "yarn build"
   },
   "repository": "https://github.com/reactotron/reactotron/tree/master/packages/reactotron-redux-saga",
   "author": "Steve Kellock",

--- a/packages/reactotron-redux/package.json
+++ b/packages/reactotron-redux/package.json
@@ -9,7 +9,8 @@
     "format": "prettier --write {**,.}/*.js && standard --fix",
     "coverage": "nyc ava",
     "build": "rollup -c ",
-    "lint": "standard"
+    "lint": "standard",
+    "prepublishOnly": "yarn build"
   },
   "repository": "https://github.com/reactotron/reactotron/tree/master/packages/reactotron-redux",
   "author": "Steve Kellock",


### PR DESCRIPTION
This ensures we run the build step before publishing.

This is important since we're deploying from lerna.  After lerna bumps the version number in the package.json files, we then need to do a rebuild before publishing since a few rollup files replace strings with the build number.

