### PR TITLE
🔧 moves tsconfig.server.json into tsconfig.json

### DIFF
--- a/packages/reactotron-server/package.json
+++ b/packages/reactotron-server/package.json
@@ -4,10 +4,10 @@
   "description": "A reactotron server",
   "main": "index.js",
   "scripts": {
-    "compile": "tsc -p tsconfig.server.json",
+    "compile": "tsc",
     "clean": "rimraf dist build",
     "lint": "tslint -p .",
-    "build:server": "yarn clean && tsc --p tsconfig.server.json",
+    "build:server": "npm-run-all clean compile",
     "start:server": "yarn build:server && node dist/server/index.js",
     "start:app": "yarn parcel watch src/app/index.html",
     "test": "npm-run-all test:compile && yarn ava",

--- a/packages/reactotron-server/tsconfig.json
+++ b/packages/reactotron-server/tsconfig.json
@@ -12,7 +12,8 @@
     "emitDecoratorMetadata": true,
     "noUnusedLocals": true,
     "removeComments": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/packages/reactotron-server/tsconfig.server.json
+++ b/packages/reactotron-server/tsconfig.server.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "compilerOptions": {
-    "outDir": "dist",
-  },
-}


### PR DESCRIPTION
@rmevans9 pointed out we don't need to have a `tsconfig.server.json` anymore.