### PR TITLE
Adding a config file + a bit of cleanup

### DIFF
--- a/packages/reactotron-server/package.json
+++ b/packages/reactotron-server/package.json
@@ -39,7 +39,8 @@
     "graphql-type-json": "^0.2.1",
     "reactotron-core-server": "^2.1.0",
     "reflect-metadata": "^0.1.12",
-    "type-graphql": "^0.13.1"
+    "type-graphql": "^0.13.1",
+    "yargs-parser": "^10.1.0"
   },
   "ava": {
     "files": [

--- a/packages/reactotron-server/src/server/apollo/index.ts
+++ b/packages/reactotron-server/src/server/apollo/index.ts
@@ -4,19 +4,15 @@ import { buildSchema } from "type-graphql"
 import { messaging } from "../messaging"
 import { resolvers } from "./resolvers"
 
-let apolloServer: ApolloServer
-
 export async function createApolloServer() {
-  if (!apolloServer) {
-    const schema = await buildSchema({
-      resolvers,
-      pubSub: messaging,
-    })
+  const schema = await buildSchema({
+    resolvers,
+    pubSub: messaging,
+  })
 
-    apolloServer = new ApolloServer({
-      schema,
-    })
-  }
+  const apolloServer = new ApolloServer({
+    schema,
+  })
 
   return apolloServer
 }

--- a/packages/reactotron-server/src/server/apollo/resolvers/commands.ts
+++ b/packages/reactotron-server/src/server/apollo/resolvers/commands.ts
@@ -2,7 +2,7 @@ import { Resolver, Query, Subscription, Root, Args, Arg } from "type-graphql"
 
 import { MessageTypes } from "../../messaging"
 import { Command } from "../../schema"
-import { commands } from "../../datastore"
+import { commandsStore } from "../../datastore"
 import { CommandAddedArgs } from "../../schema/command"
 
 @Resolver()
@@ -10,10 +10,10 @@ export class CommandsResolver {
   @Query(() => [Command])
   commands(@Arg("clientId", { nullable: true }) clientId?: string) {
     if (clientId) {
-      return commands.byClientId(clientId)
+      return commandsStore.byClientId(clientId)
     }
 
-    return commands.all()
+    return commandsStore.all()
   }
 
   @Subscription(() => Command, {

--- a/packages/reactotron-server/src/server/apollo/resolvers/connections.ts
+++ b/packages/reactotron-server/src/server/apollo/resolvers/connections.ts
@@ -2,19 +2,19 @@ import { Resolver, Query, Subscription } from "type-graphql"
 
 import { MessageTypes } from "../../messaging"
 import { Connection } from "../../schema"
-import { connections } from "../../datastore"
+import { connectionsStore } from "../../datastore"
 
 @Resolver()
 export class ConnectionsResolver {
   @Query(() => [Connection])
   connections() {
-    return connections.all()
+    return connectionsStore.all()
   }
 
   @Subscription(() => [Connection], {
     topics: [MessageTypes.CONNECTION_ESTABLISHED, MessageTypes.CONNECTION_DISCONNECTED],
   })
   connectionsUpdated(): Connection[] {
-    return connections.all()
+    return connectionsStore.all()
   }
 }

--- a/packages/reactotron-server/src/server/apollo/resolvers/executedCommands.ts
+++ b/packages/reactotron-server/src/server/apollo/resolvers/executedCommands.ts
@@ -3,14 +3,14 @@ import * as GraphQLJSON from "graphql-type-json"
 
 import { messaging, MessageTypes } from "../../messaging"
 import { ExecutedCommand } from "../../schema"
-import { executedCommands } from "../../datastore"
-import { createReactotronServer } from "../../reactotron"
+import { executedCommandsStore } from "../../datastore"
+import { reactotron } from "../../reactotron"
 
 @Resolver()
 export class ExecutedCommandsResolver {
   @Query(() => [ExecutedCommand])
   executedCommands() {
-    return executedCommands.all()
+    return executedCommandsStore.all()
   }
 
   @Mutation()
@@ -24,15 +24,10 @@ export class ExecutedCommandsResolver {
       payload,
     }
 
-    executedCommands.addCommand(newCommand)
+    executedCommandsStore.addCommand(newCommand)
     messaging.publish(MessageTypes.EXECUTED_COMMAND_ADDED, newCommand)
 
-    // Welcome to the hack zone. Where everything is permitted as long as it works.
-    // TODO: Better name? Put this into a singleton that we can import and use instead of this function? Better everything? something? ANYTHING?
-    const reactotronServer = createReactotronServer()
-
-    reactotronServer.send(type, payload)
-    // Now leaving the hack zone.
+    reactotron.send(type, payload)
 
     return true
   }

--- a/packages/reactotron-server/src/server/config.ts
+++ b/packages/reactotron-server/src/server/config.ts
@@ -1,0 +1,28 @@
+import * as fs from "fs"
+
+export function getConfig(configPath: string) {
+  const configPathTrimmed = configPath.trim()
+
+  let config = {
+    webPort: 4000,
+    reactotronPort: 9091,
+  }
+
+  if (fs.existsSync(configPathTrimmed)) {
+    try {
+      const configContents = fs.readFileSync(configPathTrimmed, "utf8")
+      const userConfig = JSON.parse(configContents)
+
+      if (userConfig) {
+        config = {
+          ...config,
+          ...userConfig,
+        }
+      }
+    } catch {
+      console.error(`Failed trying to read the config file at ${configPathTrimmed}`)
+    }
+  }
+
+  return config
+}

--- a/packages/reactotron-server/src/server/datastore/index.ts
+++ b/packages/reactotron-server/src/server/datastore/index.ts
@@ -2,8 +2,8 @@ import { Connections } from "./connections"
 import { Commands } from "./commands"
 import { ExecutedCommands } from "./executedCommands"
 
-const connections = new Connections()
-const commands = new Commands()
-const executedCommands = new ExecutedCommands()
+const connectionsStore = new Connections()
+const commandsStore = new Commands()
+const executedCommandsStore = new ExecutedCommands()
 
-export { connections, commands, executedCommands }
+export { connectionsStore, commandsStore, executedCommandsStore }

--- a/packages/reactotron-server/src/server/index.ts
+++ b/packages/reactotron-server/src/server/index.ts
@@ -1,13 +1,25 @@
 import "reflect-metadata"
+import * as argsParser from "yargs-parser"
 import * as path from "path"
 import * as express from "express"
 import { createServer } from "http"
 
+import { getConfig } from "./config"
 import { createApolloServer } from "./apollo"
-import { createReactotronServer } from "./reactotron"
+import { reactotron } from "./reactotron"
+
+const argv = argsParser(process.argv.slice(2), {
+  alias: {
+    config: ['c']
+  }
+})
+
+const config = getConfig(argv.config)
+
+console.log(config)
 
 async function bootUp() {
-  createReactotronServer()
+  reactotron.start(config.reactotronPort)
   const apolloServer = await createApolloServer()
   const app = express()
   const httpServer = createServer(app)
@@ -19,8 +31,8 @@ async function bootUp() {
     res.sendFile(path.join(__dirname, "..", "index.html"))
   })
 
-  httpServer.listen({ port: 4000 }, () => {
-    console.log(`Server ready at http://localhost:4000`)
+  httpServer.listen({ port: config.webPort }, () => {
+    console.log(`Server ready at http://localhost:${config.webPort}. Reactotron started on port ${config.reactotronPort}`)
   })
 }
 

--- a/packages/reactotron-server/src/server/reactotron/commandHandler.ts
+++ b/packages/reactotron-server/src/server/reactotron/commandHandler.ts
@@ -1,4 +1,4 @@
-import { commands } from "../datastore"
+import { commandsStore } from "../datastore"
 import { messaging, MessageTypes } from "../messaging"
 import { Command } from "../schema"
 
@@ -11,7 +11,7 @@ import { Command } from "../schema"
  * @param command A command sent from the client.
  */
 export function onCommand(command: Command) {
-  commands.addCommand(command)
+  commandsStore.addCommand(command)
 
   messaging.publish(MessageTypes.COMMAND_ADDED, command)
 }

--- a/packages/reactotron-server/src/server/reactotron/connectionHandler.ts
+++ b/packages/reactotron-server/src/server/reactotron/connectionHandler.ts
@@ -1,4 +1,4 @@
-import { connections } from "../datastore"
+import { connectionsStore } from "../datastore"
 import { messaging, MessageTypes } from "../messaging"
 import { Connection } from "../schema"
 
@@ -33,12 +33,12 @@ function onConnectionEstablished(connection: any) {
     address: connection.address,
     id: connection.id,
   }
-  connections.addConnection(newConnection)
+  connectionsStore.addConnection(newConnection)
   messaging.publish(MessageTypes.CONNECTION_ESTABLISHED, null)
 }
 
 function onConnectionDisconnected(connection) {
-  connections.removeConnection(connection)
+  connectionsStore.removeConnection(connection)
   messaging.publish(MessageTypes.CONNECTION_DISCONNECTED, null)
 }
 

--- a/packages/reactotron-server/src/server/reactotron/index.ts
+++ b/packages/reactotron-server/src/server/reactotron/index.ts
@@ -3,17 +3,23 @@ import Server, { createServer } from "reactotron-core-server"
 import { addEventHandlers as addConnectionEventHandlers } from './connectionHandler'
 import { addEventHandlers as addCommandEventHandlers } from './commandHandler'
 
-let reactotronServer: Server
+class ReactotronServer {
+  server: Server
 
-export function createReactotronServer(port = 9090) {
-  if (!reactotronServer) {
-    reactotronServer = createServer({ port })
+  start(port = 9090) {
+    this.server = createServer({ port })
 
-    addConnectionEventHandlers(reactotronServer)
-    addCommandEventHandlers(reactotronServer)
+    addConnectionEventHandlers(this.server)
+    addCommandEventHandlers(this.server)
 
-    reactotronServer.start()
+    this.server.start()
   }
 
-  return reactotronServer
+  send(type, payload) {
+    this.server.send(type, payload)
+  }
 }
+
+const reactotron = new ReactotronServer()
+
+export { reactotron }

--- a/packages/reactotron-server/yarn.lock
+++ b/packages/reactotron-server/yarn.lock
@@ -979,7 +979,7 @@ camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
-camelcase@^4.0.0:
+camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
@@ -3761,6 +3761,12 @@ yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
+yargs-parser@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  dependencies:
+    camelcase "^4.1.0"
 
 yn@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This covers a few things.

- Adds ability to pass a path to a config file via a command line argument. The config file can change the web and reactotron port. NOTE: I think in the long run we should try and do config file detection AND let the user provide a specific one. Not sure what the detection would look like yet though
- Rename data stores to contain the word `Store` at the end. Trying to reduce confusion
- Setup reactotron to be a wrapper for now. I suspect I will be adding more methods to it that are helpers so leaving the ability to do that in place. Also changed how the singleton setup works
- Apollo server is no longer a singleton but rather a creator function