### PR TITLE
✨ copy api details to clipboard as markdown

### DIFF
--- a/packages/reactotron-app/App/Lib/api-to-markdown.js
+++ b/packages/reactotron-app/App/Lib/api-to-markdown.js
@@ -1,0 +1,123 @@
+import { rightPad } from "../Lib/pad"
+
+function tableToMarkdown(table) {
+  const lines = []
+
+  // find the lengths
+  let keyLength = 0
+  let valueLength = 0
+  for (const key in table) {
+    keyLength = Math.max(keyLength, key.length)
+    valueLength = Math.max(valueLength, (table[key] || "").length)
+  }
+
+  // helpers for drawing fixed widths
+  const keyPad = (value = "") => rightPad(value, keyLength)
+  const valuePad = (value = "") => rightPad(value, valueLength)
+  const add = (key = "", value = "") =>
+    lines.push(`${keyPad(key || "")} | ${valuePad(value || "")}`)
+
+  // header
+  add("key", "value")
+
+  // divider
+  lines.push(`${"-".repeat(keyLength)} | ${"-".repeat(valueLength)}`)
+
+  // each line
+  for (const key in table) {
+    add(key, table[key])
+  }
+
+  return lines.join("\n")
+}
+
+export function apiToMarkdown(payload = {}) {
+  const lines = []
+  const request = payload.request || {}
+
+  lines.push("# Request")
+
+  lines.push("")
+  lines.push("### Endpoint")
+  lines.push("")
+  lines.push(`\`${request.method || ""}\` ${request.url || ""}`.trim())
+
+  if (typeof payload.duration === "number") {
+    lines.push("")
+    lines.push("### Duration")
+    lines.push("")
+    lines.push(`\`${payload.duration.toFixed(0)}\` ms`)
+  }
+
+  // request data
+  if (request.data) {
+    let data = request.data
+    // attempt to jsonify the request data
+    try {
+      data = JSON.stringify(JSON.parse(data), null, 2)
+    } catch (e) {}
+
+    if (data) {
+      lines.push("")
+      lines.push("### Data Sent")
+      lines.push("")
+      lines.push("```json")
+      lines.push(data)
+      lines.push("```")
+    }
+  }
+
+  // request headers
+  if (request.headers && Object.keys(request.headers).length > 0) {
+    lines.push("")
+    lines.push("### Headers")
+    lines.push("")
+    lines.push(tableToMarkdown(request.headers))
+  }
+
+  if (payload.response) {
+    const response = payload.response || {}
+
+    lines.push("")
+    lines.push("# Response")
+
+    if (response.status) {
+      lines.push("")
+      lines.push("### Status Code")
+      lines.push("")
+      lines.push(`\`${response.status}\``)
+    }
+
+    // response data
+    if (response.body) {
+      let body = response.body
+      // attempt to jsonify the request data
+      try {
+        if (typeof body === "string") {
+          body = JSON.parse(body)
+        }
+        body = JSON.stringify(body, null, 2)
+      } catch (e) {}
+
+      if (body) {
+        lines.push("")
+        lines.push("### Data Received")
+        lines.push("")
+        lines.push("```json")
+        lines.push(body)
+        lines.push("```")
+      }
+    }
+
+    // response headers
+    if (response.headers && Object.keys(response.headers).length > 0) {
+      lines.push("")
+      lines.push("### Headers")
+      lines.push("")
+      lines.push(tableToMarkdown(response.headers))
+    }
+  }
+
+  lines.push("")
+  return lines.join("\n")
+}

--- a/packages/reactotron-app/App/Lib/pad.js
+++ b/packages/reactotron-app/App/Lib/pad.js
@@ -1,0 +1,21 @@
+/**
+ * Adds spacing to the left of a string until it reaches a specific length.
+ *
+ * @param {string} str The string to pad.
+ * @param {number} length How much to pad.
+ * @param {string} chr What to pad with.
+ */
+export function leftPad(str, length, chr = " ") {
+  return chr.repeat(Math.max(0, length - str.length)) + str
+}
+
+/**
+ * Adds spacing to the right of a string until it reaches a specific length.
+ *
+ * @param {string} str The string to pad.
+ * @param {number} length How much to pad.
+ * @param {string} chr What to pad with.
+ */
+export function rightPad(str, length, chr = " ") {
+  return str + chr.repeat(Math.max(0, length - str.length))
+}


### PR DESCRIPTION
For debugging with the backend team, I needed to copy the whole api request/response including headers, status code, and duration.

Presently, we only have the ability to copy the data of the request or response.

This adds markdown support.

![image](https://user-images.githubusercontent.com/68273/43011819-8c3f740a-8c12-11e8-929d-95e76dda34af.png)

It's the 3rd button there that looks like a receipt.  😆 


<details><summary>An example</summary>

# Request

### Endpoint

`PATCH` http://********************/customer_profile

### Duration

`409` ms

### Data Sent

```json
{
  "payment_profiles": [
    {
      "masked_card_number": "xxxx-xxxx-xxxx-1111",
      "expiry_month": "12",
      "expiry_year": "2024",
      "card_type": "EP VISA",
      "tokenized_credit_card": "a09-1b6fcfc6-????-????-b07d-7efffc42cf26"
    }
  ]
}
```

### Headers

key                | value                                             
------------------ | --------------------------------------------------
accept             | application/vnd.xxxxxx_api.v1                     
content-type       | application/json                                  
cache-control      | no-cache                                          
authorization      | Token token="25bc66c5-????-????-8c70-3bef91b97077"
                   

# Response

### Status Code

`403`

### Data Received

```json
{
  "errors": {
    "error_code": "customer_profile_not_found",
    "message": "You have no user profile attached to your access key."
  }
}
```

### Headers

key                    | value                               
---------------------- | ------------------------------------
Content-Type           | application/json; charset=utf-8     
Vary                   | Accept-Encoding, Origin             
X-Request-Id           | 7cffba2b-1935-????-90a2-f4b3f44e92c4
Server                 | nginx/something                        
X-Runtime              | 0.245554                            
Content-Encoding       | gzip                                
X-XSS-Protection       | 1; mode=block                       
Status                 | 403 Forbidden                       
Transfer-Encoding      | Identity                            
Cache-Control          | no-cache                            
Date                   | Fri, 20 Jul 2018 15:07:09 GMT       
Connection             | keep-alive                          
X-Frame-Options        | SAMEORIGIN                          
X-Content-Type-Options | nosniff                             

</details>