### PR TITLE
fix #727, handle the no enhancer situation for reactotron-redux plugin

### DIFF
--- a/packages/reactotron-redux/src/create-store.js
+++ b/packages/reactotron-redux/src/create-store.js
@@ -11,7 +11,9 @@ export default (reactotron, rootReducer, preloadedState, enhancer) => {
   const reducer = reactotron.createReplacementReducer(rootReducer)
 
   // wrap the enhancer with our beginning and ending one
-  const wrappedEnhancer = compose(enhancer, reactotron.createActionTracker())
+  const wrappedEnhancer = enhancer 
+    ? compose(enhancer, reactotron.createActionTracker())
+    : reactotron.createActionTracker()
 
   // call the redux create store
   const store = createStore(reducer, preloadedState, wrappedEnhancer)


### PR DESCRIPTION
if enhancer is not provided, the this plugin causes crash.

for example:
```
import rootReducer from './reducer'
import Reactotron from 'reactotron-react-native'
import { reactotronRedux } from 'reactotron-redux' 

let instance = Reactotron
  .configure()
  .useReactNative()
  .use(reactotronRedux())
  .connect()

export default instance.createStore(rootReducer)  //  Crash occurs
export { RootState } from './reducer'
```