### PR TITLE
Setting up a config file that allows you to change the port of the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "electron-debug": "^1.4.0",
     "electron-devtools-installer": "^2.2.4",
     "electron-log": "^2.2.17",
+    "electron-store": "^3.1.0",
     "electron-updater": "^4.0.5",
     "electron-window-state": "^5.0.3",
     "font-awesome": "^4.7.0",

--- a/src/Foundation/App.js
+++ b/src/Foundation/App.js
@@ -1,6 +1,7 @@
 import { Provider, observer } from "mobx-react"
 import React, { Component } from "react"
 import { ipcRenderer } from "electron"
+import config from "../Lib/config"
 import FilterTimelineDialog from "../Dialogs/FilterTimelineDialog"
 import ExportTimelineDialog from "../Dialogs/ExportTimelineDialog"
 import RenameStateDialog from "../Dialogs/RenameStateDialog"
@@ -19,7 +20,7 @@ import Timeline from "../Timeline/Timeline"
 import Sidebar from "./Sidebar"
 import StatusBar from "./StatusBar"
 
-const session = new SessionStore()
+const session = new SessionStore(config.get("server.port", 9090))
 
 const Styles = {
   container: { ...AppStyles.Layout.vbox },

--- a/src/Foundation/Sidebar.js
+++ b/src/Foundation/Sidebar.js
@@ -39,9 +39,6 @@ class Sidebar extends Component {
     this.handleClickHelp = () => {
       this.props.session.ui.switchTab("help")
     }
-    this.handleClickSettings = () => {
-      this.props.session.ui.switchTab("settings")
-    }
     this.handleClickNative = () => {
       this.props.session.ui.switchTab("native")
     }
@@ -51,7 +48,9 @@ class Sidebar extends Component {
     const { session } = this.props
     const { ui } = session
     const isHome = ui.tab === "home"
-    const imageFilter = { filter: `grayscale(${ isHome ? 0 : 100 }%) brightness(${ isHome ? 100 : 70 }%)` }
+    const imageFilter = {
+      filter: `grayscale(${isHome ? 0 : 100}%) brightness(${isHome ? 100 : 70}%)`,
+    }
 
     return (
       <div

--- a/src/Lib/commands.js
+++ b/src/Lib/commands.js
@@ -1,8 +1,9 @@
 import { action, observable, computed } from "mobx"
 import { pipe, reject, contains, propEq } from "ramda"
 import { dotPath } from "ramdasauce"
+import config from "./config"
 
-export const MAX_COMMANDS = 500
+export const MAX_COMMANDS = config.get("commandHistory", 500)
 
 // how often to flush the buffer of commands into the main list
 const FLUSH_TIME = 50

--- a/src/Lib/config.js
+++ b/src/Lib/config.js
@@ -1,0 +1,19 @@
+import Store from "electron-store"
+
+const schema = {
+  server: {
+    port: {
+      type: "number",
+      default: 9090,
+    },
+  },
+}
+
+const configStore = new Store({ schema })
+
+// Setup defaults
+if (!configStore.has("server.port")) {
+  configStore.set("server.port", 9090)
+}
+
+export default configStore

--- a/src/Lib/config.js
+++ b/src/Lib/config.js
@@ -7,6 +7,10 @@ const schema = {
       default: 9090,
     },
   },
+  commandHistory: {
+    type: "number",
+    default: 500,
+  },
 }
 
 const configStore = new Store({ schema })
@@ -14,6 +18,9 @@ const configStore = new Store({ schema })
 // Setup defaults
 if (!configStore.has("server.port")) {
   configStore.set("server.port", 9090)
+}
+if (!configStore.has("commandHistory")) {
+  configStore.set("commandHistory", 500)
 }
 
 export default configStore

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,4 +1,7 @@
 import { app, Menu, shell, BrowserWindow } from "electron"
+import Store from "electron-store"
+
+const configStore = new Store()
 
 export default class MenuBuilder {
   constructor(mainWindow) {
@@ -55,6 +58,13 @@ export default class MenuBuilder {
           selector: "hideOtherApplications:",
         },
         { label: "Show All", selector: "unhideAllApplications:" },
+        { type: "separator" },
+        {
+          label: "Preferences",
+          click: () => {
+            configStore.openInEditor()
+          },
+        },
         { type: "separator" },
         {
           label: "Quit",

--- a/yarn.lock
+++ b/yarn.lock
@@ -503,6 +503,16 @@ ajv@^6.1.0:
     json-schema-traverse "^0.3.0"
     uri-js "^3.0.2"
 
+ajv@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 ajv@^6.5.5:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.1.tgz#6360f5ed0d80f232cc2b294c362d5dc2e538dd61"
@@ -2391,6 +2401,19 @@ concurrently@^4.1.0:
     tree-kill "^1.1.0"
     yargs "^12.0.1"
 
+conf@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/conf/-/conf-4.0.0.tgz#c675f84ce1b8efeab21cd1399021b4f03b75ded2"
+  integrity sha512-g3kLYbvtnC6w1IEBalWQoetLq8WUsYVncW7mTBPsPKw4SkNGBj3AaEiRXYPCCW9DPqKdhs1S+f6babEZju0EhA==
+  dependencies:
+    ajv "^6.10.0"
+    dot-prop "^4.2.0"
+    env-paths "^2.1.0"
+    json-schema-typed "^7.0.0"
+    make-dir "^3.0.0"
+    pkg-up "^3.0.1"
+    write-file-atomic "^2.4.2"
+
 config-chain@^1.1.12:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
@@ -3147,7 +3170,7 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dot-prop@^4.1.0, dot-prop@^4.1.1:
+dot-prop@^4.1.0, dot-prop@^4.1.1, dot-prop@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
@@ -3313,6 +3336,13 @@ electron-publish@20.38.2:
     lazy-val "^1.0.3"
     mime "^2.4.0"
 
+electron-store@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-3.1.0.tgz#952a655d3468095ffc40c0a307a0ab8cce8383c0"
+  integrity sha512-PB04EM46LFsZV+KAy7Ahd3vAnt9iRJLaOVkqlTJCODjzq73Xt0I5g6eVxprEu4otuI+YKJRaojCQ/HTCh6RzzA==
+  dependencies:
+    conf "^4.0.0"
+
 electron-to-chromium@^1.3.86:
   version "1.3.88"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.88.tgz#f36ab32634f49ef2b0fdc1e82e2d1cc17feb29e7"
@@ -3417,6 +3447,11 @@ env-ci@^3.0.0:
 env-paths@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
+
+env-paths@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
+  integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -5123,6 +5158,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-typed@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-7.0.0.tgz#714f3bb539637644b8cb9c99a097c4ee8f8e8c8f"
+  integrity sha512-ikVqF4dlAgRvAb3MDAgDQRtB/GIC8+iq+z5bczPh9bUT7bAZCdGfGCypJHBquzZNoxebql1UgPxWbImnvkSuJg==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -5520,6 +5560,13 @@ make-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.2.0.tgz#6d6a49eead4aae296c53bbf3a1a008bd6c89469b"
   dependencies:
     pify "^3.0.0"
+
+make-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
+  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
+  dependencies:
+    semver "^6.0.0"
 
 "make-fetch-happen@^2.5.0 || 3 || 4", make-fetch-happen@^4.0.1:
   version "4.0.1"
@@ -6971,6 +7018,13 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
+pkg-up@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.0.1.tgz#91ea5597c5585fe438d32689ac8943f1b5f17900"
+  integrity sha512-M8N4levGL4P4tHD+l9/glzZuRJqDhwnL5hAMoz7dIpgHhw0NmOjrcvF2plRCy/c7hkylftdehtnJZNkkBeKpzQ==
+  dependencies:
+    find-up "^3.0.0"
+
 plist@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.1.tgz#a9b931d17c304e8912ef0ba3bdd6182baf2e1f8c"
@@ -8269,6 +8323,11 @@ semver-regex@^2.0.0:
 "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
+  integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -9808,6 +9867,15 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
   integrity sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
+write-file-atomic@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
+  integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"


### PR DESCRIPTION
This only sets up a single config item but it opens up the ability to have configuration for the first time ever!

There is an option in the Reactotron menu to open the configuration file. Right now any changes to the config file require a restart of reactotron. The `electron-store` package allows watching specific setting keys which we could setup and do that for the port and just restart the server when it happens but I didn't want to go that far with it just yet.

fixes: #922 
fixes: #825 