### PR TITLE
Expose GraphQL with tests

### DIFF
--- a/packages/reactotron-server/package.json
+++ b/packages/reactotron-server/package.json
@@ -12,8 +12,8 @@
     "start:server": "yarn build:server && node dist/server/index.js",
     "test": "npm-run-all test:compile && yarn ava",
     "test:watch": "npm-run-all test:compile && yarn ava --watch",
-    "test:compile": "tsc -p tsconfig.test.json --pretty && yarn copy-index",
-    "test:compile:watch": "tsc -p tsconfig.test.json --pretty --watch && yarn copy-index"
+    "test:compile": "tsc -p tsconfig.test.json --pretty --skipLibCheck && yarn copy-index",
+    "test:compile:watch": "tsc -p tsconfig.test.json --pretty --watch --skipLibCheck && yarn copy-index"
   },
   "keywords": [],
   "author": "Steve Kellock and Richard Evans",
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@types/express": "^4.16.0",
     "ava": "^0.25.0",
+    "graphql-request": "^1.8.2",
     "npm-run-all": "^4.1.3",
     "prettier": "^1.14.2",
     "request": "^2.88.0",

--- a/packages/reactotron-server/src/server/index.test.ts
+++ b/packages/reactotron-server/src/server/index.test.ts
@@ -1,36 +1,39 @@
 import test from "ava"
 import * as request from "request-promise-native"
-import { httpServerInstance, apolloServerInstance } from './'
+import { httpServerInstance, apolloServerInstance, startServersListening } from "./"
 
 // Tests in here are ran in serial due to the webserver binding to port 4000 (concurrency results in EADDRINUSE error)
 
-let app, httpServer;
+let appServer, apolloServer;
 
 test.serial("Can create a http server to serve react app", async t => {
-
-  let appServer;
 
   t.notThrows(() => {
     appServer = httpServerInstance()
   })
 
   // Not sure if there is a way to nicely destructure here, this does for now
-  app = appServer.app;
-  httpServer = appServer.httpServer;
+  let httpServer = appServer.httpServer;
 
-  t.true(httpServer !== null && typeof httpServer === "object")
+  t.true(httpServer !== null && typeof httpServer === "object")  
+}) 
+
+test.serial("Can create an apollo server to interact with react app", async t => {
+  
+  const { app, httpServer } = appServer
+  apolloServer = await apolloServerInstance(app, httpServer)
+
+  t.true(apolloServer !== null && typeof apolloServer === "object")
+  t.true(apolloServer.graphqlPath === '/graphql')
+}) 
+
+test.serial("Does serve react app and apollo pubsub", async t => {
+
+  startServersListening(appServer, apolloServer)
 
   const responseString = await request("http://localhost:4000").catch(err => {
     t.is(err, null, "request to http server has errored")
   })
 
   t.true(responseString.includes("the new home of reactotron"))
-}) 
-
-test.serial("Can create an apollo server to interact with react app", async t => {
-  
-  const apolloServer = await apolloServerInstance(app, httpServer)
-
-  t.true(apolloServer !== null && typeof apolloServer === "object")
-  t.true(apolloServer.graphqlPath === '/graphql')
-}) 
+})

--- a/packages/reactotron-server/src/server/index.test.ts
+++ b/packages/reactotron-server/src/server/index.test.ts
@@ -1,8 +1,11 @@
 import test from "ava"
 import * as request from "request-promise-native"
+import { GraphQLClient } from "graphql-request"
 import { httpServerInstance, apolloServerInstance, startServersListening } from "./"
 
 // Tests in here are ran in serial due to the webserver binding to port 4000 (concurrency results in EADDRINUSE error)
+// I really want to find a way to refactor out the serials in here. Perhaps after calling "startServersListening" we dont need them any more?
+// Im new to ava so not sure what the best solution is here
 
 let appServer, apolloServer;
 
@@ -37,3 +40,25 @@ test.serial("Does serve react app and apollo pubsub", async t => {
 
   t.true(responseString.includes("the new home of reactotron"))
 })
