### PR TITLE
Add issue template with link to slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,13 @@
+---
+name: File An Issue
+about: Report an issue with Reactotron
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+If you have a general question, please ask it in the #reactotron channel of the
+[Infinite Red Community slack](https://community.infinite.red/).
+
+When reporting a bug, please include steps to reproduce the issue.


### PR DESCRIPTION
Adds an issue template that encourages people who have questions to ask
in the Infinite Red Community slack, where it's more likely their
question will be addressed quickly.