### PR TITLE
Safely Import Reactotron

### DIFF
--- a/docs/quick-start-react-native.md
+++ b/docs/quick-start-react-native.md
@@ -56,7 +56,9 @@ Finally, we import this on startup in
 on line 1:
 
 ```js
-import './ReactotronConfig'
+if(__DEV__) {
+  import('.ReactotronConfig').then(() => console.log('Reactotron Configured'))
+}
 ```
 
 At this point, Reactotron is hooked up.


### PR DESCRIPTION
Because Reactotron is a dev dependency, we want to be careful not to accidentally import the config in production. Therefore, wrapping the import in a conditional include makes sense as best practice.