### PR TITLE
Add reapply overlay button

### DIFF
--- a/src/Native/NativeOverlay.js
+++ b/src/Native/NativeOverlay.js
@@ -31,12 +31,9 @@ const Styles = {
     marginTop: 20,
   },
   row: {
-    ...AppStyles.Layout.hbox,
-    padding: "15px 20px",
-    justifyContent: "space-between",
-    alignItems: "center",
-    borderBottom: `1px solid ${Colors.line}`,
-    cursor: "pointer",
+    display: "flex",
+    flexDirection: "row",
+    marginTop: 10,
   },
   name: {
     color: Colors.tag,
@@ -110,6 +107,7 @@ class NativeOverlay extends Component {
     this.handleOpacityChange = this.handleOpacityChange.bind(this)
     this.handleMarginsChange = this.handleMarginsChange.bind(this)
     this.removeImage = this.removeImage.bind(this)
+    this.applyOverlay = this.applyOverlay.bind(this)
   }
 
   /**
@@ -136,9 +134,6 @@ class NativeOverlay extends Component {
    * @memberOf Native
    */
   import(path) {
-    const { ui } = this.props.session
-    const { opacity, scale, justifyContent, alignItems, resizeMode, growToWindow } = this.state
-
     // need to load from a buffer because electron has a problem reading
     // from '@2x.png' named files.  :|
     fs.readFile(path, (err, data) => {
@@ -147,17 +142,42 @@ class NativeOverlay extends Component {
         const uri = image.toDataURL()
         const { width, height } = image.getSize()
         this.setState({ uri, width, height })
-        ui.setOverlay({
-          uri,
-          width: width * scale,
-          height: height * scale,
-          justifyContent,
-          alignItems,
-          opacity,
-          growToWindow,
-          resizeMode,
-        })
+        this.applyOverlay()
       }
+    })
+  }
+
+  applyOverlay() {
+    const { ui } = this.props.session
+    const {
+      opacity,
+      scale,
+      justifyContent,
+      alignItems,
+      resizeMode,
+      growToWindow,
+      uri,
+      width,
+      height,
+      marginTop,
+      marginRight,
+      marginBottom,
+      marginLeft,
+    } = this.state
+
+    ui.setOverlay({
+      uri,
+      width: width * scale,
+      height: height * scale,
+      justifyContent,
+      alignItems,
+      opacity,
+      growToWindow,
+      resizeMode,
+      marginTop,
+      marginRight,
+      marginBottom,
+      marginLeft,
     })
   }
 
@@ -255,6 +275,19 @@ class NativeOverlay extends Component {
     } else {
       return <p>Drop Image Here</p>
     }
+  }
+
+  renderReapply() {
+    const { uri } = this.state
+    if (!uri) return <div />
+
+    return (
+      <div style={Styles.row}>
+        <button style={Styles.button} onClick={this.applyOverlay}>
+          Reapply Overlay
+        </button>
+      </div>
+    )
   }
 
   renderLayoutType() {
@@ -358,6 +391,7 @@ class NativeOverlay extends Component {
             >
               {this.renderImagePreview()}
             </div>
+            {this.renderReapply()}
           </div>
           {this.renderLayoutType()}
           {this.renderScale()}

--- a/src/Native/NativeOverlayMargins.js
+++ b/src/Native/NativeOverlayMargins.js
@@ -1,26 +1,26 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import Colors from '../Theme/Colors'
+import React from "react"
+import PropTypes from "prop-types"
+import Colors from "../Theme/Colors"
 
 const Styles = {
   container: {},
   row: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center'
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
   },
   label: {
-    marginRight: 4
+    marginRight: 4,
   },
   field: {
     marginRight: 4,
     width: 45,
     border: 0,
-    padding: '8px 5px',
-    fontSize: '1.1rem',
+    padding: "8px 5px",
+    fontSize: "1.1rem",
     backgroundColor: Colors.backgroundLight,
-    color: Colors.backgroundColor
-  }
+    color: Colors.backgroundColor,
+  },
 }
 
 class NativeOverlayMargins extends React.PureComponent {
@@ -29,10 +29,10 @@ class NativeOverlayMargins extends React.PureComponent {
     marginRight: PropTypes.number,
     marginTop: PropTypes.number,
     marginBottom: PropTypes.number,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
   }
 
-  render () {
+  render() {
     const { onChange, marginTop, marginRight, marginBottom, marginLeft } = this.props
     const makeHandler = whichMargin => event => {
       event.stopPropagation()
@@ -48,29 +48,33 @@ class NativeOverlayMargins extends React.PureComponent {
         <div style={Styles.row}>
           <div style={Styles.label}>Top</div>
           <input
+            type="number"
             style={Styles.field}
-            onChange={makeHandler('marginTop')}
+            onChange={makeHandler("marginTop")}
             value={marginTop}
             tabIndex={10}
           />
           <div style={Styles.label}>Right</div>
           <input
+            type="number"
             style={Styles.field}
-            onChange={makeHandler('marginRight')}
+            onChange={makeHandler("marginRight")}
             value={marginRight}
             tabIndex={11}
           />
           <div style={Styles.label}>Bottom</div>
           <input
+            type="number"
             style={Styles.field}
-            onChange={makeHandler('marginBottom')}
+            onChange={makeHandler("marginBottom")}
             value={marginBottom}
             tabIndex={12}
           />
           <div style={Styles.label}>Left</div>
           <input
+            type="number"
             style={Styles.field}
-            onChange={makeHandler('marginLeft')}
+            onChange={makeHandler("marginLeft")}
             value={marginLeft}
             tabIndex={13}
           />


### PR DESCRIPTION
Adds a "Reapply Overlay" button to the overlay page. My use case is that I often refresh the simulator (rather than hot reload), which then loses the overlay.

The button shows when there's an image uri. I guess ideally it would only show when the overlay isn't visible on the simulator anymore but I wasn't sure how to go about that.

I also updated the margin inputs to be `type="number"` so that arrow keys are usable in those fields.

<img width="774" alt="Screenshot 2019-08-06 at 12 00 05" src="https://user-images.githubusercontent.com/348342/62534903-00a9ef80-b842-11e9-9378-2ce1deaaf65f.png">
