### PR TITLE
Allow exporting (command) timestamps

### DIFF
--- a/src/Stores/UiStore.js
+++ b/src/Stores/UiStore.js
@@ -536,6 +536,7 @@ class UI {
       return
     }
     const formatCommand = command => ({
+      time: command.date,
       clientId: command.clientId,
       payload: {
         name: command.payload.name,
@@ -543,6 +544,7 @@ class UI {
       },
       type: command.type,
     })
+
     const commands = JSON.stringify(this.session.commands.map(formatCommand))
     fs.writeFile(this.exportFilePath + "/reactotron_timeline.txt", commands, err => {
       if (err) {


### PR DESCRIPTION
As Reactotron allows exporting API calls logs to a file, it misses a timestamp attribute which can be useful for certain purposes as discussed [here](https://github.com/infinitered/reactotron/issues/912#issue-399269567).

This commit thus adds a "time" property on every exported object.

Related: https://github.com/infinitered/reactotron/issues/912