### PR TITLE
Adds clipboard saving of state backups

### DIFF
--- a/src/State/BackupItem.js
+++ b/src/State/BackupItem.js
@@ -2,6 +2,7 @@ import React, { Component } from "react"
 import IconRename from "react-icons/lib/md/create"
 import IconDelete from "react-icons/lib/md/delete"
 import IconUpload from "react-icons/lib/md/file-upload"
+import IconCopy from "react-icons/lib/md/call-received"
 import AppStyles from "../Theme/AppStyles"
 import Colors from "../Theme/Colors"
 import Content from "../Shared/Content"
@@ -67,6 +68,11 @@ export default class BackupItem extends Component {
     this.props.onRestore(this.props.backup)
   }
 
+  handleExport = event => {
+    event.stopPropagation()
+    this.props.onExport(this.props.backup)
+  }
+
   render() {
     const {
       backup: { name, state },
@@ -77,6 +83,7 @@ export default class BackupItem extends Component {
       <div style={Styles.container}>
         <div style={Styles.row} onClick={this.handleToggle}>
           <div style={Styles.name}>{name}</div>
+          <IconCopy size={Styles.iconSize} style={Styles.button} onClick={this.handleExport} />
           <IconUpload size={Styles.iconSize} style={Styles.button} onClick={this.handleRestore} />
           <IconRename size={Styles.iconSize} style={Styles.button} onClick={this.handleRename} />
           <IconDelete size={Styles.iconSize} style={Styles.button} onClick={this.handleRemove} />

--- a/src/State/Backups.js
+++ b/src/State/Backups.js
@@ -52,6 +52,11 @@ class Backups extends Component {
     stateBackupStore.sendRestore(backup)
   }
 
+  handleExport = backup => {
+    const { stateBackupStore } = this.props.session
+    stateBackupStore.exportBackup(backup)
+  }
+
   renderBackup(backup) {
     const { id, name } = backup
 
@@ -62,6 +67,7 @@ class Backups extends Component {
         onRemove={this.handleRemove}
         onRename={this.handleRename}
         onRestore={this.handleRestore}
+        onExport={this.handleExport}
       />
     )
   }

--- a/src/State/State.js
+++ b/src/State/State.js
@@ -75,7 +75,14 @@ class State extends Component {
           text="Snapshots"
           icon="import-export"
           renderActions={() => (
-            <div>
+            <div style={Styles.toolbarContainer}>
+              <Button
+                icon="call-received"
+                onClick={() => stateBackupStore.exportAllBackups()}
+                tip="Copy All Backups to Clipboard"
+                size={Styles.iconSize}
+                style={Styles.toolbarAdd}
+              />
               <Button
                 icon="file-download"
                 onClick={() => stateBackupStore.sendBackup()}

--- a/src/Stores/StateBackupStore.js
+++ b/src/Stores/StateBackupStore.js
@@ -1,5 +1,6 @@
 import { format } from "date-fns"
 import { action, observable } from "mobx"
+import { clipboard } from "electron"
 
 /**
  * The data powering a backup.
@@ -46,6 +47,24 @@ export class StateBackupStore {
     server.on("command", command => {
       command.type === "state.backup.response" && this.createBackupFromCommand(command)
     })
+  }
+
+  /**
+   * Exports all backups.
+   *
+   */
+  @action
+  exportAllBackups() {
+    clipboard.writeText(JSON.stringify(this.backups))
+  }
+
+  /**
+   * Exports individual backup.
+   *
+   */
+  @action
+  exportBackup(currentBackup) {
+    clipboard.writeText(JSON.stringify(currentBackup))
   }
 
   /**


### PR DESCRIPTION
A potential way for passing the baton of state from colleague to colleague for debugging.

FUTURE: Ability to import by pasting this JSON dump into Reactotron in the state snapshot. 