### PR TITLE
Minor update to close to specify its void return

### DIFF
--- a/packages/reactotron-react-native/reactotron-react-native.d.ts
+++ b/packages/reactotron-react-native/reactotron-react-native.d.ts
@@ -118,7 +118,7 @@ declare module "reactotron-react-native" {
     /**
      * Closes the active connection.
      */
-    close()
+    close(): void;
 
     /**
      * Use the pack of ReactNative plugins.


### PR DESCRIPTION
Typescript gave me a warning about the reactotron type definition.

I know is a pretty silly change but I will be revisiting the type definition in order to create its types for all the plugins.