### PR TITLE
JSON Tree APIResponse Integration

### DIFF
--- a/packages/reactotron-server/src/app/commands/ApiResponse.tsx
+++ b/packages/reactotron-server/src/app/commands/ApiResponse.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Command } from "reactotron-core-ui"
+import { JsonTree } from "reactotron-core-ui"
 
 interface Props {
   command: Command
@@ -17,13 +18,13 @@ export class ApiResponseTimeline extends React.Component<Props, State> {
 
     switch (this.state.expanded) {
       case "response":
-        contents = JSON.stringify(this.props.command.payload.response.body)
+        contents = <JsonTree data={this.props.command.payload.response.body} />
         break
       case "responseHeaders":
-        contents = JSON.stringify(this.props.command.payload.response.headers)
+        contents = <JsonTree data={this.props.command.payload.response.headers} />
         break
       case "requestHeaders":
-        contents = JSON.stringify(this.props.command.payload.request.headers)
+        contents = <JsonTree data={this.props.command.payload.request.headers} />
         break
       default:
         contents = null


### PR DESCRIPTION
Not really any work here, I just wanted to do this just to see it in the timeline - we now have a real working demo of a tree view in the APIResponse. Great Job @rmevans9 / @skellock 

<img width="1376" alt="screenshot 2018-10-03 at 09 07 31" src="https://user-images.githubusercontent.com/789192/46398271-90e04b00-c6ec-11e8-9082-bc6ebb58b988.png">
