### PR TITLE
💄 fixes wrong flex direction on dialog titles

### DIFF
--- a/packages/reactotron-app/App/Theme/ModalStyles.js
+++ b/packages/reactotron-app/App/Theme/ModalStyles.js
@@ -52,9 +52,9 @@ export default {
     ...Layout.vbox,
     padding: "1em 2em 0em",
     display: "flex",
-    flexDirection: "row",
+    flexDirection: "column",
     justifyContent: "space-between",
-    alignItems: "center",
+    alignItems: "left",
   },
   body: {
     ...Layout.vbox,


### PR DESCRIPTION
Then now look like this again:

![image](https://user-images.githubusercontent.com/68273/41777389-235f745a-75f9-11e8-97f9-b4e6e0932684.png)


Instead of this:

![image](https://user-images.githubusercontent.com/68273/41777404-315231c4-75f9-11e8-82ec-3b7581d323de.png)

