### PR TITLE
Handling of gzipped/bytearray content in API Responses

### DIFF
--- a/packages/reactotron-react-native/package.json
+++ b/packages/reactotron-react-native/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "mitt": "^1.1.2",
+    "pako": "1",
     "prop-types": "^15.5.10",
     "reactotron-core-client": "^2.0.0"
   }

--- a/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
+++ b/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
@@ -4,7 +4,7 @@ const pako = require("pako")
 
 export default {
   byteArrayToStr: (byteArray, method = "auto") => {
-    let actualMethod
+    let actualMethod = method
     if (method === "auto") {
       if (byteArray.length > 1) {
         // cf. http://www.zlib.org/rfc-gzip.html

--- a/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
+++ b/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
@@ -16,7 +16,7 @@ export default {
           actualMethod = "utf-8"
         }
       } else {
-        actualMethod = method
+        actualMethod = "utf-8"
       }
     }
     switch (actualMethod) {

--- a/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
+++ b/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
@@ -1,0 +1,30 @@
+import { decode as utf8Decode } from "./utf8-helpers"
+
+const pako = require("pako")
+
+export default {
+  byteArrayToStr: (byteArray, method = "auto") => {
+    let actualMethod
+    if (method === "auto") {
+      if (byteArray.length > 1) {
+        // cf. http://www.zlib.org/rfc-gzip.html
+        const [ID1, ID2] = byteArray
+        if (ID1 === 31 && ID2 === 139) {
+          actualMethod = "gzip"
+        } else {
+          actualMethod = "string"
+        }
+      } else {
+        actualMethod = method
+      }
+    }
+    switch (actualMethod) {
+      case "string":
+        return utf8Decode(byteArray)
+      case "gzip":
+        return pako.inflate(byteArray, { to: "string" })
+      default:
+        throw new Error(`Invalid byte array to string method: ${method}`)
+    }
+  },
+}

--- a/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
+++ b/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
@@ -8,8 +8,8 @@ export default {
     if (method === "auto") {
       if (byteArray.length > 1) {
         // cf. http://www.zlib.org/rfc-gzip.html
-        const ID1 = byteArray[0];
-        const ID2 = byteArray[1];
+        const ID1 = byteArray[0]
+        const ID2 = byteArray[1]
         if (ID1 === 31 && ID2 === 139) {
           actualMethod = "gzip"
         } else {

--- a/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
+++ b/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
@@ -13,14 +13,14 @@ export default {
         if (ID1 === 31 && ID2 === 139) {
           actualMethod = "gzip"
         } else {
-          actualMethod = "string"
+          actualMethod = "utf-8"
         }
       } else {
         actualMethod = method
       }
     }
     switch (actualMethod) {
-      case "string":
+      case "utf-8":
         return utf8Decode(byteArray)
       case "gzip":
         return pako.inflate(byteArray, { to: "string" })

--- a/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
+++ b/packages/reactotron-react-native/src/helpers/byteArray-helpers.js
@@ -8,7 +8,8 @@ export default {
     if (method === "auto") {
       if (byteArray.length > 1) {
         // cf. http://www.zlib.org/rfc-gzip.html
-        const [ID1, ID2] = byteArray
+        const ID1 = byteArray[0];
+        const ID2 = byteArray[1];
         if (ID1 === 31 && ID2 === 139) {
           actualMethod = "gzip"
         } else {

--- a/packages/reactotron-react-native/src/helpers/networking-helpers.js
+++ b/packages/reactotron-react-native/src/helpers/networking-helpers.js
@@ -1,0 +1,28 @@
+import helpers from "./byteArray-helpers"
+
+const responseToString = xhttp => {
+  try {
+    switch (xhttp.responseType) {
+      case "": // Defaults to text
+      case "text":
+        return xhttp.responseText
+      case "arraybuffer": {
+        const { response } = xhttp
+        const contentEncoding = xhttp.getResponseHeader("Content-Encoding")
+        if (contentEncoding === "gzip") {
+          const byteArray = new Uint8Array(response)
+          return helpers.byteArrayToStr(byteArray)
+        }
+        return response
+      }
+      default:
+        throw new Error("Could not convert response to string, unhandled response type")
+    }
+  } catch (e) {
+    throw new Error(`Could not convert response to string\n${e}`)
+  }
+}
+
+export default {
+  responseToString,
+}

--- a/packages/reactotron-react-native/src/helpers/networking-helpers.js
+++ b/packages/reactotron-react-native/src/helpers/networking-helpers.js
@@ -7,13 +7,8 @@ const responseToString = xhttp => {
       case "text":
         return xhttp.responseText
       case "arraybuffer": {
-        const { response } = xhttp
-        const contentEncoding = xhttp.getResponseHeader("Content-Encoding")
-        if (contentEncoding === "gzip") {
-          const byteArray = new Uint8Array(response)
-          return helpers.byteArrayToStr(byteArray)
-        }
-        return response
+        const byteArray = new Uint8Array(xhttp.response)
+        return byteArrayToStr(byteArray)
       }
       default:
         throw new Error("Could not convert response to string, unhandled response type")

--- a/packages/reactotron-react-native/src/helpers/networking-helpers.js
+++ b/packages/reactotron-react-native/src/helpers/networking-helpers.js
@@ -8,7 +8,7 @@ const responseToString = xhttp => {
         return xhttp.responseText
       case "arraybuffer": {
         const byteArray = new Uint8Array(xhttp.response)
-        return byteArrayToStr(byteArray)
+        return helpers.byteArrayToStr(byteArray)
       }
       default:
         throw new Error("Could not convert response to string, unhandled response type")

--- a/packages/reactotron-react-native/src/helpers/utf8-helpers.js
+++ b/packages/reactotron-react-native/src/helpers/utf8-helpers.js
@@ -1,0 +1,172 @@
+// Adapted from https://stackoverflow.com/questions/8936984
+
+const EOF_byte = -1
+const EOF_code_point = -1
+
+const encoderError = code_point => {
+  console.error("UTF8 encoderError", code_point)
+}
+
+const decoderError = (fatal, opt_code_point) => {
+  if (fatal) console.error("UTF8 decoderError", opt_code_point)
+  return opt_code_point || 0xfffd
+}
+
+const inRange = (a, min, max) => {
+  return min <= a && a <= max
+}
+
+const div = (n, d) => {
+  return Math.floor(n / d)
+}
+
+const stringToCodePoints = string => {
+  /** @type {Array.<number>} */
+  const cps = []
+  // Based on http://www.w3.org/TR/WebIDL/#idl-DOMString
+  let i = 0
+  const n = string.length
+  while (i < string.length) {
+    const c = string.charCodeAt(i)
+    if (!inRange(c, 0xd800, 0xdfff)) {
+      cps.push(c)
+    } else if (inRange(c, 0xdc00, 0xdfff)) {
+      cps.push(0xfffd)
+    } else if (i === n - 1) {
+      // (inRange(c, 0xD800, 0xDBFF))
+      cps.push(0xfffd)
+    } else {
+      const d = string.charCodeAt(i + 1)
+      if (inRange(d, 0xdc00, 0xdfff)) {
+        const a = c & 0x3ff
+        const b = d & 0x3ff
+        i += 1
+        cps.push(0x10000 + (a << 10) + b)
+      } else {
+        cps.push(0xfffd)
+      }
+    }
+    i += 1
+  }
+  return cps
+}
+
+export function encode(str) {
+  let pos = 0
+  const codePoints = stringToCodePoints(str)
+  const outputBytes = []
+
+  while (codePoints.length > pos) {
+    const code_point = codePoints[pos++]
+
+    if (inRange(code_point, 0xd800, 0xdfff)) {
+      encoderError(code_point)
+    } else if (inRange(code_point, 0x0000, 0x007f)) {
+      outputBytes.push(code_point)
+    } else {
+      let count = 0
+      let offset = 0
+      if (inRange(code_point, 0x0080, 0x07ff)) {
+        count = 1
+        offset = 0xc0
+      } else if (inRange(code_point, 0x0800, 0xffff)) {
+        count = 2
+        offset = 0xe0
+      } else if (inRange(code_point, 0x10000, 0x10ffff)) {
+        count = 3
+        offset = 0xf0
+      }
+
+      outputBytes.push(div(code_point, 64 ** count) + offset)
+
+      while (count > 0) {
+        const temp = div(code_point, 64 ** (count - 1))
+        outputBytes.push(0x80 + (temp % 64))
+        count -= 1
+      }
+    }
+  }
+  return new Uint8Array(outputBytes)
+}
+
+export function decode(data) {
+  const fatal = false
+  let pos = 0
+  let result = ""
+  let code_point
+  let utf8_code_point = 0
+  let utf8_bytes_needed = 0
+  let utf8_bytes_seen = 0
+  let utf8_lower_boundary = 0
+
+  while (data.length > pos) {
+    const byte = data[pos++]
+
+    if (byte === this.EOF_byte) {
+      if (utf8_bytes_needed !== 0) {
+        code_point = decoderError(fatal)
+      } else {
+        code_point = EOF_code_point
+      }
+    } else if (utf8_bytes_needed === 0) {
+      if (inRange(byte, 0x00, 0x7f)) {
+        code_point = byte
+      } else {
+        if (inRange(byte, 0xc2, 0xdf)) {
+          utf8_bytes_needed = 1
+          utf8_lower_boundary = 0x80
+          utf8_code_point = byte - 0xc0
+        } else if (inRange(byte, 0xe0, 0xef)) {
+          utf8_bytes_needed = 2
+          utf8_lower_boundary = 0x800
+          utf8_code_point = byte - 0xe0
+        } else if (inRange(byte, 0xf0, 0xf4)) {
+          utf8_bytes_needed = 3
+          utf8_lower_boundary = 0x10000
+          utf8_code_point = byte - 0xf0
+        } else {
+          decoderError(fatal)
+        }
+        utf8_code_point *= 64 ** utf8_bytes_needed
+        code_point = null
+      }
+    } else if (!inRange(byte, 0x80, 0xbf)) {
+      utf8_code_point = 0
+      utf8_bytes_needed = 0
+      utf8_bytes_seen = 0
+      utf8_lower_boundary = 0
+      pos--
+      code_point = decoderError(fatal, byte)
+    } else {
+      utf8_bytes_seen += 1
+      utf8_code_point += (byte - 0x80) * 64 ** (utf8_bytes_needed - utf8_bytes_seen)
+
+      if (utf8_bytes_seen !== utf8_bytes_needed) {
+        code_point = null
+      } else {
+        const cp = utf8_code_point
+        const lower_boundary = utf8_lower_boundary
+        utf8_code_point = 0
+        utf8_bytes_needed = 0
+        utf8_bytes_seen = 0
+        utf8_lower_boundary = 0
+        if (inRange(cp, lower_boundary, 0x10ffff) && !inRange(cp, 0xd800, 0xdfff)) {
+          code_point = cp
+        } else {
+          code_point = decoderError(fatal, byte)
+        }
+      }
+    }
+    // Decode string
+    if (code_point !== null && code_point !== EOF_code_point) {
+      if (code_point <= 0xffff) {
+        if (code_point > 0) result += String.fromCharCode(code_point)
+      } else {
+        code_point -= 0x10000
+        result += String.fromCharCode(0xd800 + ((code_point >> 10) & 0x3ff))
+        result += String.fromCharCode(0xdc00 + (code_point & 0x3ff))
+      }
+    }
+  }
+  return result
+}

--- a/packages/reactotron-react-native/src/plugins/networking.js
+++ b/packages/reactotron-react-native/src/plugins/networking.js
@@ -1,5 +1,7 @@
 import XHRInterceptor from 'react-native/Libraries/Network/XHRInterceptor'
 
+import helpers from "../helpers/networking-helpers"
+
 /**
  * Don't include the response bodies for images by default.
  */
@@ -117,6 +119,13 @@ export default (pluginConfig = {}) => reactotron => {
         }
         bReader.addEventListener('loadend', brListener)
         bReader.readAsText(response)
+      } else if (/^application\/json(;|$)/.test(contentType)) {
+        try {
+          const str = helpers.responseToString(xhr)
+          sendResponse(str || response)
+        } catch (e) {
+          sendResponse(response)
+        }
       } else {
         sendResponse(response)
       }

--- a/packages/reactotron-react-native/src/plugins/networking.js
+++ b/packages/reactotron-react-native/src/plugins/networking.js
@@ -119,15 +119,13 @@ export default (pluginConfig = {}) => reactotron => {
         }
         bReader.addEventListener('loadend', brListener)
         bReader.readAsText(response)
-      } else if (/^application\/json(;|$)/.test(contentType)) {
+      } else {
         try {
           const str = helpers.responseToString(xhr)
-          sendResponse(str || response)
+          sendResponse(str)
         } catch (e) {
           sendResponse(response)
         }
-      } else {
-        sendResponse(response)
       }
     } else {
       sendResponse('')

--- a/packages/reactotron-react-native/src/plugins/networking.js
+++ b/packages/reactotron-react-native/src/plugins/networking.js
@@ -89,7 +89,11 @@ export default (pluginConfig = {}) => reactotron => {
           // all i am saying, is give JSON a chance...
           body = JSON.parse(responseBodyText)
         } catch (boom) {
-          body = response
+          if (typeof responseBodyText === "string") {
+            body = responseBodyText
+          } else {
+            body = response
+          }
         }
       }
       const tronResponse = {


### PR DESCRIPTION
Hi Reactotron!

React Native on Android does not automatically uncompress gzipped API responses. This forces you to use `bytearray` as a `responseType`.

```
if (compress) {
    headers.push(['Accept-Encoding', 'gzip']);
    xhttp.responseType = 'arraybuffer';
} else {
    headers.push(['Accept-Encoding', 'identity']);
    xhttp.responseType = ''; // Defaults to text
}
```

<img width="537" alt="image" src="https://user-images.githubusercontent.com/7315069/43643536-e2437c42-972b-11e8-9094-857fbb393a64.png">

This scenario is not currently supported by Reactotron (Response shows "skipped" instead).

This PR fixes that.

Before
<img width="447" alt="image" src="https://user-images.githubusercontent.com/7315069/43643397-728b22b0-972b-11e8-9b44-7c40b4c00324.png">

After:
<img width="445" alt="image" src="https://user-images.githubusercontent.com/7315069/43643362-5a3ff488-972b-11e8-9aa3-8873845cc055.png">