### PR TITLE
fix: align expander icons with mui

### DIFF
--- a/src/Shared/Command.js
+++ b/src/Shared/Command.js
@@ -3,8 +3,8 @@ import PropTypes from "prop-types"
 import React, { Component } from "react"
 import {
   MdLabel as DisplayIcon,
-  MdExpandMore as IconOpen,
-  MdChevronRight as IconClosed
+  MdExpandLess as IconOpen,
+  MdExpandMore as IconClosed
 } from "react-icons/md"
 import Timestamp from "../Shared/Timestamp"
 import AppStyles from "../Theme/AppStyles"


### PR DESCRIPTION
This is actually different then what I suggested in #1130 and I'd happy to go with that change instead. This PR aligns the command panel with how Material actually does expansion panels, making the current closed Icon `MdExpandMore` (which was previously the open Icon), and makes the open Icon `MdExpandLess`.