### PR TITLE
Upstart fixes

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -39,7 +39,7 @@ Run the app
 ```
 cd packages/reactotron-server
 yarn start:server
-yarn yarn start:app
+yarn start:app
 ```
 
 Visit `http://localhost:4000/`. More docs are available in the `packages/reactotron-server/readme.md` file.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "lerna run test --scope 'reactotron-core-*' --scope 'reactotron-redux*' --scope 'reactotron-apisauce'",
     "lint": "lerna run lint",
     "welcome": "yarn run clean && yarn run bootstrap && yarn run build && yarn run copy-internal-deps && yarn run lint -s",
-    "format": "lerna run format"
+    "format": "lerna run format",
+    "postinstall": "./setupV3ServerLinks.sh"
   },
   "devDependencies": {
     "@types/jest": "^21.1.2",


### PR DESCRIPTION
I've noticed that whenever I come back to the project, I forget to run the `./setupV3ServerLinks.sh` command and as such I get out of date component exports when I try to build the project.

As such, I've packaged in here a quick `postinstall` call to run the `./setupV3ServerLinks` script after every `yarn install`.

This PR also fixes a minor documentation issue.