### PR TITLE
Fixed redux typedef issue and added redux-saga typedef

### DIFF
--- a/packages/reactotron-redux-saga/package.json
+++ b/packages/reactotron-redux-saga/package.json
@@ -24,6 +24,7 @@
     "LICENSE",
     "README.md"
   ],
+  "types": "./reactotron-redux-saga.d.ts",
   "devDependencies": {
     "ava": "^0.20.0",
     "babel-core": "^6.25.0",

--- a/packages/reactotron-redux-saga/reactotron-redux-saga.d.ts
+++ b/packages/reactotron-redux-saga/reactotron-redux-saga.d.ts
@@ -1,0 +1,19 @@
+// Module Augmentation for plugin
+declare module 'reactotron-react-native' {
+    import { Monitor } from 'redux-saga';
+
+    export interface Reactotron {
+        createSagaMonitor(): Monitor;
+    }
+}
+
+declare module 'reactotron-redux-saga' {
+    import { ReactotronPlugin, Reactotron } from 'reactotron-react-native';
+
+    interface PluginConfig {
+        except?: string[];
+    }
+
+    export default function sagaPlugin(config: PluginConfig = {}): (tron: Reactotron) => ReactotronPlugin;
+}
+

--- a/packages/reactotron-redux/reactotron-redux.d.ts
+++ b/packages/reactotron-redux/reactotron-redux.d.ts
@@ -34,9 +34,14 @@ declare module 'reactotron-redux' {
   export function reactotronRedux(pluginConfig?: PluginConfig): (tron: Reactotron) => ReactotronPlugin;
 }
 
+// Module Augmentation for plugin
 declare module 'reactotron-react-native' {
   import { StoreCreator } from 'redux';
+
   export interface Reactotron {
-    public createStore: StoreCreator;
+    /**
+     * Wraps Redux's createStore for sane configuration
+     */
+    createStore: StoreCreator;
   }
 }


### PR DESCRIPTION
Fixed small issue with redux's typedef as an interface should not define the accessor (everything on an interface is public via definition).

Redux-Saga type definition is included here with the augmentation to create the saga monitor.