### PR TITLE
Added overlay to typings

### DIFF
--- a/packages/reactotron-react-native/reactotron-react-native.d.ts
+++ b/packages/reactotron-react-native/reactotron-react-native.d.ts
@@ -202,6 +202,10 @@ declare module "reactotron-react-native" {
      * @param title The name of the benchmark.
      */
     benchmark(title?: string): ReactotronBenchmark
+              
+              
+              
+    overlay(App: React.ReactNode):void          
   }
 
   var instance: Reactotron


### PR DESCRIPTION
used in andross boilerplate in Containers/App
```
export default DebugConfig.useReactotron
  ? console.tron.overlay(App)
  : App
```

if we convert app.js to app.ts , the error comes up so we need add overlay() to typings