### PR TITLE
Included extra plugin definitions of "reactotron-react-native" for typescript

### DIFF
--- a/packages/reactotron-react-native/reactotron-react-native.d.ts
+++ b/packages/reactotron-react-native/reactotron-react-native.d.ts
@@ -195,6 +195,28 @@ declare module "reactotron-react-native" {
     benchmark(title?: string): ReactotronBenchmark
   }
 
+  /**
+   * Provides async storage information to Reactotron.
+   */
+  function asyncStorage(): (tron: Reactotron) => ReactotronPlugin;
+  /**
+   * Provides a global error handler to report errors.
+   */
+  function trackGlobalErrors(): (tron: Reactotron) => ReactotronPlugin;
+  function openInEditor(): (tron: Reactotron) => ReactotronPlugin;
+  /**
+   * Provides an image.
+   */
+  function overlay(): (tron: Reactotron) => ReactotronPlugin;
+  /**
+   * Provides network information to reactotron.
+   */
+  function networking(): (tron: Reactotron) => ReactotronPlugin;
+  /**
+   * A plugin which provides .storybookSwitcher() on Reactotron.
+   */
+  function storybook(): (tron: Reactotron) => ReactotronPlugin;
+
   var instance: Reactotron
 
   export { instance as default }


### PR DESCRIPTION
This commit enables the definition of the following scenario:

```typescript
import * as Reactotron from "reactotron-react-native";

Reactotron.default
    .configure({ name: config.name })
    .use(Reactotron.trackGlobalErrors()) // tracking errors
    .use(Reactotron.asyncStorage()) // tracking storage
    .use(Reactotron.networking()) // tracking networking
    // the lines above could be substituted by
    //.useReactNative() 
    .connect();
```