### PR TITLE
Add "react-native" package.json entry

### DIFF
--- a/lib/reactotron-apisauce/package.json
+++ b/lib/reactotron-apisauce/package.json
@@ -12,10 +12,12 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "src"
   ],
   "main": "dist/index.js",
   "typings": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-core-client/package.json
+++ b/lib/reactotron-core-client/package.json
@@ -12,10 +12,12 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "src"
   ],
   "main": "dist/index.js",
   "typings": "dist/types/src/reactotron-core-client.d.ts",
+  "react-native": "src/reactotron-core-client.ts",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-core-server/package.json
+++ b/lib/reactotron-core-server/package.json
@@ -12,10 +12,12 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "src"
   ],
   "main": "dist/index.js",
   "typings": "dist/types/src/reactotron-core-server.d.ts",
+  "react-native": "src/reactotron-core-server.ts",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-core-ui/package.json
+++ b/lib/reactotron-core-ui/package.json
@@ -11,6 +11,7 @@
   "repository": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-core-ui",
   "main": "dist/index.js",
   "typings": "dist/types/index.d.ts",
+  "react-native": "src/index.ts",
   "scripts": {
     "start": "start-storybook -p 6006",
     "prebuild": "yarn clean",
@@ -32,7 +33,8 @@
     "format:write": "yarn format --write"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/lib/reactotron-mst/package.json
+++ b/lib/reactotron-mst/package.json
@@ -11,11 +11,13 @@
   "repository": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-mst",
   "files": [
     "dist",
-    "LICENSE"
+    "LICENSE",
+    "src"
   ],
   "main": "dist/reactotron-mst.umd.js",
   "module": "dist/reactotron-mst.es5.js",
   "typings": "dist/types/reactotron-mst.d.ts",
+  "react-native": "src/reactotron-mst.ts",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-react-js/package.json
+++ b/lib/reactotron-react-js/package.json
@@ -12,10 +12,12 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "src"
   ],
   "main": "dist/index.js",
   "types": "./dist/types/index.d.ts",
+  "react-native": "src/index.ts",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-react-native/package.json
+++ b/lib/reactotron-react-native/package.json
@@ -13,10 +13,12 @@
     "dist",
     "LICENSE",
     "README.md",
-    "reactotron-react-native.d.ts"
+    "reactotron-react-native.d.ts",
+    "src"
   ],
   "main": "dist/index.js",
   "types": "dist/types/src/reactotron-react-native.d.ts",
+  "react-native": "src/reactotron-react-native.ts",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-redux/package.json
+++ b/lib/reactotron-redux/package.json
@@ -13,10 +13,12 @@
     "dist",
     "LICENSE",
     "README.md",
-    "reactotron-redux.d.ts"
+    "reactotron-redux.d.ts",
+    "src"
   ],
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",
+  "react-native": "src/index.ts",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",


### PR DESCRIPTION
This PR adds `react-native` entry key and `src` to the files included in the published packages.

This will allow Metro to handle bundling the Typescript source files directly, which can allows Metro to offer better errors and include source maps.

Adding this to your metro config will tell Metro to prefer this entry point instead of `main`. 

<img width="750" alt="Screenshot 2023-04-20 at 4 38 38 PM" src="https://user-images.githubusercontent.com/37849890/233508378-a6226ed9-31a0-4054-b6df-b06df22e6284.png">


Example:

| Before | After |
|--------|--------|
| <img width="457" alt="Screenshot 2023-04-20 at 4 31 47 PM" src="https://user-images.githubusercontent.com/37849890/233507873-2f827ad0-2ec0-4aaa-90db-6551aa70016d.png">|<img width="447" alt="Screenshot 2023-04-20 at 4 33 43 PM" src="https://user-images.githubusercontent.com/37849890/233507898-ac226e17-527d-414d-93dd-3baa81f24bf7.png"> |