### PR TITLE
fix: Resolve issue when multiple devices connected in the state subscriptions tab

### DIFF
--- a/examples/ReactotronTester/app/redux/store.ts
+++ b/examples/ReactotronTester/app/redux/store.ts
@@ -1,13 +1,19 @@
+import { Dimensions } from "react-native"
 import { createStore, combineReducers, applyMiddleware, compose } from "redux"
 import ReduxThunk from "redux-thunk"
 import Reactotron from "reactotron-react-native"
 
 function dummyReducer(state = { counter: 0 }, action) {
-  switch(action.type) {
+  switch (action.type) {
     case "RandomThunkAction":
       return {
         ...state,
         counter: state.counter + 1,
+        height: Dimensions.get("screen").height,
+      }
+    default:
+      return {
+        ...state,
       }
   }
 
@@ -25,8 +31,8 @@ export default () => {
     rootReducer,
     compose(
       middleware,
-      Reactotron.createEnhancer(),
-    ),
+      Reactotron.createEnhancer()
+    )
   )
   // const store = (Reactotron as any).createStore(rootReducer, compose(middleware))
 

--- a/src/Stores/SessionStore.js
+++ b/src/Stores/SessionStore.js
@@ -116,7 +116,7 @@ class Session {
     } else {
       if (!this.selectedConnection) return [] // If we have > 1 connection and "All" is selected jet since what we will show won't be "all"
       connectionsChangeCommands = reject(
-        c => c.connectionId === this.selectedConnection.id,
+        c => c.connectionId !== this.selectedConnection.id,
         changeCommands
       )
     }


### PR DESCRIPTION
fix: https://github.com/infinitered/reactotron/issues/1002

We were rejecting the selected connections change commands instead of only keeping the select connections change commands.