### PR TITLE
Set app title to "Reactotron"

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Hello Electron React!</title>
+    <title>Reactotron</title>
     <script>
       (function() {
         if (!process.env.HOT) {


### PR DESCRIPTION
On macOS, "Reactotron" shows up as the title of Reactotron when using Exposé instead of "Hello Electron React!"

<img width="400" alt="screen-shot" src="https://user-images.githubusercontent.com/1402235/55597366-95c99a00-5723-11e9-9cb8-28cbac385777.png">
