### PR TITLE
🐛 fixes broken reactotron-mst build

### DIFF
--- a/packages/reactotron-mst/package.json
+++ b/packages/reactotron-mst/package.json
@@ -7,6 +7,7 @@
   "typings": "dist/reactotron-mst.d.ts",
   "scripts": {
     "compile": "tsc",
+    "prebuild": "tsc",
     "build": "rollup -c rollup.config.ts",
     "clean": "npm-run-all clean:*",
     "clean:build": "rimraf build",


### PR DESCRIPTION
`rollup` requires `typescript` to have run.

Oopsie.
