### PR TITLE
Refactor bootstrap and add tests

### DIFF
--- a/packages/reactotron-server/package.json
+++ b/packages/reactotron-server/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "compile": "tsc",
     "clean": "rimraf dist build",
+    "copy-index": "node scripts/cp-index.js",
     "lint": "tslint -p .",
-    "build:server": "yarn clean && tsc --p tsconfig.server.json",
+    "build:server": "yarn clean && tsc --p tsconfig.server.json && yarn copy-index",
     "start:server": "yarn build:server && node dist/server/index.js",
     "test": "npm-run-all test:compile && yarn ava",
     "test:watch": "npm-run-all test:compile && yarn ava --watch",
-    "test:compile": "tsc -p tsconfig.test.json --pretty",
-    "test:compile:watch": "tsc -p tsconfig.test.json --pretty --watch"
+    "test:compile": "tsc -p tsconfig.test.json --pretty && yarn copy-index",
+    "test:compile:watch": "tsc -p tsconfig.test.json --pretty --watch && yarn copy-index"
   },
   "keywords": [],
   "author": "Steve Kellock and Richard Evans",

--- a/packages/reactotron-server/scripts/cp-index.js
+++ b/packages/reactotron-server/scripts/cp-index.js
@@ -1,0 +1,38 @@
+// Temp script to copy index.html to the required directory
+// This is just short term until we use webpack or similar.
+
+const fs = require('fs');
+
+const copyIndex = dir => {
+  if (fs.existsSync(`${dir}`)) {
+    console.log(`${dir} EXISTS - COPYING INDEX`)
+
+    if (fs.existsSync(`${dir}/index.html`)) {
+      console.log('PREVIOUS VERSION FOUND, REMOVING');
+
+      fs.unlinkSync(`${dir}/index.html`);
+
+      if (fs.existsSync(`${dir}/index.html`)) {
+        console.log(`FILE COULD NOT BE DELETED ${dir}`);
+        return false;
+      }
+    }
+
+    fs.copyFileSync('src/index.html', `${dir}/index.html`);
+
+    if (fs.existsSync(`${dir}/index.html`)) {
+      console.log(`FILE COPIED TO ${dir} SUCESSFULLY`);
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+const dirsToCopyTo = [
+  'build',
+  'dist',
+];
+
+dirsToCopyTo.map(dir => copyIndex(dir));

--- a/packages/reactotron-server/src/server/index.test.ts
+++ b/packages/reactotron-server/src/server/index.test.ts
@@ -2,7 +2,7 @@ import test from "ava"
 import * as request from "request-promise-native"
 import { httpServerInstance, apolloServerInstance } from './'
 
-// Tests in here are ran in serial due to the webserver binding to port 4000 (concurrency results in EADDRINUSE)
+// Tests in here are ran in serial due to the webserver binding to port 4000 (concurrency results in EADDRINUSE error)
 
 let app, httpServer;
 
@@ -20,16 +20,17 @@ test.serial("Can create a http server to serve react app", async t => {
 
   t.true(httpServer !== null && typeof httpServer === "object")
 
-  const httpString = await request("http://localhost:4000").catch(err => {
+  const responseString = await request("http://localhost:4000").catch(err => {
     t.is(err, null, "request to http server has errored")
   })
 
-  
+  t.true(responseString.includes("the new home of reactotron"))
 }) 
 
-test.serial("Can create an apollo server to interact with react app", t => {
+test.serial("Can create an apollo server to interact with react app", async t => {
   
-  const apolloServer = apolloServerInstance(app, httpServer)
+  const apolloServer = await apolloServerInstance(app, httpServer)
 
   t.true(apolloServer !== null && typeof apolloServer === "object")
+  t.true(apolloServer.graphqlPath === '/graphql')
 }) 

--- a/packages/reactotron-server/src/server/index.ts
+++ b/packages/reactotron-server/src/server/index.ts
@@ -51,7 +51,7 @@ export const bootUp = async () => {
 
   const { app, httpServer } = await httpServerInstance()
   
-  // Ignore compile issue as we will be using this later
+  // Ignore compile issue of unusued var as we will be using this later
   // @ts-ignore
   const apolloServer = await apolloServerInstance(app, httpServer)
 }

--- a/packages/reactotron-server/tsconfig.test.json
+++ b/packages/reactotron-server/tsconfig.test.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSourceMap": true,
-    "outDir": "build",
+    "outDir": "build/server",
     "noUnusedLocals": false,
   },
   "include": ["src", "test"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,7 +351,7 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0:
+ajv@^5.1.0, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -798,6 +798,10 @@ aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+
 babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -1164,7 +1168,7 @@ binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
-bluebird@^3.0.0:
+bluebird@^3.0.0, bluebird@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -1586,7 +1590,7 @@ columnify@^1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
-combined-stream@1.0.6, combined-stream@~1.0.5:
+combined-stream@1.0.6, combined-stream@~1.0.5, combined-stream@~1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
@@ -2633,6 +2637,10 @@ extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
 external-editor@^2.0.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
@@ -2812,7 +2820,7 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@~2.3.1:
+form-data@~2.3.1, form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
@@ -3123,6 +3131,13 @@ har-validator@~5.0.3:
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
   dependencies:
     ajv "^5.1.0"
+    har-schema "^2.0.0"
+
+har-validator@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
+  dependencies:
+    ajv "^5.3.0"
     har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
@@ -4394,7 +4409,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -4618,7 +4633,7 @@ mime-types@^2.1.12, mime-types@~2.1.17:
   dependencies:
     mime-db "~1.35.0"
 
-mime-types@~2.1.18:
+mime-types@~2.1.18, mime-types@~2.1.19:
   version "2.1.20"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
   dependencies:
@@ -4895,6 +4910,10 @@ number-is-nan@^1.0.0:
 oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
 object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
@@ -5377,7 +5396,7 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@6.5.2, qs@~6.5.1:
+qs@6.5.2, qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -5636,6 +5655,29 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
+
+request-promise@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.2.tgz#d1ea46d654a6ee4f8ee6a4fea1018c22911904b4"
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
+
 request@^2.79.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
@@ -5660,6 +5702,31 @@ request@^2.79.0:
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
+
+request@^2.88.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -6151,6 +6218,10 @@ statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
 stream-combiner@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
@@ -6490,7 +6561,7 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-tough-cookie@^2.3.2:
+tough-cookie@>=2.3.3, tough-cookie@^2.3.2, tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
   dependencies:
@@ -6724,7 +6795,7 @@ uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 


### PR DESCRIPTION
This PR ensures that the `reactotron-server` comes online and serves our index.html file.

I have done this mostly so I can get up to speed with whats going on in the project, but basically this PR:

- Refactors the index.js bootstrap process so that is unit-testable - separating out logic and only calling the "bootUp" method if the app isn't being executed in a test environment.
- Adds tests for the index.js file, to verify that an express server is booted correctly, and when accessed it serves out our dummy index.html file. This test checks to make sure some content is as we expect it.
- Creates a temporary script to copy index.html from the `src` directory to build / dist (as defined in the script). This is because TypeScript only compiles JS stuff, and we dont have webpack (or whichever bundle tool we intend to use) and I wanted to get the system working with tests passing.
- Adds a flag to the test config so that we dont get errors on unusedlocals. I agree that for actual production code this is useful, but for testing its annoying, especially when you're doing TDD. 

Hope this is useful / relevant.