### PR TITLE
[docs] Updates installing docs to explain how to open

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -29,3 +29,5 @@ To update an existing installation of reactotron via brew, type:
 ```
 brew cask reinstall reactotron
 ```
+
+After a successful `brew cask install`, you can find the app in your **Applications** folder. Run it like any other application. :sparkles:


### PR DESCRIPTION
As an infrequent `brew ` user, I did not catch that adding the `cask` argument makes a package into an application. Since I spent a while looking around my computer for `reactotron`, I thought this small update might help the next person who was a little behind on the `brew` command landscape.

Thanks for making some fun tools to use, everyone!