### PR TITLE
Fix for negative value in timeline

### DIFF
--- a/packages/reactotron-app/App/Timeline/Timeline.js
+++ b/packages/reactotron-app/App/Timeline/Timeline.js
@@ -86,7 +86,8 @@ class Timeline extends Component {
       previousCommand.date &&
       command.date &&
       command.date.getTime() - previousCommand.date.getTime()
-    const deltaTime = isLast ? 0 : diff
+    // glitches in the matrix
+    const deltaTime = isLast || diff < 0 ? 0 : diff
 
     return <CommandComponent deltaTime={deltaTime} key={command.messageId} command={command} />
   }


### PR DESCRIPTION
When some event happens before connection, display nothing instead of +-

Fix: https://github.com/infinitered/reactotron/issues/762