### PR TITLE
✨ explores various apollo loading strategies

### DIFF
--- a/packages/reactotron-server/package.json
+++ b/packages/reactotron-server/package.json
@@ -48,6 +48,7 @@
     "apollo-link": "^1.2.2",
     "apollo-link-error": "^1.1.0",
     "apollo-link-http": "^1.5.4",
+    "apollo-link-ws": "^1.0.8",
     "apollo-server-express": "^2.0.4",
     "express": "^4.16.3",
     "graphql": "^14.0.2",
@@ -58,6 +59,7 @@
     "react-dom": "^16.5.0",
     "reactotron-core-server": "^2.1.0",
     "reflect-metadata": "^0.1.12",
+    "subscriptions-transport-ws": "^0.9.14",
     "type-graphql": "^0.13.1",
     "yargs-parser": "^10.1.0"
   },

--- a/packages/reactotron-server/src/app/main.tsx
+++ b/packages/reactotron-server/src/app/main.tsx
@@ -1,29 +1,50 @@
 import React from "react"
 import ReactDOM from "react-dom"
-import { SampleApollo } from "./sample-apollo"
+import { SampleLoadOnly, SampleSubscribeOnly, SampleLoadAndSubscribe } from "./sample-apollo"
 import { ApolloClient } from "apollo-client"
 import { InMemoryCache } from "apollo-cache-inmemory"
 import { HttpLink } from "apollo-link-http"
 import { onError } from "apollo-link-error"
-import { ApolloLink } from "apollo-link"
+import { ApolloLink, split } from "apollo-link"
 import { ApolloProvider } from "react-apollo"
