### PR TITLE
Publish reactotron-redux.d.ts w/ reactotron-redux

### DIFF
--- a/packages/reactotron-redux/package.json
+++ b/packages/reactotron-redux/package.json
@@ -22,7 +22,8 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "reactotron-redux.d.ts"
   ],
   "types": "./reactotron-redux.d.ts",
   "devDependencies": {


### PR DESCRIPTION
This adds reactotron-redux.d.ts to the "files" section of the reactotron-redux package.json so it is available to users when the package is published.

It fixes this bug #826 

I admit I didnt test this super thoroughly, but its a small change.  I just did an npm pack on reactotron-redux and listed the tgz contents to make sure the file was present.