### PR TITLE
Use the correct yarn command for adding to devDependencies

### DIFF
--- a/docs/plugin-mst.md
+++ b/docs/plugin-mst.md
@@ -13,7 +13,7 @@ This is also a plugin for `mobx-state-tree`, so you'll also need that installed 
 In your app, add a dev-dependency to `reactotron-mst`.
 
 ```sh
-yarn add reactotron-mst --save-dev
+yarn add reactotron-mst --dev
 ```
 
 or


### PR DESCRIPTION
The docs just had the incorrect flag for adding to dev dependencies, 