### PR TITLE
Add note to reload app after forwarding 9090

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,6 +43,8 @@ While plugged in type:
 adb reverse tcp:9090 tcp:9090
 ```
 
+and reload the app on your device.
+
 This only works on Android 5.x+.
 
 As of 1.1.4, the proper IP address is auto-discovered.  Simply leave the `configure` as is.


### PR DESCRIPTION
Small docs change to note that the app will need to be reloaded to show up in reactotron after forwarding port 9090.