+import { WebSocketLink } from "apollo-link-ws"
+import { getMainDefinition } from "apollo-utilities"
+
+const SERVER = "localhost:4000"
+
+const httpLink = ApolloLink.from([
+  onError(({ graphQLErrors, networkError }) => {
+    if (graphQLErrors)
+      graphQLErrors.map(({ message, locations, path }) =>
+        console.log(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`),
+      )
+    if (networkError) console.log(`[Network error]: ${networkError}`)
+  }),
+  new HttpLink({
+    uri: `http://${SERVER}/graphql`,
+    credentials: "same-origin",
+  }),
+])
+
+const wsLink = new WebSocketLink({
+  uri: `ws://${SERVER}/graphql`,
+  options: {
+    reconnect: true,
+  },
+})
+
+const link = split(
+  // split based on operation type
+  ({ query }) => {
+    const def = getMainDefinition(query)
+    return def.kind === "OperationDefinition" && def.operation === "subscription"
+  },
+  wsLink,
+  httpLink,
+)
 
 const client = new ApolloClient({
-  link: ApolloLink.from([
-    onError(({ graphQLErrors, networkError }) => {
-      if (graphQLErrors)
-        graphQLErrors.map(({ message, locations, path }) =>
-          console.log(
-            `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
-          ),
-        )
-      if (networkError) console.log(`[Network error]: ${networkError}`)
-    }),
-    new HttpLink({
-      uri: "http://localhost:4000/graphql",
-      credentials: "same-origin",
-    }),
-  ]),
+  link,
   cache: new InMemoryCache(),
 })
 
@@ -33,7 +54,9 @@ class Main extends React.Component<Props> {
   render() {
     return (
       <ApolloProvider client={client}>
-        <SampleApollo />
+        <SampleLoadOnly />
+        <SampleSubscribeOnly />
+        <SampleLoadAndSubscribe />
       </ApolloProvider>
     )
   }

--- a/packages/reactotron-server/src/app/sample-apollo.tsx
+++ b/packages/reactotron-server/src/app/sample-apollo.tsx
@@ -1,50 +1,154 @@
+// We're going to nuke this file... i'm just exploring apollo
+
 import React from "react"
-import { Query } from "react-apollo"
+import { Query, Subscription } from "react-apollo"
 import gql from "graphql-tag"
 
-export const SampleApollo = () => (
-  <Query
-    query={gql`
-      {
-        connections {
-          platform
-          reactotronLibraryName
-          name
-          systemName
-          platformVersion
-          screenWidth
-          screenHeight
-          screenScale
-          reactNativeVersion
-          id
-        }
-      }
-    `}
-  >
-    {({ loading, error, data }) => {
-      if (loading) return <p>Loading...</p>
-      if (error) return <p>Error :(</p>
+const CONNECTIONS_QUERY = gql`
+  {
+    connections {
+      platform
+      reactotronLibraryName
+      name
+      systemName
+      platformVersion
+      screenWidth
+      screenHeight
+      screenScale
+      reactNativeVersion
+      id
+    }
+  }
+`
 
-      return data.connections.map(data => (
-        <div key={data.id}>
-          <dl>
-            <dt>id</dt>
-            <dd>{data.id}</dd>
-            <dt>Platform</dt>
-            <dd>{data.platform}</dd>
-            <dt>reactotronLibraryName</dt>
-            <dd>{data.reactotronLibraryName}</dd>
-            <dt>screenWidth</dt>
-            <dd>{data.screenWidth}</dd>
-            <dt>screenHeight</dt>
-            <dd>{data.screenHeight}</dd>
-            <dt>screenScale</dt>
-            <dd>{data.screenScale}</dd>
-            <dt>reactNativeVersion</dt>
-            <dd>{data.reactNativeVersion}</dd>
-          </dl>
-        </div>
-      ))
-    }}
-  </Query>
+const COMMAND_QUERY = gql`
+  {
+    commands {
+      messageId
+      type
+      date
+      clientId
+    }
+  }
+`
+const COMMAND_SUB = gql`
+  subscription {
+    commandAdded {
+      messageId
+      type
+      date
+      clientId
+    }
+  }
+`
+
+const SampleConnection = params => (
+  <div key={params.id}>
+    <dl>
+      <dt>id</dt>
+      <dd>{params.id}</dd>
+      <dt>Platform</dt>
+      <dd>{params.platform}</dd>
+      <dt>reactotronLibraryName</dt>
+      <dd>{params.reactotronLibraryName}</dd>
+      <dt>screenWidth</dt>
+      <dd>{params.screenWidth}</dd>
+      <dt>screenHeight</dt>
+      <dd>{params.screenHeight}</dd>
+      <dt>screenScale</dt>
+      <dd>{params.screenScale}</dd>
+      <dt>reactNativeVersion</dt>
+      <dd>{params.reactNativeVersion}</dd>
+    </dl>
+  </div>
+)
+
+export const SampleLoadOnly = () => (
+  <div>
+    <h3>
+      Connections <small>(demos a 1-time data load)</small>
+    </h3>
+
+    <Query query={CONNECTIONS_QUERY}>
+      {({ loading, error, data }) => {
+        const connections = (data && data.connections) || []
+        return (
+          <div>
+            {loading && <p>Loading...</p>}
+            {error && <p>Error :(</p>}
+            {connections.length === 0 && <p>No connections</p>}
+            {connections.map(SampleConnection)}
+          </div>
+        )
+      }}
+    </Query>
+  </div>
+)
+
+export const SampleSubscribeOnly = () => (
+  <div>
+    <h3>
+      Last Message <small>(demos subscription only)</small>
+    </h3>
+    <Subscription subscription={COMMAND_SUB}>
+      {({ data, loading }) => {
+        if (loading) return <p>waiting for new messages</p>
+
+        return <p>last message was {data.commandAdded.type}</p>
+      }}
+    </Subscription>
+  </div>
+)
+
+const SampleCommand = ({ messageId, type, date }) => (
+  <div key={messageId} style={{ display: "flex", flexDirection: "row", width: "50%" }}>
+    <span style={{ flex: 1 }}>{type}</span>
+    <span style={{ flex: 1 }}>{date}</span>
+  </div>
+)
+
+class SampleCommandList extends React.Component<{
+  subscribeToCommands: Function
+  commands: any[]
+}> {
+  componentDidMount() {
+    this.props.subscribeToCommands()
+  }
+
+  render() {
+    return this.props.commands.slice(-10).map(SampleCommand)
+  }
+}
+
+export const SampleLoadAndSubscribe = () => (
+  <div>
+    <h3>
+      Last Few Messages <small>(demos load + subscription)</small>
+    </h3>
+
+    <Query query={COMMAND_QUERY}>
+      {({ loading, error, data, subscribeToMore }) => {
+        const commands = (data && data.commands) || []
+        return (
+          <div>
+            {loading && <p>Loading...</p>}
+            {error && <p>Error :(</p>}
+            <SampleCommandList
+              commands={commands}
+              subscribeToCommands={() =>
+                subscribeToMore({
+                  document: COMMAND_SUB,
+                  updateQuery: (prev, { subscriptionData }) => {
+                    if (!subscriptionData.data) return prev
+                    const newItem = subscriptionData.data.commandAdded
+                    return { ...prev, commands: [...prev.commands, newItem] }
+                  },
+                })
+              }
+            />
+          </div>
+        )
+      }}
+    </Query>
+  </div>
 )

--- a/packages/reactotron-server/src/server/apollo/resolvers/commands.ts
+++ b/packages/reactotron-server/src/server/apollo/resolvers/commands.ts
@@ -4,6 +4,7 @@ import { MessageTypes } from "../../messaging"
 import { Command } from "../../schema"
 import { commandsStore } from "../../datastore"
 import { CommandAddedArgs } from "../../schema/command"
+import { createCommandMatcher } from "../../datastore/commands"
 
 @Resolver()
 export class CommandsResolver {
@@ -17,7 +18,7 @@ export class CommandsResolver {
 
   @Subscription(() => Command, {
     topics: [MessageTypes.COMMAND_ADDED],
-    filter: ({ payload, args }) => commandsStore.filterItem(payload, args.clientId, args.filter),
+    filter: ({ payload, args }) => createCommandMatcher(args.clientId, args.filter)(payload),
   })
   commandAdded(@Root() command: Command, @Args() { clientId, filter }: CommandAddedArgs): Command {
     return command

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,6 +1065,12 @@ apollo-link-http@^1.5.4:
     apollo-link "^1.2.2"
     apollo-link-http-common "^0.2.4"
 
+apollo-link-ws@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/apollo-link-ws/-/apollo-link-ws-1.0.8.tgz#ac1de8f29e92418728479a9a523af9f75b9ccc8b"
+  dependencies:
+    apollo-link "^1.2.2"
+
 apollo-link@^1.0.0, apollo-link@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.2.tgz#54c84199b18ac1af8d63553a68ca389c05217a03"
@@ -9381,7 +9387,7 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-subscriptions-transport-ws@^0.9.11:
+subscriptions-transport-ws@^0.9.11, subscriptions-transport-ws@^0.9.14:
   version "0.9.14"
   resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.14.tgz#a39e08edba89ee4cfd95f30484c55d865f5d8451"
   dependencies:


### PR DESCRIPTION
Ok, I think i'm getting a handle on this... 

We'll probably want to move things like `message limits` server side tho right?  Right now there's a buttload of data since the datastore is nothing but a never-ending array.

I got it working with:

- load once only
- subscribe only
- load and then subscribe

Pretty straight forward.

![reactotron-strats](https://user-images.githubusercontent.com/68273/45229258-5f15c900-b293-11e8-820a-dbfda48e1c78.gif)