+
+test.serial("Does return reactotron current connection details", async t => {
+
+  // @ts-nocheck
+  const client = new GraphQLClient('http://localhost:4000/graphql')
+
+  const query = `{
+    connections {
+      platform
+      name
+    }
+  }`
+
+  const data = await client.request(query).catch(err => console.log(err))
+
+  console.log(data);
+
+  t.deepEqual({
+    connections: []
+  }, data)
+
+});

--- a/packages/reactotron-server/src/server/index.ts
+++ b/packages/reactotron-server/src/server/index.ts
@@ -53,6 +53,7 @@ export const startServersListening = async ({ httpServer }, apolloServer = null,
 
     if (apolloServer) {
       console.log(`🚀 Subscriptions ready at ws://localhost:${config.webPort}${apolloServer.subscriptionsPath}`)
+      console.log(`GQL query browser ready at http://localhost:${config.webPort}/graphql`)
     }
   })
 }

--- a/packages/reactotron-server/src/server/index.ts
+++ b/packages/reactotron-server/src/server/index.ts
@@ -35,25 +35,34 @@ export const httpServerInstance = () => {
     res.sendFile(path.join(__dirname, "..", "index.html"))
   })
 
-  httpServer.listen({ port: config.webPort }, () => {
-    console.log(
-      `Server ready at http://localhost:${config.webPort}. Reactotron started on port ${
-        config.reactotronPort
-      }`,
-    )
-  })
-
   return { app, httpServer }
 }
 
-export const bootUp = async () => {
-  reactotron.start(config.reactotronPort)
-
-  const { app, httpServer } = await httpServerInstance()
+export const startServersListening = async ({ httpServer }, apolloServer = null, reactotronServer = null) => {
   
-  // Ignore compile issue of unusued var as we will be using this later
-  // @ts-ignore
+  // If we have been given a reactotron server instance, start listening
+  if (reactotronServer) {
+    reactotronServer.start(config.reactotronPort)
+  }
+
+  // @TODO Id expect some way to actually "start" apollo server listening in here, but new to this...
+
+  // Start express server listening
+  httpServer.listen({ port: config.webPort }, () => {
+    console.log(`Server ready at http://localhost:${config.webPort}. Reactotron started on port ${config.reactotronPort}`)
+
+    if (apolloServer) {
+      console.log(`🚀 Subscriptions ready at ws://localhost:${config.webPort}${apolloServer.subscriptionsPath}`)
+    }
+  })
+}
+
+export const bootUp = async () => {
+  const appServer = await httpServerInstance()
+  const { app, httpServer } = appServer
   const apolloServer = await apolloServerInstance(app, httpServer)
+
+  return startServersListening(appServer, apolloServer, reactotron);
 }
 
 // Only actually boot the server if we are not running tests

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,6 +1914,13 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+cross-fetch@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
+  dependencies:
+    node-fetch "2.1.2"
+    whatwg-fetch "2.0.4"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3077,6 +3084,12 @@ graphql-extensions@0.1.2:
   resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.1.2.tgz#d289cbddcf52364c066d8241a78d359c93c79c30"
   dependencies:
     apollo-server-env "2.0.2"
+
+graphql-request@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
+  dependencies:
+    cross-fetch "2.2.2"
 
 graphql-subscriptions@^0.5.8:
   version "0.5.8"
@@ -4786,6 +4799,10 @@ next-tick@1:
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+
+node-fetch@2.1.2:
+  version "2.1.2"
+  resolved "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
 node-fetch@^2.1.2:
   version "2.2.0"
@@ -6858,6 +6875,10 @@ whatwg-encoding@^1.0.1:
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"
   dependencies:
     iconv-lite "0.4.19"
+
+whatwg-fetch@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
 whatwg-url@^4.3.0:
   version "4.8.0"


### PR DESCRIPTION
These changes extend what was done previously to allow us to query the graphql client with tests via `request`.

One thing I've had to do is set the `skipLibCheck` flag in TypeScript, as there appears to be some issues with TypeScript trying to type check node_modules. Not sure what the norm here is (being new to TS) but without this I was getting compile errors.

