### PR TITLE
Various fixes for getting started

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,14 +31,18 @@ Run the setup script to install the dependencies & run tests.
 ```
 yarn install
 yarn welcome
+./setupV3ServerLinks.sh
 ```
 
 Run the app
 
 ```
-cd packages/reactotron-app
-yarn start
+cd packages/reactotron-server
+yarn start:server
+yarn yarn start:app
 ```
+
+Visit `http://localhost:4000/`. More docs are available in the `packages/reactotron-server/readme.md` file.
 
 ### Monorepo & Lerna
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "workspaces": [
     "packages/reactotron-server",
     "packages/reactotron-core-plugin",
-    "packages/reactotron-plugin-*"
+    "packages/reactotron-plugin-*",
+    "packages/reactotron-core-ui"
   ],
   "lint-staged": {
     "subTaskConcurrency": 1,

--- a/packages/reactotron-core-ui/src/text/text.tsx
+++ b/packages/reactotron-core-ui/src/text/text.tsx
@@ -29,6 +29,7 @@ export interface TextProps {
   text?: string
   variant?: TEXT_VARIANTS
   className?: string
+  tx?: string
 }
 
 // --- component ---


### PR DESCRIPTION
Upon re-setting up the project for v3, I discovered some issues. These changes got me up and running. Includes:

- Ensuring reactotron-core-ui was included as a yarn workspace (and therefore `yarn install` runs automatically)
- Add missing proptype dec for text component
- Update contributing docs to help get going.