### PR TITLE
Remove circular dependency in redux-saga

### DIFF
--- a/packages/reactotron-redux-saga/package.json
+++ b/packages/reactotron-redux-saga/package.json
@@ -52,6 +52,6 @@
     "ramdasauce": "^2.0.0",
     "reactotron-core-client": "^2.1.0",
     "redux": "^3.7.1",
-    "redux-saga": "^0.15.3"
+    "redux-saga": "^0.16.1"
   }
 }

--- a/packages/reactotron-redux-saga/yarn.lock
+++ b/packages/reactotron-redux-saga/yarn.lock
@@ -3535,6 +3535,10 @@ rc@^1.0.1, rc@^1.1.6, rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
+reactotron-core-client@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/reactotron-core-client/-/reactotron-core-client-2.1.0.tgz#d36f806eaf14a9f8c4595a9866f8cbfaafc1ee8c"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -3619,9 +3623,9 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux-saga@^0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.15.3.tgz#be2b86b4ad46bf0d84fcfcb0ca96cfc33db91acb"
+redux-saga@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.1.tgz#aa43d2ac029dab57f7f522b143f7db179a9e1324"
 
 redux@^3.7.1:
   version "3.7.2"


### PR DESCRIPTION
Hello,

This PR upgrade redux-saga to version 0.16.1 which fixes circular dependency.
The circular dependency is annoying with React Native 0.57 because of the yellow box warnings.

Thanks,
Julien Usson