### PR TITLE
Pass through response if already JSON-Object

### DIFF
--- a/packages/reactotron-react-native/src/plugins/networking.js
+++ b/packages/reactotron-react-native/src/plugins/networking.js
@@ -82,7 +82,7 @@ export default (pluginConfig = {}) => reactotron => {
 
     const sendResponse = responseBodyText => {
       let body = `~~~ skipped ~~~`
-      if (responseBodyText && responseBodyText.length) {
+      if (responseBodyText) {  
         try {
           // all i am saying, is give JSON a chance...
           body = JSON.parse(responseBodyText)


### PR DESCRIPTION
My problem was that Reactotron was always showing "skipped" for any responses I sent in json-format from my expressjs server.
I found that the check ``&& responseBodyText.length`` in line 85 would prevent every JSON-Object response from being passed through if it's not a json-STRING.
Because responseBodyText.length would fail on every Object without that property and only pass on a string, also the catch-block would never be executed and thus instead of the response object, the string "skipped" would always be passed to the Reactotron-App-UI.

This PR removes the check ``&& responseBodyText.length`` and thus enables the wanted behavior.
If it's a string it tries to JSON-parse it and if it's an object already the catch-block get's executed.