### PR TITLE
Map Command+K to clear timeline

### DIFF
--- a/apps/reactotron-app/src/renderer/KeybindHandler.tsx
+++ b/apps/reactotron-app/src/renderer/KeybindHandler.tsx
@@ -4,6 +4,13 @@ import { ReactotronContext, StateContext } from "reactotron-core-ui"
 import LayoutContext from "./contexts/Layout"
 
 const keyMap = {
+  // Application wide
+  ToggleSidebar: {
+    name: "Toggle Sidebar",
+    group: "Application",
+    sequences: ["command+shift+s", "ctrl+shift+s"],
+    action: "keyup" as KeyEventName,
+  },
   // Tab Navigation
   OpenHomeTab: {
     name: "Home tab",
@@ -41,14 +48,21 @@ const keyMap = {
     sequences: ["command+?", "ctrl+?"],
     action: "keyup" as KeyEventName,
   },
-
-  // Modals
-  OpenFindKeysValuesModal: {
-    name: "Find keys or values",
-    group: "State",
+  // Timeline
+  ClearTimeline: {
+    name: "Clear Timeline",
+    group: "Timeline",
     sequences: ["command+k", "ctrl+k"],
     action: "keyup" as KeyEventName,
   },
+  // Modals
+  // TODO: What keybinding should this be set to?
+  // OpenFindKeysValuesModal: {
+  //   name: "Find keys or values",
+  //   group: "State",
+  //   sequences: ["command+k", "ctrl+k"],
+  //   action: "keyup" as KeyEventName,
+  // },
   OpenSubscriptionModal: {
     name: "Open Subscription modal",
     group: "State",
@@ -67,19 +81,11 @@ const keyMap = {
     sequences: ["command+s", "ctrl+s"],
     action: "keyup" as KeyEventName,
   },
-
-  // Miscellaneous
-  ToggleSidebar: {
-    name: "Toggle Sidebar",
-    group: "State",
-    sequences: ["command+shift+s", "ctrl+shift+s"],
-    action: "keyup" as KeyEventName,
-  },
 }
 
 function KeybindHandler({ children }) {
   const { toggleSideBar } = useContext(LayoutContext)
-  const { openDispatchModal, openSubscriptionModal } = useContext(ReactotronContext)
+  const { openDispatchModal, openSubscriptionModal, clearCommands } = useContext(ReactotronContext)
   const { createSnapshot } = useContext(StateContext)
 
   const handlers = {
@@ -104,9 +110,9 @@ function KeybindHandler({ children }) {
     },
 
     // Modals
-    OpenFindKeysValuesModal: () => {
-      throw new Error("Implement Me!")
-    },
+    // OpenFindKeysValuesModal: () => {
+    //   throw new Error("Implement Me!")
+    // },
     OpenSubscriptionModal: () => {
       openSubscriptionModal()
     },
@@ -120,6 +126,9 @@ function KeybindHandler({ children }) {
     // Miscellaneous
     ToggleSidebar: () => {
       toggleSideBar()
+    },
+    ClearTimeline: () => {
+      clearCommands()
     },
   }
 


### PR DESCRIPTION
- Adds a key mapping for `command+k` to clear the timeline
- Also did a quick rearrange of the help screen so it makes a little more sense

I was too lazy to figure out a way to show key presses in the video. So you'll just have to trust that I'm pressing `command+k`.

https://user-images.githubusercontent.com/1761434/222011823-b481eceb-168b-4240-ae2f-59893ee40fc9.mov

