### PR TITLE
Fix logo on help screen

### DIFF
--- a/apps/reactotron-app/src/renderer/pages/help/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/help/index.tsx
@@ -11,9 +11,9 @@ import { FaTwitter as TwitterIcon } from "react-icons/fa"
 import { getApplicationKeyMap } from "react-hotkeys"
 
 import KeybindGroup from "./components/KeybindGroup"
+import { reactotronLogo } from "../../images"
 
 const projectJson = require("../../../../package.json")
-const logo = require("../../images/Reactotron-128.png")
 
 const Container = styled.div`
   display: flex;
@@ -113,7 +113,7 @@ function Help() {
       <Header title={`Using Reactotron ${projectJson.version}`} isDraggable />
       <HelpContainer>
         <LogoContainer>
-          <LogoImage src={logo} />
+          <LogoImage src={reactotronLogo} />
         </LogoContainer>
         <Title>Let&apos;s Connect!</Title>
         <ConnectContainer>


### PR DESCRIPTION
This PR fixes the reference to this image. Paired on this with @spacetoaststudios!

| Before | After |
|--------|--------|
| <img width="496" alt="Screenshot 2023-04-24 at 2 34 20 PM" src="https://user-images.githubusercontent.com/37849890/234121916-47e5f81d-96e6-4b5d-a36b-8e585d621f33.png"> | <img width="680" alt="Screenshot 2023-04-24 at 2 32 40 PM" src="https://user-images.githubusercontent.com/37849890/234121953-5785bfe6-5dad-4cbd-bd59-3caf864c7b64.png"> |

