### PR TITLE
Fix typo in react native quick start

### DIFF
--- a/docs/quick-start-react-native.md
+++ b/docs/quick-start-react-native.md
@@ -71,7 +71,7 @@ on line 1:
 
 ```js
 if(__DEV__) {
-  import('.ReactotronConfig').then(() => console.log('Reactotron Configured'))
+  import('./ReactotronConfig').then(() => console.log('Reactotron Configured'))
 }
 ```
 


### PR DESCRIPTION
Just a quick typo fix. Fixed forgetting `/`.

