### PR TITLE
Flesh out some typescript type definitions for reactotron-react-native and reactotron-redux

### DIFF
--- a/packages/reactotron-react-native/reactotron-react-native.d.ts
+++ b/packages/reactotron-react-native/reactotron-react-native.d.ts
@@ -154,6 +154,15 @@ declare module "reactotron-react-native" {
     logImportant(...value: any[]): void
 
     /**
+     * Prints a value such a string, object, or array.
+     *
+     * This is the same as console.warn, except it sends it to the Reactotron app.
+     *
+     * @param value Anything you'd like to log.
+     */
+    warn(...value: any[]): void
+
+    /**
      * Logs an error with a stack trace.
      *
      * @param error

--- a/packages/reactotron-redux/package.json
+++ b/packages/reactotron-redux/package.json
@@ -24,6 +24,7 @@
     "LICENSE",
     "README.md"
   ],
+  "types": "./reactotron-redux.d.ts",
   "devDependencies": {
     "ava": "^0.20.0",
     "babel-core": "^6.25.0",

--- a/packages/reactotron-redux/reactotron-redux.d.ts
+++ b/packages/reactotron-redux/reactotron-redux.d.ts
@@ -1,4 +1,42 @@
 declare module 'reactotron-redux' {
+  import { AnyAction } from 'redux';
   import { ReactotronPlugin, Reactotron } from 'reactotron-react-native';
-  export function reactotronRedux(): (tron: Reactotron) => ReactotronPlugin;
+
+  interface PluginConfig {
+    /**
+     * If you have some actions you'd rather just not see (for example,
+     * redux-saga triggers a little bit of noise), you can suppress them by
+     * using this property and passing the action types you want to suppress.
+     */
+    except?: string[];
+    /**
+     * isActionImportant is a function which receives an action and returns a
+     * boolean. true will cause the action to show up in the Reactotron app
+     * with a highlight.
+     */
+    isActionImportant?: (action: AnyAction) => boolean;
+    /**
+     * onBackup fires when we're about to transfer a copy of your Redux global
+     * state tree and send it to the server. It accepts an object called state
+     * and returns an object called state.
+     *
+     * You can use this to prevent big, sensitive, or transient data from going
+     * to Reactotron.
+     */
+    onBackup?: (state: any) => any;
+    /**
+     * onRestore is the opposite of onBackup. It will fire when the Reactotron
+     * app sends a new copy of state to the app.
+     */
+    onRestore?: (state: any) => any;
+  }
+
+  export function reactotronRedux(pluginConfig?: PluginConfig): (tron: Reactotron) => ReactotronPlugin;
+}
+
+declare module 'reactotron-react-native' {
+  import { StoreCreator } from 'redux';
+  export interface Reactotron {
+    public createStore: StoreCreator;
+  }
 }


### PR DESCRIPTION
Nothing too crazy here, I hope.

I found that the `warn` method was missing from the Reactotron interface exposed by `reactotron-react-native`, so I am adding that.

And for `reactotron-redux` there was a basic type definition file already, but it wasn't being referenced from package.json, so I added that (otherwise typescript doesn't know how to find it), and then fleshed it out some.  I used the readme for the comments  (more or less).

I tested it w/ my own react native project to make sure typescript was happy (and it was :) ).