### PR TITLE
Fix `trackGlobalError` plugin

### DIFF
--- a/lib/reactotron-core-ui/src/timelineCommands/BaseCommand.tsx
+++ b/lib/reactotron-core-ui/src/timelineCommands/BaseCommand.tsx
@@ -12,7 +12,7 @@ export interface TimelineCommandPropsEx<T> {
     type: string
   }
   copyToClipboard?: (text: string) => void
-  readFile?: (path: string) => void
+  readFile?: (path: string) => Promise<string>
   sendCommand?: (type: string, payload: any, clientId?: string) => void
   openDispatchDialog?: (action: string) => void
   dispatchAction?: (action: any) => void

--- a/lib/reactotron-core-ui/src/timelineCommands/LogCommand/LogCommand.story.tsx
+++ b/lib/reactotron-core-ui/src/timelineCommands/LogCommand/LogCommand.story.tsx
@@ -90,7 +90,7 @@ export const OpenWithObject = () => (
     })}
     isOpen
     setIsOpen={() => {}}
-    readFile={() => {}}
+    readFile={async () => ""}
   />
 )
 
@@ -158,7 +158,7 @@ export const OpenWithStackAndSource = () => (
     isOpen
     setIsOpen={() => {}}
     readFile={() =>
-      new Promise(resolve =>
+      new Promise((resolve) =>
         resolve(`
 module.exports = {
   test: true,

--- a/lib/reactotron-core-ui/src/timelineCommands/LogCommand/index.tsx
+++ b/lib/reactotron-core-ui/src/timelineCommands/LogCommand/index.tsx
@@ -17,24 +17,24 @@ const ErrorMessage = styled.div`
   padding: 20px 0 20px 10px;
   cursor: text;
   user-select: text;
-  color: ${props => props.theme.tag};
-  background-color: ${props => props.theme.backgroundDarker};
-  border-left: 1px solid ${props => props.theme.tag};
-  border-right: 1px solid ${props => props.theme.subtleLine};
-  border-top: 1px solid ${props => props.theme.subtleLine};
-  border-bottom: 1px solid ${props => props.theme.subtleLine};
+  color: ${(props) => props.theme.tag};
+  background-color: ${(props) => props.theme.backgroundDarker};
+  border-left: 1px solid ${(props) => props.theme.tag};
+  border-right: 1px solid ${(props) => props.theme.subtleLine};
+  border-top: 1px solid ${(props) => props.theme.subtleLine};
+  border-bottom: 1px solid ${(props) => props.theme.subtleLine};
 `
 
 const SourceContainer = styled.div`
   display: flex;
   flex-direction: column;
   padding-bottom: 10px;
-  color: ${props => props.theme.foreground};
+  color: ${(props) => props.theme.foreground};
 `
 const SourceFilename = styled.div`
   padding: 5px 0;
   margin-bottom: 5px;
-  color: ${props => props.theme.tag};
+  color: ${(props) => props.theme.tag};
 `
 interface SourceLineContainerProps {
   isSelected: boolean
@@ -43,17 +43,19 @@ const SourceLineContainer = styled.div<SourceLineContainerProps>`
   display: flex;
   padding: 6px 0;
   cursor: pointer;
-  color: ${props => (props.isSelected ? props.theme.tag : props.theme.foregroundDark)};
-  background-color: ${props => (props.isSelected ? props.theme.backgroundDarker : "transparent")};
-  border-left: ${props => (props.isSelected ? `1px solid ${props.theme.tag}` : undefined)};
-  border-right: ${props => (props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined)};
-  border-top: ${props => (props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined)};
-  border-bottom: ${props => (props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined)};
+  color: ${(props) => (props.isSelected ? props.theme.tag : props.theme.foregroundDark)};
+  background-color: ${(props) => (props.isSelected ? props.theme.backgroundDarker : "transparent")};
+  border-left: ${(props) => (props.isSelected ? `1px solid ${props.theme.tag}` : undefined)};
+  border-right: ${(props) =>
+    props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined};
+  border-top: ${(props) => (props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined)};
+  border-bottom: ${(props) =>
+    props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined};
 `
 const SourceLineNumber = styled.div`
   width: 60px;
   padding-right: 15px;
-  color: ${props => props.theme.constant};
+  color: ${(props) => props.theme.constant};
   text-align: right;
 `
 const SourceLineCode = styled.div`
@@ -70,8 +72,8 @@ const StackTitle = styled.div`
   padding-top: 5px;
   padding-bottom: 5px;
   margin-bottom: 5px;
-  color: ${props => props.theme.tag};
-  border-bottom: 1px solid ${props => props.theme.line};
+  color: ${(props) => props.theme.tag};
+  border-bottom: 1px solid ${(props) => props.theme.line};
 `
 const StackTable = styled.div`
   display: flex;
@@ -80,7 +82,7 @@ const StackTable = styled.div`
 const StackTableHeadRow = styled.div`
   display: flex;
   padding: 6px;
-  color: ${props => props.theme.foregroundDark};
+  color: ${(props) => props.theme.foregroundDark};
 `
 const StackTableHeaderFunction = styled.div`
   text-align: left;
@@ -100,15 +102,17 @@ const StackFrameContainer = styled.div<StackFrameContainerProps>`
   padding: 6px;
   word-break: break-all;
   /* cursor: pointer; */
-  opacity: ${props => (props.isNodeModule ? 0.4 : 1)};
+  opacity: ${(props) => (props.isNodeModule ? 0.4 : 1)};
   cursor: pointer;
 
-  color: ${props => (props.isSelected ? props.theme.tag : props.theme.foreground)};
-  background-color: ${props => (props.isSelected ? props.theme.backgroundDarker : "transparent")};
-  border-left: ${props => (props.isSelected ? `1px solid ${props.theme.tag}` : undefined)};
-  border-right: ${props => (props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined)};
-  border-top: ${props => (props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined)};
-  border-bottom: ${props => (props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined)};
+  color: ${(props) => (props.isSelected ? props.theme.tag : props.theme.foreground)};
+  background-color: ${(props) => (props.isSelected ? props.theme.backgroundDarker : "transparent")};
+  border-left: ${(props) => (props.isSelected ? `1px solid ${props.theme.tag}` : undefined)};
+  border-right: ${(props) =>
+    props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined};
+  border-top: ${(props) => (props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined)};
+  border-bottom: ${(props) =>
+    props.isSelected ? `1px solid ${props.theme.subtleLine}` : undefined};
 `
 const StackFrameFunction = styled.div`
   flex: 1;
@@ -118,11 +122,37 @@ const StackFrameFile = styled.div`
   word-break: break-all;
 `
 const StackFrameLineNumber = styled.div`
-  color: ${props => props.theme.constant};
+  color: ${(props) => props.theme.constant};
   word-break: break-all;
   width: 50px;
   text-align: right;
 `
+
+interface ErrorStack {
+  fileName: string
+  functionName: string
+  lineNumber: number
+  columnNumber?: number
+}
+
+const isErrorStack = (value: unknown): value is ErrorStack =>
+  value &&
+  typeof value === "object" &&
+  "fileName" in value &&
+  typeof value.fileName === "string" &&
+  "functionName" in value &&
+  typeof value.functionName === "string" &&
+  "lineNumber" in value &&
+  typeof value.lineNumber === "number"
+
+const isErrorStackArray = (value: unknown): value is ErrorStack[] =>
+  Array.isArray(value) && value.every(isErrorStack)
+
+interface ErrorLogPayload {
+  level: "error"
+  message: string
+  stack: Error["stack"] | string[] | ErrorStack[]
+}
 
 /** @see `lib/reactotron-core-client/src/plugins/logger.ts` */
 type LogPayload =
@@ -134,11 +164,7 @@ type LogPayload =
       level: "warn"
       message: string
     }
-  | {
-      level: "error"
-      message: string
-      stack: string | string[] | null
-    }
+  | ErrorLogPayload
 
 interface Props extends TimelineCommandProps<LogPayload> {}
 
@@ -189,7 +215,7 @@ function getPreview(message: any) {
 
     Object.keys(message)
       .slice(0, 5)
-      .forEach(key => (firstValues[key] = message[key]))
+      .forEach((key) => (firstValues[key] = message[key]))
 
     const preview = stringifyObject(firstValues, {
       transform: (obj, prop, originalResult) => {
@@ -215,14 +241,26 @@ function getPreview(message: any) {
   return message
 }
 
-function useFileSource(stack, readFile) {
-  const [sourceCode, setSourceCode] = useState(null)
+function useFileSource(stack: LogPayload, readFile: (path: string) => Promise<string>) {
+  const [sourceCode, setSourceCode] = useState<{
+    lines: {
+      isSelected: boolean
+      lineNumber: number
+      source: string
+    }[]
+    lineNumber: number
+    fileName: string
+    partialFilename: string
+  }>(null)
 
   useEffect(() => {
     if (!readFile) return
     if (!stack) return
+    if (stack.level !== "error") return
+    if (!stack.stack) return
     if (!stack.stack) return
     if (stack.stack.length === 0) return
+    if (typeof stack.stack[0] === "string") return
 
     const { fileName, lineNumber } = stack.stack[0]
     if (!fileName) return
@@ -233,7 +271,7 @@ function useFileSource(stack, readFile) {
       .join("/")
 
     readFile(fileName)
-      .then(source => {
+      .then((source) => {
         if (!source || typeof source !== "string") return
 
         try {
@@ -242,7 +280,7 @@ function useFileSource(stack, readFile) {
 
           const contents = source.split(/\n/g)
 
-          const sourceLines = contents.map(line => {
+          const sourceLines = contents.map((line) => {
             lineCounter = lineCounter + 1
 
             // Normalize indentation
@@ -282,8 +320,12 @@ function useFileSource(stack, readFile) {
   return sourceCode
 }
 
-function renderStackFrame(stackFrame, idx, openInEditor) {
-  let fileName = stackFrame.fileName || ""
+function renderStackFrame(
+  stackFrame: ErrorStack,
+  idx: number,
+  openInEditor: (file: string, lineNumber: number) => void
+) {
+  let fileName = stackFrame?.fileName || ""
   let functionName = stackFrame.functionName || ""
   const lineNumber = stackFrame.lineNumber || 0
 
@@ -322,7 +364,7 @@ const LogCommand: FunctionComponent<Props> = ({
 }) => {
   const { payload, date, deltaTime, important } = command
 
-  const openInEditor = (file, lineNumber) => {
+  const openInEditor = (file: string, lineNumber: number) => {
     if (file === "") return
 
     sendCommand("editor.open", {
@@ -333,6 +375,10 @@ const LogCommand: FunctionComponent<Props> = ({
 
   const source = useFileSource(payload, readFile)
   const toolbar = buildToolbar(payload, copyToClipboard)
+
+  useEffect(() => {
+    console.log(payload)
+  }, [payload])
 
   return (
     <TimelineCommand
@@ -352,7 +398,7 @@ const LogCommand: FunctionComponent<Props> = ({
           {source && (
             <SourceContainer>
               <SourceFilename>{source.partialFilename}</SourceFilename>
-              {source.lines.map(line => {
+              {source.lines.map((line) => {
                 return (
                   <SourceLineContainer
                     key={`${line.source}-${line.lineNumber}`}
@@ -376,11 +422,11 @@ const LogCommand: FunctionComponent<Props> = ({
                 <StackTableHeaderFunction>File</StackTableHeaderFunction>
                 <StackTableHeaderLineNumber>Line</StackTableHeaderLineNumber>
               </StackTableHeadRow>
-              {Array.isArray(payload.stack)
-                ? payload.stack
-                : [payload.stack].map((stackFrame, idx) => {
-                    return renderStackFrame(stackFrame, idx, openInEditor)
-                  })}
+              {isErrorStackArray(payload.stack)
+                ? payload.stack.map((stackFrame, idx) =>
+                    renderStackFrame(stackFrame, idx, openInEditor)
+                  )
+                : null}
             </StackTable>
           </StackContainer>
         </>

--- a/lib/reactotron-react-native/package.json
+++ b/lib/reactotron-react-native/package.json
@@ -47,6 +47,9 @@
   "optionalDependencies": {
     "react-native-flipper": "^0.164.0"
   },
+  "resolutions": {
+    "@types/react-native": "0.72.1"
+  },
   "devDependencies": {
     "@babel/core": "^7.21.0",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
@@ -56,7 +59,7 @@
     "@types/jest": "29.4.0",
     "@types/node": "16.11.11",
     "@types/react": "18.0.0",
-    "@types/react-native": "0.69.5",
+    "@types/react-native": "0.72.1",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.40.0",
     "babel-eslint": "^10.1.0",
@@ -72,7 +75,7 @@
     "npm-run-all": "4.1.5",
     "prettier": "^2.8.4",
     "react": ">=17.0.2",
-    "react-native": "0.69.5",
+    "react-native": "0.72.1",
     "react-native-flipper": "0.164.0",
     "rimraf": "4.1.3",
     "rollup": "2.60.2",

--- a/lib/reactotron-react-native/src/helpers/parseErrorStack.ts
+++ b/lib/reactotron-react-native/src/helpers/parseErrorStack.ts
@@ -1,0 +1,11 @@
+// eslint-disable-next-line import/namespace
+import type { StackFrame } from "react-native/Libraries/Core/NativeExceptionsManager"
+import type { HermesParsedStack } from "react-native/Libraries/Core/Devtools/parseHermesStack"
+
+// Fixing react-native/Libraries/Core/Devtools/symbolicateStackTrace
+// since the native type definitions are wrong lol
+
+/** @see https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/Libraries/Core/Devtools/parseErrorStack.js#L41-L57 */
+export type ParseErrorStackFn = <T extends any[]>(
+  errorStack?: string | T | HermesParsedStack
+) => Array<StackFrame>

--- a/lib/reactotron-react-native/src/helpers/symbolicateStackTrace.ts
+++ b/lib/reactotron-react-native/src/helpers/symbolicateStackTrace.ts
@@ -1,0 +1,25 @@
+// The actual type definitions are wrong, so we are fixing them lol
+// eslint-disable-next-line import/namespace
+import type { StackFrame } from "react-native/Libraries/Core/NativeExceptionsManager"
+
+/** @see https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/Libraries/Core/Devtools/symbolicateStackTrace.js#L17-L25 */
+export type CodeFrame = Readonly<{
+  content: string
+  location:
+    | {
+        row: number
+        column: number
+      }
+    | null
+    | undefined
+  fileName: string
+}>
+
+/** @see https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/Libraries/Core/Devtools/symbolicateStackTrace.js#L27-L30 */
+export type SymbolicatedStackTrace = Readonly<{
+  stack: Array<StackFrame>
+  codeFrame: CodeFrame | null | undefined
+}>
+
+/** @see https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/Libraries/Core/Devtools/symbolicateStackTrace.js#L32-L34 */
+export type SymbolicateStackTraceFn = (stack: Array<StackFrame>) => Promise<SymbolicatedStackTrace>

--- a/lib/reactotron-react-native/src/plugins/overlay/overlay.tsx
+++ b/lib/reactotron-react-native/src/plugins/overlay/overlay.tsx
@@ -8,6 +8,7 @@ import {
   ViewStyle,
   Text,
   TextStyle,
+  AnimatableNumericValue,
 } from "react-native"
 
 const Styles: {
@@ -53,7 +54,7 @@ interface Props {
 }
 
 interface State {
-  opacity: number
+  opacity: AnimatableNumericValue
   uri: string
   justifyContent:
     | "flex-start"

--- a/lib/reactotron-react-native/src/plugins/trackGlobalErrors.ts
+++ b/lib/reactotron-react-native/src/plugins/trackGlobalErrors.ts
@@ -3,11 +3,13 @@
  */
 import { NativeModules } from "react-native"
 import { Reactotron, ReactotronCore } from "reactotron-core-client"
+// eslint-disable-next-line import/default, import/namespace
+import LogBox from "react-native/Libraries/LogBox/LogBox"
 
 // a few functions to help source map errors -- these seem to be not available immediately
 // so we're lazy loading.
-let parseErrorStack
-let symbolicateStackTrace
+let parseErrorStack: typeof import("react-native/Libraries/Core/Devtools/parseErrorStack").default
+let symbolicateStackTrace: typeof import("react-native/Libraries/Core/Devtools/symbolicateStackTrace").default
 
 export interface TrackGlobalErrorsOptions {
   veto?: (frame: any) => boolean
@@ -21,97 +23,107 @@ const PLUGIN_DEFAULTS: TrackGlobalErrorsOptions = {
 // const reactNativeFrameFinder = frame => contains('/node_modules/react-native/', frame.fileName)
 
 // our plugin entry point
-export default <ReactotronSubtype = ReactotronCore>(options: TrackGlobalErrorsOptions) => (reactotron: Reactotron<ReactotronSubtype> & ReactotronSubtype) => {
-  // setup configuration
-  const config = Object.assign({}, PLUGIN_DEFAULTS, options || {})
+export default <ReactotronSubtype = ReactotronCore>(options: TrackGlobalErrorsOptions) =>
+  (reactotron: Reactotron<ReactotronSubtype> & ReactotronSubtype) => {
+    // setup configuration
+    const config = Object.assign({}, PLUGIN_DEFAULTS, options || {})
 
-  let swizzled = null
-  let isSwizzled = false
+    let swizzled = null
+    let isSwizzled = false
 
-  function reactotronExceptionHijacker(message, prettyStack, currentExceptionID) {
-    // do Facebook's stuff first
-    swizzled(message, prettyStack, currentExceptionID)
+    function reactotronExceptionHijacker(message, prettyStack, currentExceptionID) {
+      // do Facebook's stuff first
+      swizzled(message, prettyStack, currentExceptionID)
 
-    // then convert & transport it
-    try {
-      // rewrite the stack frames to be in the format we're expecting
-      let stack = prettyStack.map(frame => ({
-        functionName: frame.methodName === "<unknown>" ? null : frame.methodName,
-        lineNumber: frame.lineNumber,
-        columnNumber: frame.column,
-        fileName: frame.file,
-      }))
+      // then convert & transport it
+      try {
+        // rewrite the stack frames to be in the format we're expecting
+        let stack = prettyStack.map((frame) => ({
+          functionName: frame.methodName === "<unknown>" ? null : frame.methodName,
+          lineNumber: frame.lineNumber,
+          columnNumber: frame.column,
+          fileName: frame.file,
+        }))
 
-      // does the dev want us to keep each frame?
-      if (config.veto) {
-        stack = stack.filter(frame => config.veto(frame))
+        // does the dev want us to keep each frame?
+        if (config.veto) {
+          stack = stack.filter((frame) => config.veto(frame))
+        }
+
+        // throw it over to us
+        ;(reactotron as any).error(message, stack) // TODO: Fix this.
+      } catch (e) {
+        // TODO: no one must ever know our dark secrets
       }
-
-      // throw it over to us
-      (reactotron as any).error(message, stack) // TODO: Fix this.
-    } catch (e) {
-      // TODO: no one must ever know our dark secrets
     }
-  }
 
-  // here's how to swizzle
-  function trackGlobalErrors() {
-    if (isSwizzled) return
-    if (!NativeModules.ExceptionsManager) return
-    swizzled = NativeModules.ExceptionsManager.updateExceptionMessage
-    NativeModules.ExceptionsManager.updateExceptionMessage = reactotronExceptionHijacker
-    isSwizzled = true
-  }
+    // here's how to swizzle
+    function trackGlobalErrors() {
+      if (isSwizzled) return
+      if (!NativeModules.ExceptionsManager) return
+      swizzled = NativeModules.ExceptionsManager.updateExceptionMessage
+      NativeModules.ExceptionsManager.updateExceptionMessage = reactotronExceptionHijacker
+      isSwizzled = true
+    }
 
-  // restore the original
-  function untrackGlobalErrors() {
-    if (!swizzled) return
-    if (!NativeModules.ExceptionsManager) return
-    NativeModules.ExceptionsManager.updateExceptionMessage = swizzled
-    isSwizzled = false
-  }
+    // restore the original
+    function untrackGlobalErrors() {
+      if (!swizzled) return
+      if (!NativeModules.ExceptionsManager) return
+      NativeModules.ExceptionsManager.updateExceptionMessage = swizzled
+      isSwizzled = false
+    }
 
-  // auto start this
-  trackGlobalErrors()
+    // manually fire an error
+    function reportError(error: Parameters<typeof LogBox.addException>[0]) {
+      try {
+        parseErrorStack =
+          parseErrorStack || require("react-native/Libraries/Core/Devtools/parseErrorStack")
+        symbolicateStackTrace =
+          symbolicateStackTrace ||
+          require("react-native/Libraries/Core/Devtools/symbolicateStackTrace")
+        if (parseErrorStack && symbolicateStackTrace) {
+          const parsedStacktrace = parseErrorStack(error.stack)
+          symbolicateStackTrace(parsedStacktrace).then(function (res) {
+            let stack = res.stack.map(function (stackFrame) {
+              return {
+                fileName: stackFrame.file,
+                functionName: stackFrame.methodName,
+                lineNumber: stackFrame.lineNumber,
+              }
+            })
 
-  // manually fire an error
-  function reportError(error) {
-    try {
-      parseErrorStack =
-        parseErrorStack || require("react-native/Libraries/Core/Devtools/parseErrorStack")
-      symbolicateStackTrace =
-        symbolicateStackTrace ||
-        require("react-native/Libraries/Core/Devtools/symbolicateStackTrace")
-      if (parseErrorStack && symbolicateStackTrace) {
-        const parsedStacktrace = parseErrorStack(error)
+            // does the dev want us to keep each frame?
+            if (config.veto) {
+              stack = stack.filter(function (frame) {
+                return config.veto(frame)
+              })
+            }
+            reactotron.error(error.message, stack) // TODO: Fix this.
+          })
+        }
+      } catch (e) {
+        // nothing happened. move along.
+      }
+    }
 
-        symbolicateStackTrace(parsedStacktrace).then(goodStack => {
-          let stack = goodStack.map(stackFrame => ({
-            fileName: stackFrame.file,
-            functionName: stackFrame.methodName,
-            lineNumber: stackFrame.lineNumber,
-          }))
-
-          // does the dev want us to keep each frame?
-          if (config.veto) {
-            stack = stack.filter(frame => config.veto(frame))
-          }
-
-          (reactotron as any).error(error.message, stack) // TODO: Fix this.
+    // the reactotron plugin interface
+    return {
+      onConnect: () => {
+        LogBox.addException = new Proxy(LogBox.addException, {
+          apply: function (target, thisArg, argumentsList: Parameters<typeof LogBox.addException>) {
+            const error = argumentsList[0]
+            reportError(error)
+            return target.apply(thisArg, argumentsList)
+          },
         })
-      }
-    } catch (e) {
-      // nothing happened. move along.
+      },
+
+      // attach these functions to the Reactotron
+      features: {
+        reportError,
+        trackGlobalErrors,
+        untrackGlobalErrors,
+      },
     }
   }
-
-  // the reactotron plugin interface
-  return {
-    // attach these functions to the Reactotron
-    features: {
-      reportError,
-      trackGlobalErrors,
-      untrackGlobalErrors,
-    },
-  }
-}

--- a/lib/reactotron-react-native/src/plugins/trackGlobalErrors.ts
+++ b/lib/reactotron-react-native/src/plugins/trackGlobalErrors.ts
@@ -10,14 +10,14 @@ import {
 // eslint-disable-next-line import/namespace
 import type { ExtendedExceptionData } from "react-native/Libraries/LogBox/Data/parseLogBoxLog"
 
-interface LogboxStaticPrivate extends LogBoxStaticPublic {
+interface LogBoxStaticPrivate extends LogBoxStaticPublic {
   /**
    * @see https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/Libraries/LogBox/LogBox.js#L29
    */
   addException: (error: ExtendedExceptionData) => void
 }
 
-const LogBox = _LogBox as unknown as LogboxStaticPrivate
+const LogBox = _LogBox as unknown as LogBoxStaticPrivate
 
 // a few functions to help source map errors -- these seem to be not available immediately
 // so we're lazy loading.

--- a/lib/reactotron-react-native/src/plugins/trackGlobalErrors.ts
+++ b/lib/reactotron-react-native/src/plugins/trackGlobalErrors.ts
@@ -24,8 +24,15 @@ const LogBox = _LogBox as unknown as LogBoxStaticPrivate
 let parseErrorStack: typeof import("react-native/Libraries/Core/Devtools/parseErrorStack").default
 let symbolicateStackTrace: typeof import("react-native/Libraries/Core/Devtools/symbolicateStackTrace").default
 
+export interface ErrorStackFrame {
+  fileName: string
+  functionName: string
+  lineNumber: number
+  columnNumber: number | null
+}
+
 export interface TrackGlobalErrorsOptions {
-  veto?: (frame: any) => boolean
+  veto?: (frame: ErrorStackFrame) => boolean
 }
 
 // defaults
@@ -58,6 +65,7 @@ export default <ReactotronSubtype = ReactotronCore>(options: TrackGlobalErrorsOp
                 fileName: stackFrame.file,
                 functionName: stackFrame.methodName,
                 lineNumber: stackFrame.lineNumber,
+                columnNumber: stackFrame?.column,
               }
             })
 

--- a/lib/reactotron-react-native/src/plugins/trackGlobalErrors.ts
+++ b/lib/reactotron-react-native/src/plugins/trackGlobalErrors.ts
@@ -50,7 +50,7 @@ export default <ReactotronSubtype = ReactotronCore>(options: TrackGlobalErrorsOp
           symbolicateStackTrace ||
           require("react-native/Libraries/Core/Devtools/symbolicateStackTrace")
         if (parseErrorStack && symbolicateStackTrace) {
-          // @ts-expect-error parseErrorStack arg type is wrong, it's expecting an array, a string, or a hermes error data, https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/Libraries/Core/Devtools/parseErrorStack.js#L41
+          // parseErrorStack arg type is wrong, it's expecting an array, a string, or a hermes error data, https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/Libraries/Core/Devtools/parseErrorStack.js#L41
           const parsedStacktrace = parseErrorStack(error.stack)
           symbolicateStackTrace(parsedStacktrace).then(function (stackFrames) {
             let prettyStackFrames = stackFrames.map(function (stackFrame) {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,17 +10,12 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es2017", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
-    "paths": {}
+    "paths": {},
+    "typeRoots": ["node_modules/@types", "types"]
   },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp"]
 }

--- a/types/react-native/Libraries/Core/Devtools/parseHermesStack.d.ts
+++ b/types/react-native/Libraries/Core/Devtools/parseHermesStack.d.ts
@@ -1,0 +1,47 @@
+declare module "react-native/Libraries/Core/Devtools/parseHermesStack" {
+  type HermesStackLocationNative = Readonly<{
+    type: "NATIVE";
+  }>;
+  type HermesStackLocationSource = Readonly<{
+    type: "SOURCE";
+    sourceUrl: string;
+    line1Based: number;
+    column1Based: number;
+  }>;
+  type HermesStackLocationInternalBytecode = Readonly<{
+    type: "INTERNAL_BYTECODE";
+    sourceUrl: string;
+    line1Based: number;
+    virtualOffset0Based: number;
+  }>;
+  type HermesStackLocationBytecode = Readonly<{
+    type: "BYTECODE";
+    sourceUrl: string;
+    line1Based: number;
+    virtualOffset0Based: number;
+  }>;
+  type HermesStackLocation =
+    | HermesStackLocationNative
+    | HermesStackLocationSource
+    | HermesStackLocationInternalBytecode
+    | HermesStackLocationBytecode;
+  type HermesStackEntryFrame = Readonly<{
+    type: "FRAME";
+    location: HermesStackLocation;
+    functionName: string;
+  }>;
+  type HermesStackEntrySkipped = Readonly<{
+    type: "SKIPPED";
+    count: number;
+  }>;
+  type HermesStackEntry = HermesStackEntryFrame | HermesStackEntrySkipped;
+
+  export type HermesParsedStack = Readonly<{
+    message: string;
+    entries: ReadonlyArray<HermesStackEntry>;
+  }>;
+
+  function parseHermesStack(stack: string): HermesParsedStack;
+
+  export default parseHermesStack;
+}

--- a/types/react-native/Libraries/Core/NativeExceptionsManager.d.ts
+++ b/types/react-native/Libraries/Core/NativeExceptionsManager.d.ts
@@ -1,6 +1,6 @@
 declare module "react-native/Libraries/Core/NativeExceptionsManager" {
   /**
-   * @see https://github.com/facebook/react-native/blob/330639f74018cfeda28e74c6dae8110d97603860/packages/react-native/Libraries/Core/NativeExceptionsManager.js#L17-L24
+   * @see https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/Libraries/Core/NativeExceptionsManager.js#L17-L23
    */
   export interface StackFrame {
     column?: number;
@@ -10,7 +10,7 @@ declare module "react-native/Libraries/Core/NativeExceptionsManager" {
     collapse?: boolean;
   }
   /**
-   * @see https://github.com/facebook/react-native/blob/330639f74018cfeda28e74c6dae8110d97603860/packages/react-native/Libraries/Core/NativeExceptionsManager.js#L24-L35
+   * @see https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/Libraries/Core/NativeExceptionsManager.js#L24-L35
    */
   export interface ExceptionData {
     message: string;

--- a/types/react-native/Libraries/Core/NativeExceptionsManager.d.ts
+++ b/types/react-native/Libraries/Core/NativeExceptionsManager.d.ts
@@ -1,0 +1,25 @@
+declare module "react-native/Libraries/Core/NativeExceptionsManager" {
+  /**
+   * @see https://github.com/facebook/react-native/blob/330639f74018cfeda28e74c6dae8110d97603860/packages/react-native/Libraries/Core/NativeExceptionsManager.js#L17-L24
+   */
+  export interface StackFrame {
+    column?: number;
+    file?: string;
+    lineNumber?: number;
+    methodName: string;
+    collapse?: boolean;
+  }
+  /**
+   * @see https://github.com/facebook/react-native/blob/330639f74018cfeda28e74c6dae8110d97603860/packages/react-native/Libraries/Core/NativeExceptionsManager.js#L24-L35
+   */
+  export interface ExceptionData {
+    message: string;
+    originalMessage?: string;
+    name?: string;
+    componentStack?: string;
+    stack: Array<StackFrame>;
+    id: number;
+    isFatal: boolean;
+    extraData?: object;
+  }
+}

--- a/types/react-native/Libraries/LogBox/Data/parseLogBoxLog.d.ts
+++ b/types/react-native/Libraries/LogBox/Data/parseLogBoxLog.d.ts
@@ -1,7 +1,7 @@
 declare module "react-native/Libraries/LogBox/Data/parseLogBoxLog" {
   import type { ExceptionData } from "react-native/Libraries/Core/NativeExceptionsManager";
   /**
-   * @see https://github.com/facebook/react-native/blob/330639f74018cfeda28e74c6dae8110d97603860/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js#L52-L56
+   * @see https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js#L26-L29
    */
   export interface ExtendedExceptionData extends ExceptionData {
     isComponentError: boolean;

--- a/types/react-native/Libraries/LogBox/Data/parseLogBoxLog.d.ts
+++ b/types/react-native/Libraries/LogBox/Data/parseLogBoxLog.d.ts
@@ -1,0 +1,9 @@
+declare module "react-native/Libraries/LogBox/Data/parseLogBoxLog" {
+  import type { ExceptionData } from "react-native/Libraries/Core/NativeExceptionsManager";
+  /**
+   * @see https://github.com/facebook/react-native/blob/330639f74018cfeda28e74c6dae8110d97603860/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js#L52-L56
+   */
+  export interface ExtendedExceptionData extends ExceptionData {
+    isComponentError: boolean;
+  }
+}

--- a/types/react-native/Libraries/LogBox/LogBox.d.ts
+++ b/types/react-native/Libraries/LogBox/LogBox.d.ts
@@ -1,0 +1,12 @@
+declare module "react-native/Libraries/LogBox/LogBox" {
+  import type { ExtendedExceptionData } from "react-native/Libraries/LogBox/Data/parseLogBoxLog";
+  /**
+   * @see https://github.com/facebook/react-native/blob/330639f74018cfeda28e74c6dae8110d97603860/packages/react-native/Libraries/LogBox/LogBox.js#L21-L22
+   */
+  interface ILogBox {
+    addException: (error: ExtendedExceptionData) => void;
+  }
+
+  const LogBox: ILogBox;
+  export default LogBox;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,6 +58,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/code-frame@npm:7.22.5"
+  dependencies:
+    "@babel/highlight": ^7.22.5
+  checksum: cfe804f518f53faaf9a1d3e0f9f74127ab9a004912c3a16fda07fb6a633393ecb9918a053cb71804204c1b7ec3d49e1699604715e2cfb0c9f7bc4933d324ebb6
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.16.4":
   version: 7.21.0
   resolution: "@babel/compat-data@npm:7.21.0"
@@ -69,6 +78,13 @@ __metadata:
   version: 7.20.14
   resolution: "@babel/compat-data@npm:7.20.14"
   checksum: 6c9efe36232094e4ad0b70d165587f21ca718e5d011f7a52a77a18502a7524e90e2855aa5a2e086395bcfd21bd2c7c99128dcd8d9fdffe94316b72acf5c66f2c
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/compat-data@npm:7.22.5"
+  checksum: eb1a47ebf79ae268b4a16903e977be52629339806e248455eb9973897c503a04b701f36a9de64e19750d6e081d0561e77a514c8dc470babbeba59ae94298ed18
   languageName: node
   linkType: hard
 
@@ -95,7 +111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.0.0, @babel/core@npm:^7.1.0, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.14.0, @babel/core@npm:^7.3.3, @babel/core@npm:^7.4.5, @babel/core@npm:^7.7.5, @babel/core@npm:^7.8.7, @babel/core@npm:^7.9.0":
+"@babel/core@npm:^7.0.0, @babel/core@npm:^7.1.0, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.3.3, @babel/core@npm:^7.4.5, @babel/core@npm:^7.7.5, @babel/core@npm:^7.8.7, @babel/core@npm:^7.9.0":
   version: 7.20.12
   resolution: "@babel/core@npm:7.20.12"
   dependencies:
@@ -115,6 +131,29 @@ __metadata:
     json5: ^2.2.2
     semver: ^6.3.0
   checksum: 62e6c3e2149a70b5c9729ef5f0d3e2e97e9dcde89fc039c8d8e3463d5d7ba9b29ee84d10faf79b61532ac1645aa62f2bd42338320617e6e3a8a4d8e2a27076e7
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.20.0":
+  version: 7.22.5
+  resolution: "@babel/core@npm:7.22.5"
+  dependencies:
+    "@ampproject/remapping": ^2.2.0
+    "@babel/code-frame": ^7.22.5
+    "@babel/generator": ^7.22.5
+    "@babel/helper-compilation-targets": ^7.22.5
+    "@babel/helper-module-transforms": ^7.22.5
+    "@babel/helpers": ^7.22.5
+    "@babel/parser": ^7.22.5
+    "@babel/template": ^7.22.5
+    "@babel/traverse": ^7.22.5
+    "@babel/types": ^7.22.5
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.2.2
+    semver: ^6.3.0
+  checksum: 173ae426958c90c7bbd7de622c6f13fcab8aef0fac3f138e2d47bc466d1cd1f86f71ca82ae0acb9032fd8794abed8efb56fea55c031396337eaec0d673b69d56
   languageName: node
   linkType: hard
 
@@ -155,7 +194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.12.11, @babel/generator@npm:^7.14.0, @babel/generator@npm:^7.20.7, @babel/generator@npm:^7.7.2":
+"@babel/generator@npm:^7.12.11, @babel/generator@npm:^7.20.7, @babel/generator@npm:^7.7.2":
   version: 7.20.14
   resolution: "@babel/generator@npm:7.20.14"
   dependencies:
@@ -178,6 +217,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.20.0, @babel/generator@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/generator@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+    "@jridgewell/gen-mapping": ^0.3.2
+    "@jridgewell/trace-mapping": ^0.3.17
+    jsesc: ^2.5.1
+  checksum: efa64da70ca88fe69f05520cf5feed6eba6d30a85d32237671488cc355fdc379fe2c3246382a861d49574c4c2f82a317584f8811e95eb024e365faff3232b49d
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.21.0, @babel/generator@npm:^7.21.1":
   version: 7.21.1
   resolution: "@babel/generator@npm:7.21.1"
@@ -196,6 +247,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.18.6
   checksum: 88ccd15ced475ef2243fdd3b2916a29ea54c5db3cd0cfabf9d1d29ff6e63b7f7cd1c27264137d7a40ac2e978b9b9a542c332e78f40eb72abe737a7400788fc1b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-annotate-as-pure@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-annotate-as-pure@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: 53da330f1835c46f26b7bf4da31f7a496dee9fd8696cca12366b94ba19d97421ce519a74a837f687749318f94d1a37f8d1abcbf35e8ed22c32d16373b2f6198d
   languageName: node
   linkType: hard
 
@@ -221,6 +281,21 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 8c32c873ba86e2e1805b30e0807abd07188acbe00ebb97576f0b09061cc65007f1312b589eccb4349c5a8c7f8bb9f2ab199d41da7030bf103d9f347dcd3a3cf4
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-compilation-targets@npm:7.22.5"
+  dependencies:
+    "@babel/compat-data": ^7.22.5
+    "@babel/helper-validator-option": ^7.22.5
+    browserslist: ^4.21.3
+    lru-cache: ^5.1.1
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: a479460615acffa0f4fd0a29b740eafb53a93694265207d23a6038ccd18d183a382cacca515e77b7c9b042c3ba80b0aca0da5f1f62215140e81660d2cf721b68
   languageName: node
   linkType: hard
 
@@ -295,6 +370,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-environment-visitor@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-environment-visitor@npm:7.22.5"
+  checksum: 248532077d732a34cd0844eb7b078ff917c3a8ec81a7f133593f71a860a582f05b60f818dc5049c2212e5baa12289c27889a4b81d56ef409b4863db49646c4b1
+  languageName: node
+  linkType: hard
+
 "@babel/helper-explode-assignable-expression@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-explode-assignable-expression@npm:7.18.6"
@@ -324,12 +406,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-function-name@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-function-name@npm:7.22.5"
+  dependencies:
+    "@babel/template": ^7.22.5
+    "@babel/types": ^7.22.5
+  checksum: 6b1f6ce1b1f4e513bf2c8385a557ea0dd7fa37971b9002ad19268ca4384bbe90c09681fe4c076013f33deabc63a53b341ed91e792de741b4b35e01c00238177a
+  languageName: node
+  linkType: hard
+
 "@babel/helper-hoist-variables@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-hoist-variables@npm:7.18.6"
   dependencies:
     "@babel/types": ^7.18.6
   checksum: fd9c35bb435fda802bf9ff7b6f2df06308a21277c6dec2120a35b09f9de68f68a33972e2c15505c1a1a04b36ec64c9ace97d4a9e26d6097b76b4396b7c5fa20f
+  languageName: node
+  linkType: hard
+
+"@babel/helper-hoist-variables@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-hoist-variables@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: 394ca191b4ac908a76e7c50ab52102669efe3a1c277033e49467913c7ed6f7c64d7eacbeabf3bed39ea1f41731e22993f763b1edce0f74ff8563fd1f380d92cc
   languageName: node
   linkType: hard
 
@@ -367,6 +468,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.18.6
   checksum: f393f8a3b3304b1b7a288a38c10989de754f01d29caf62ce7c4e5835daf0a27b81f3ac687d9d2780d39685aae7b55267324b512150e7b2be967b0c493b6a1def
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-module-imports@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: 9ac2b0404fa38b80bdf2653fbeaf8e8a43ccb41bd505f9741d820ed95d3c4e037c62a1bcdcb6c9527d7798d2e595924c4d025daed73283badc180ada2c9c49ad
   languageName: node
   linkType: hard
 
@@ -418,6 +528,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-transforms@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-module-transforms@npm:7.22.5"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.22.5
+    "@babel/helper-module-imports": ^7.22.5
+    "@babel/helper-simple-access": ^7.22.5
+    "@babel/helper-split-export-declaration": ^7.22.5
+    "@babel/helper-validator-identifier": ^7.22.5
+    "@babel/template": ^7.22.5
+    "@babel/traverse": ^7.22.5
+    "@babel/types": ^7.22.5
+  checksum: 8985dc0d971fd17c467e8b84fe0f50f3dd8610e33b6c86e5b3ca8e8859f9448bcc5c84e08a2a14285ef388351c0484797081c8f05a03770bf44fc27bf4900e68
+  languageName: node
+  linkType: hard
+
 "@babel/helper-optimise-call-expression@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-optimise-call-expression@npm:7.18.6"
@@ -434,6 +560,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-plugin-utils@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-plugin-utils@npm:7.22.5"
+  checksum: c0fc7227076b6041acd2f0e818145d2e8c41968cc52fb5ca70eed48e21b8fe6dd88a0a91cbddf4951e33647336eb5ae184747ca706817ca3bef5e9e905151ff5
+  languageName: node
+  linkType: hard
+
 "@babel/helper-remap-async-to-generator@npm:^7.18.9":
   version: 7.18.9
   resolution: "@babel/helper-remap-async-to-generator@npm:7.18.9"
@@ -445,6 +578,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 4be6076192308671b046245899b703ba090dbe7ad03e0bea897bb2944ae5b88e5e85853c9d1f83f643474b54c578d8ac0800b80341a86e8538264a725fbbefec
+  languageName: node
+  linkType: hard
+
+"@babel/helper-remap-async-to-generator@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-remap-async-to-generator@npm:7.22.5"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.22.5
+    "@babel/helper-environment-visitor": ^7.22.5
+    "@babel/helper-wrap-function": ^7.22.5
+    "@babel/types": ^7.22.5
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 1e51dcff1c22e97ea3d22034b77788048eb6d8c6860325bd7a1046b7a7135730cefd93b5c96fd9839d76031095d5ffb6f0cd6ee90a5d69a4c7de980d7f4623d9
   languageName: node
   linkType: hard
 
@@ -471,6 +618,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-simple-access@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-simple-access@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: fe9686714caf7d70aedb46c3cce090f8b915b206e09225f1e4dbc416786c2fdbbee40b38b23c268b7ccef749dd2db35f255338fb4f2444429874d900dede5ad2
+  languageName: node
+  linkType: hard
+
 "@babel/helper-skip-transparent-expression-wrappers@npm:^7.20.0":
   version: 7.20.0
   resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.20.0"
@@ -489,6 +645,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-split-export-declaration@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-split-export-declaration@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: d10e05a02f49c1f7c578cea63d2ac55356501bbf58856d97ac9bfde4957faee21ae97c7f566aa309e38a256eef58b58e5b670a7f568b362c00e93dfffe072650
+  languageName: node
+  linkType: hard
+
 "@babel/helper-string-parser@npm:^7.19.4":
   version: 7.19.4
   resolution: "@babel/helper-string-parser@npm:7.19.4"
@@ -496,10 +661,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-string-parser@npm:7.22.5"
+  checksum: 836851ca5ec813077bbb303acc992d75a360267aa3b5de7134d220411c852a6f17de7c0d0b8c8dcc0f567f67874c00f4528672b2a4f1bc978a3ada64c8c78467
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.18.6, @babel/helper-validator-identifier@npm:^7.19.1":
   version: 7.19.1
   resolution: "@babel/helper-validator-identifier@npm:7.19.1"
   checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-validator-identifier@npm:7.22.5"
+  checksum: 7f0f30113474a28298c12161763b49de5018732290ca4de13cdaefd4fd0d635a6fe3f6686c37a02905fb1e64f21a5ee2b55140cf7b070e729f1bd66866506aea
   languageName: node
   linkType: hard
 
@@ -517,6 +696,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-option@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-validator-option@npm:7.22.5"
+  checksum: bbeca8a85ee86990215c0424997438b388b8d642d69b9f86c375a174d3cdeb270efafd1ff128bc7a1d370923d13b6e45829ba8581c027620e83e3a80c5c414b3
+  languageName: node
+  linkType: hard
+
 "@babel/helper-wrap-function@npm:^7.18.9":
   version: 7.20.5
   resolution: "@babel/helper-wrap-function@npm:7.20.5"
@@ -526,6 +712,18 @@ __metadata:
     "@babel/traverse": ^7.20.5
     "@babel/types": ^7.20.5
   checksum: 11a6fc28334368a193a9cb3ad16f29cd7603bab958433efc82ebe59fa6556c227faa24f07ce43983f7a85df826f71d441638442c4315e90a554fe0a70ca5005b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-wrap-function@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-wrap-function@npm:7.22.5"
+  dependencies:
+    "@babel/helper-function-name": ^7.22.5
+    "@babel/template": ^7.22.5
+    "@babel/traverse": ^7.22.5
+    "@babel/types": ^7.22.5
+  checksum: a4ba2d7577ad3ce92fadaa341ffce3b0e4b389808099b07c80847f9be0852f4b42344612bc1b3d1b796ffb75be56d5957c5c56a1734f6aee5ccbb7cd9ab12691
   languageName: node
   linkType: hard
 
@@ -551,6 +749,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helpers@npm:7.22.5"
+  dependencies:
+    "@babel/template": ^7.22.5
+    "@babel/traverse": ^7.22.5
+    "@babel/types": ^7.22.5
+  checksum: a96e785029dff72f171190943df895ab0f76e17bf3881efd630bc5fae91215042d1c2e9ed730e8e4adf4da6f28b24bd1f54ed93b90ffbca34c197351872a084e
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.0.0, @babel/highlight@npm:^7.10.4, @babel/highlight@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/highlight@npm:7.18.6"
@@ -562,7 +771,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.13, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.7.0":
+"@babel/highlight@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/highlight@npm:7.22.5"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.22.5
+    chalk: ^2.0.0
+    js-tokens: ^4.0.0
+  checksum: f61ae6de6ee0ea8d9b5bcf2a532faec5ab0a1dc0f7c640e5047fc61630a0edb88b18d8c92eb06566d30da7a27db841aca11820ecd3ebe9ce514c9350fbed39c4
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.13, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.7.0":
   version: 7.20.15
   resolution: "@babel/parser@npm:7.20.15"
   bin:
@@ -577,6 +797,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: a71e6456a1260c2a943736b56cc0acdf5f2a53c6c79e545f56618967e51f9b710d1d3359264e7c979313a7153741b1d95ad8860834cc2ab4ce4f428b13cc07be
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.20.0, @babel/parser@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/parser@npm:7.22.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 470ebba516417ce8683b36e2eddd56dcfecb32c54b9bb507e28eb76b30d1c3e618fd0cfeee1f64d8357c2254514e1a19e32885cfb4e73149f4ae875436a6d59c
   languageName: node
   linkType: hard
 
@@ -648,7 +877,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-class-properties@npm:^7.0.0, @babel/plugin-proposal-class-properties@npm:^7.12.1, @babel/plugin-proposal-class-properties@npm:^7.13.0, @babel/plugin-proposal-class-properties@npm:^7.16.0, @babel/plugin-proposal-class-properties@npm:^7.18.6, @babel/plugin-proposal-class-properties@npm:^7.3.3, @babel/plugin-proposal-class-properties@npm:^7.7.0":
+"@babel/plugin-proposal-class-properties@npm:^7.0.0, @babel/plugin-proposal-class-properties@npm:^7.12.1, @babel/plugin-proposal-class-properties@npm:^7.13.0, @babel/plugin-proposal-class-properties@npm:^7.16.0, @babel/plugin-proposal-class-properties@npm:^7.18.0, @babel/plugin-proposal-class-properties@npm:^7.18.6, @babel/plugin-proposal-class-properties@npm:^7.3.3, @babel/plugin-proposal-class-properties@npm:^7.7.0":
   version: 7.18.6
   resolution: "@babel/plugin-proposal-class-properties@npm:7.18.6"
   dependencies:
@@ -761,7 +990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-nullish-coalescing-operator@npm:^7.0.0, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.12.1, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.13.8, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.16.0, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.18.6":
+"@babel/plugin-proposal-nullish-coalescing-operator@npm:^7.12.1, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.13.8, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.16.0, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.18.0, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-proposal-nullish-coalescing-operator@npm:7.18.6"
   dependencies:
@@ -773,7 +1002,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-numeric-separator@npm:^7.16.0, @babel/plugin-proposal-numeric-separator@npm:^7.18.6":
+"@babel/plugin-proposal-numeric-separator@npm:^7.0.0, @babel/plugin-proposal-numeric-separator@npm:^7.16.0, @babel/plugin-proposal-numeric-separator@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-proposal-numeric-separator@npm:7.18.6"
   dependencies:
@@ -785,7 +1014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-object-rest-spread@npm:^7.0.0, @babel/plugin-proposal-object-rest-spread@npm:^7.12.1, @babel/plugin-proposal-object-rest-spread@npm:^7.16.0, @babel/plugin-proposal-object-rest-spread@npm:^7.20.2, @babel/plugin-proposal-object-rest-spread@npm:^7.6.2":
+"@babel/plugin-proposal-object-rest-spread@npm:^7.0.0, @babel/plugin-proposal-object-rest-spread@npm:^7.12.1, @babel/plugin-proposal-object-rest-spread@npm:^7.16.0, @babel/plugin-proposal-object-rest-spread@npm:^7.20.0, @babel/plugin-proposal-object-rest-spread@npm:^7.20.2, @babel/plugin-proposal-object-rest-spread@npm:^7.6.2":
   version: 7.20.7
   resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.20.7"
   dependencies:
@@ -812,7 +1041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-optional-chaining@npm:^7.0.0, @babel/plugin-proposal-optional-chaining@npm:^7.12.1, @babel/plugin-proposal-optional-chaining@npm:^7.13.12, @babel/plugin-proposal-optional-chaining@npm:^7.18.9, @babel/plugin-proposal-optional-chaining@npm:^7.20.7":
+"@babel/plugin-proposal-optional-chaining@npm:^7.12.1, @babel/plugin-proposal-optional-chaining@npm:^7.13.12, @babel/plugin-proposal-optional-chaining@npm:^7.18.9, @babel/plugin-proposal-optional-chaining@npm:^7.20.7":
   version: 7.20.7
   resolution: "@babel/plugin-proposal-optional-chaining@npm:7.20.7"
   dependencies:
@@ -825,7 +1054,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-optional-chaining@npm:^7.16.0":
+"@babel/plugin-proposal-optional-chaining@npm:^7.16.0, @babel/plugin-proposal-optional-chaining@npm:^7.20.0":
   version: 7.21.0
   resolution: "@babel/plugin-proposal-optional-chaining@npm:7.21.0"
   dependencies:
@@ -945,7 +1174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-dynamic-import@npm:^7.0.0, @babel/plugin-syntax-dynamic-import@npm:^7.2.0, @babel/plugin-syntax-dynamic-import@npm:^7.8.3":
+"@babel/plugin-syntax-dynamic-import@npm:^7.2.0, @babel/plugin-syntax-dynamic-import@npm:^7.8.0, @babel/plugin-syntax-dynamic-import@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/plugin-syntax-dynamic-import@npm:7.8.3"
   dependencies:
@@ -978,7 +1207,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-flow@npm:^7.0.0, @babel/plugin-syntax-flow@npm:^7.18.6, @babel/plugin-syntax-flow@npm:^7.2.0":
+"@babel/plugin-syntax-flow@npm:^7.0.0, @babel/plugin-syntax-flow@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-syntax-flow@npm:7.18.6"
   dependencies:
@@ -986,6 +1215,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: abe82062b3eef14de7d2b3c0e4fecf80a3e796ca497e9df616d12dd250968abf71495ee85a955b43a6c827137203f0c409450cf792732ed0d6907c806580ea71
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-flow@npm:^7.12.1, @babel/plugin-syntax-flow@npm:^7.18.0, @babel/plugin-syntax-flow@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/plugin-syntax-flow@npm:7.22.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.22.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 84c8c40fcfe8e78cecdd6fb90e8f97f419e3f3b27a33de8324ae97d5ce1b87cdd98a636fa21a68d4d2c37c7d63f3a279bb84b6956b849921affed6b806b6ffe7
   languageName: node
   linkType: hard
 
@@ -1143,7 +1383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-async-to-generator@npm:^7.0.0, @babel/plugin-transform-async-to-generator@npm:^7.16.0, @babel/plugin-transform-async-to-generator@npm:^7.18.6":
+"@babel/plugin-transform-async-to-generator@npm:^7.16.0, @babel/plugin-transform-async-to-generator@npm:^7.18.6":
   version: 7.20.7
   resolution: "@babel/plugin-transform-async-to-generator@npm:7.20.7"
   dependencies:
@@ -1153,6 +1393,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: fe9ee8a5471b4317c1b9ea92410ace8126b52a600d7cfbfe1920dcac6fb0fad647d2e08beb4fd03c630eb54430e6c72db11e283e3eddc49615c68abd39430904
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-async-to-generator@npm:^7.20.0":
+  version: 7.22.5
+  resolution: "@babel/plugin-transform-async-to-generator@npm:7.22.5"
+  dependencies:
+    "@babel/helper-module-imports": ^7.22.5
+    "@babel/helper-plugin-utils": ^7.22.5
+    "@babel/helper-remap-async-to-generator": ^7.22.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b95f23f99dcb379a9f0a1c2a3bbea3f8dc0e1b16dc1ac8b484fe378370169290a7a63d520959a9ba1232837cf74a80e23f6facbe14fd42a3cda6d3c2d7168e62
   languageName: node
   linkType: hard
 
@@ -1261,6 +1514,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-destructuring@npm:^7.20.0":
+  version: 7.22.5
+  resolution: "@babel/plugin-transform-destructuring@npm:7.22.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.22.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 76f6ea2aee1fcfa1c3791eb7a5b89703c6472650b993e8666fff0f1d6e9d737a84134edf89f63c92297f3e75064c1263219463b02dd9bc7434b6e5b9935e3f20
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-dotall-regex@npm:^7.16.0, @babel/plugin-transform-dotall-regex@npm:^7.18.6, @babel/plugin-transform-dotall-regex@npm:^7.4.4":
   version: 7.18.6
   resolution: "@babel/plugin-transform-dotall-regex@npm:7.18.6"
@@ -1284,7 +1548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-exponentiation-operator@npm:^7.0.0, @babel/plugin-transform-exponentiation-operator@npm:^7.16.0, @babel/plugin-transform-exponentiation-operator@npm:^7.18.6":
+"@babel/plugin-transform-exponentiation-operator@npm:^7.16.0, @babel/plugin-transform-exponentiation-operator@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.18.6"
   dependencies:
@@ -1305,6 +1569,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: c35339bf80c2a2b9abb9e2ce0382e1d9cc3ef7db2af127f4ec3d184bad2aec3269f3fcac5fdcd565439732803acad72eb9e7d5a18e439221526fdc041c9e8e1e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-flow-strip-types@npm:^7.20.0":
+  version: 7.22.5
+  resolution: "@babel/plugin-transform-flow-strip-types@npm:7.22.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.22.5
+    "@babel/plugin-syntax-flow": ^7.22.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 1ba48187d6f33814be01c6870489f0b1858256cf2b9dd7e62f02af8b30049bf375112f1d44692c5fed3cb9cd26ee2fb32e358cd79b6ad2360a51e8f993e861bf
   languageName: node
   linkType: hard
 
@@ -2071,6 +2347,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/template@npm:7.22.5"
+  dependencies:
+    "@babel/code-frame": ^7.22.5
+    "@babel/parser": ^7.22.5
+    "@babel/types": ^7.22.5
+  checksum: c5746410164039aca61829cdb42e9a55410f43cace6f51ca443313f3d0bdfa9a5a330d0b0df73dc17ef885c72104234ae05efede37c1cc8a72dc9f93425977a3
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.0.0":
   version: 7.21.2
   resolution: "@babel/traverse@npm:7.21.2"
@@ -2089,7 +2376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.14.0, @babel/traverse@npm:^7.20.10, @babel/traverse@npm:^7.20.12, @babel/traverse@npm:^7.20.13, @babel/traverse@npm:^7.20.5, @babel/traverse@npm:^7.20.7, @babel/traverse@npm:^7.4.5, @babel/traverse@npm:^7.7.0, @babel/traverse@npm:^7.7.2":
+"@babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.20.10, @babel/traverse@npm:^7.20.12, @babel/traverse@npm:^7.20.13, @babel/traverse@npm:^7.20.5, @babel/traverse@npm:^7.20.7, @babel/traverse@npm:^7.4.5, @babel/traverse@npm:^7.7.0, @babel/traverse@npm:^7.7.2":
   version: 7.20.13
   resolution: "@babel/traverse@npm:7.20.13"
   dependencies:
@@ -2122,6 +2409,24 @@ __metadata:
     debug: ^4.1.0
     globals: ^11.1.0
   checksum: 0af5bcd47a2fc501592b90ac1feae9d449afb9ab0772a4f6e68230f4cd3a475795d538c1de3f880fe3414b6c2820bac84d02c6549eea796f39d74a603717447b
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.20.0, @babel/traverse@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/traverse@npm:7.22.5"
+  dependencies:
+    "@babel/code-frame": ^7.22.5
+    "@babel/generator": ^7.22.5
+    "@babel/helper-environment-visitor": ^7.22.5
+    "@babel/helper-function-name": ^7.22.5
+    "@babel/helper-hoist-variables": ^7.22.5
+    "@babel/helper-split-export-declaration": ^7.22.5
+    "@babel/parser": ^7.22.5
+    "@babel/types": ^7.22.5
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 560931422dc1761f2df723778dcb4e51ce0d02e560cf2caa49822921578f49189a5a7d053b78a32dca33e59be886a6b2200a6e24d4ae9b5086ca0ba803815694
   languageName: node
   linkType: hard
 
@@ -2195,6 +2500,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.19.1
     to-fast-properties: ^2.0.0
   checksum: a45a52acde139e575502c6de42c994bdbe262bafcb92ae9381fb54cdf1a3672149086843fda655c7683ce9806e998fd002bbe878fa44984498d0fdc7935ce7ff
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/types@npm:7.22.5"
+  dependencies:
+    "@babel/helper-string-parser": ^7.22.5
+    "@babel/helper-validator-identifier": ^7.22.5
+    to-fast-properties: ^2.0.0
+  checksum: c13a9c1dc7d2d1a241a2f8363540cb9af1d66e978e8984b400a20c4f38ba38ca29f06e26a0f2d49a70bad9e57615dac09c35accfddf1bb90d23cd3e0a0bab892
   languageName: node
   linkType: hard
 
@@ -2819,12 +3135,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/create-cache-key-function@npm:^27.0.1":
-  version: 27.5.1
-  resolution: "@jest/create-cache-key-function@npm:27.5.1"
+"@jest/create-cache-key-function@npm:^29.2.1":
+  version: 29.5.0
+  resolution: "@jest/create-cache-key-function@npm:29.5.0"
   dependencies:
-    "@jest/types": ^27.5.1
-  checksum: a6c3a8c769aca6f66f5dc80f1c77e66980b4f213a6b2a15a92ba3595f032848a1261c06c9c798dcf2b672b1ffbefad5085af89d130548741c85ddbe0cf4284e7
+    "@jest/types": ^29.5.0
+  checksum: 9d96245897caf1a69bc09ab262fb33249165eaaeaeb012ba5a8aabc4a3745494419b1168462fa32fcca23bc13106b8eacfe4d002b9c179f3d6a30f592fbb2060
   languageName: node
   linkType: hard
 
@@ -3570,6 +3886,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/source-map@npm:^0.3.3":
+  version: 0.3.4
+  resolution: "@jridgewell/source-map@npm:0.3.4"
+  checksum: 87fae5d8a81bbe5d691f2a415588ee020ec3b858674f675c206f0f7060d820c49dcc755ffd27cc8467e4f50576d7b5b7fc86d34d5e53a879ce7440deef732948
+  languageName: node
+  linkType: hard
+
 "@jridgewell/sourcemap-codec@npm:1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
@@ -4143,51 +4466,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-clean@npm:^8.0.4":
-  version: 8.0.4
-  resolution: "@react-native-community/cli-clean@npm:8.0.4"
+"@react-native-community/cli-clean@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-clean@npm:11.3.3"
   dependencies:
-    "@react-native-community/cli-tools": ^8.0.4
+    "@react-native-community/cli-tools": 11.3.3
     chalk: ^4.1.2
-    execa: ^1.0.0
+    execa: ^5.0.0
     prompts: ^2.4.0
-  checksum: 793f900d592cf2f7ca5ab3263cdc6382d0c579a53af5946de89e3be0d9d28bb60a64466d7b145fd68ff42ebb740c9fadc9e63f3e684a5e43dad61e917fcca0c7
+  checksum: ba0c35bdfce35fae9230d61e485954cafa691d9c911efa0dbdbf8e70f315c837b774eae9001dd559a1da6a9a61555a701c62ac45cfc3538585b77d834735324d
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-config@npm:^8.0.6":
-  version: 8.0.6
-  resolution: "@react-native-community/cli-config@npm:8.0.6"
+"@react-native-community/cli-config@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-config@npm:11.3.3"
   dependencies:
-    "@react-native-community/cli-tools": ^8.0.4
+    "@react-native-community/cli-tools": 11.3.3
+    chalk: ^4.1.2
     cosmiconfig: ^5.1.0
-    deepmerge: ^3.2.0
+    deepmerge: ^4.3.0
     glob: ^7.1.3
     joi: ^17.2.1
-  checksum: 6191c801d49e34a6d5650bc7c44559ce913d2acaf8d5e9b9dd27ced486d2735a74b4b5bfa3c92b7a670536124f95ccdfa85c1e65c329b90674d6b16e3e801e45
+  checksum: 3876d4a0dc6b1cdad20ebc56b37acb55f201016688cd238aad3fda40ca8206485b7d753ed5546c841053ab8708c824b54ab834af2a190124d3607da74b639fcc
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-debugger-ui@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@react-native-community/cli-debugger-ui@npm:8.0.0"
+"@react-native-community/cli-debugger-ui@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-debugger-ui@npm:11.3.3"
   dependencies:
     serve-static: ^1.13.1
-  checksum: 926dcbf55d3732cefbabb16d62e2ad29d9c2b85d8c231a76b4bea618715ab16e8ca4cddb5879085449423b6776b035d94d148eead3db065fc61c1d156a0550bd
+  checksum: 4d6c19d549d94e95bdfd1623aa6a195c9efa1461646c77198b6f1b6db3a92376999dc587c89270748f0cb16173fcd17e946110dab26802c72f7199a7d759a57d
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-doctor@npm:^8.0.6":
-  version: 8.0.6
-  resolution: "@react-native-community/cli-doctor@npm:8.0.6"
+"@react-native-community/cli-doctor@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-doctor@npm:11.3.3"
   dependencies:
-    "@react-native-community/cli-config": ^8.0.6
-    "@react-native-community/cli-platform-ios": ^8.0.6
-    "@react-native-community/cli-tools": ^8.0.4
+    "@react-native-community/cli-config": 11.3.3
+    "@react-native-community/cli-platform-android": 11.3.3
+    "@react-native-community/cli-platform-ios": 11.3.3
+    "@react-native-community/cli-tools": 11.3.3
     chalk: ^4.1.2
     command-exists: ^1.2.8
     envinfo: ^7.7.2
-    execa: ^1.0.0
+    execa: ^5.0.0
     hermes-profile-transformer: ^0.0.6
     ip: ^1.1.5
     node-stream-zip: ^1.9.1
@@ -4197,168 +4522,198 @@ __metadata:
     strip-ansi: ^5.2.0
     sudo-prompt: ^9.0.0
     wcwidth: ^1.0.1
-  checksum: fe33bd8f7d69a4fedc400a9d17556d260144c6b6fc39d7ef4bfeca385c456edd106f9a10f7fd8e58516ee68984762acff062a9050aea14d084a3523390298bb3
+    yaml: ^2.2.1
+  checksum: 905dadf5232fd0789652cd169fd3442e587c06bd14306b6678c6bf3f7f215692b586fb86144aefac4b7bf6df9b1db63ad1d3dbbe7a8d0378fc8fd2e1c77b6add
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-hermes@npm:^8.0.5":
-  version: 8.0.5
-  resolution: "@react-native-community/cli-hermes@npm:8.0.5"
+"@react-native-community/cli-hermes@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-hermes@npm:11.3.3"
   dependencies:
-    "@react-native-community/cli-platform-android": ^8.0.5
-    "@react-native-community/cli-tools": ^8.0.4
+    "@react-native-community/cli-platform-android": 11.3.3
+    "@react-native-community/cli-tools": 11.3.3
     chalk: ^4.1.2
     hermes-profile-transformer: ^0.0.6
     ip: ^1.1.5
-  checksum: d98cb53b062bf2b61c4c6f861112d4a5ebc3736a0d352f7cc31efa33352a102b4f45a8fef8ddc940d0142142ba14db716d1be8a709174d5321a3fac6dec783b2
+  checksum: 10dfed28b9163ff40ff9096e12c6518d791b0669b00112f60ae817fa9791370a05fafd6f8bbbc7556d0ac5617ffa047a5df0aa6009388451d68bdd50ffa2f353
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-platform-android@npm:^8.0.4, @react-native-community/cli-platform-android@npm:^8.0.5":
-  version: 8.0.5
-  resolution: "@react-native-community/cli-platform-android@npm:8.0.5"
+"@react-native-community/cli-platform-android@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-platform-android@npm:11.3.3"
   dependencies:
-    "@react-native-community/cli-tools": ^8.0.4
+    "@react-native-community/cli-tools": 11.3.3
     chalk: ^4.1.2
-    execa: ^1.0.0
-    fs-extra: ^8.1.0
+    execa: ^5.0.0
     glob: ^7.1.3
-    jetifier: ^1.6.2
-    lodash: ^4.17.15
     logkitty: ^0.7.1
-    slash: ^3.0.0
-  checksum: 84166b2fba5d09add581abffd1d1b68feac0cf9b849ba19f79b2b2672b66bc73dd9f93fa4e6c17bc2d75ad0f78ede1bbd4fe7678928c94b212278eec7072be36
+  checksum: 2650ff3583fa916905bb7d153e3b8841d2a3422271ba1de823995fbb695374d5df5ed203ab0a9a91fbd5f7da6a7a40b6c103fba828569796f680149a348bb0bd
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-platform-ios@npm:^8.0.4, @react-native-community/cli-platform-ios@npm:^8.0.6":
-  version: 8.0.6
-  resolution: "@react-native-community/cli-platform-ios@npm:8.0.6"
+"@react-native-community/cli-platform-ios@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-platform-ios@npm:11.3.3"
   dependencies:
-    "@react-native-community/cli-tools": ^8.0.4
+    "@react-native-community/cli-tools": 11.3.3
     chalk: ^4.1.2
-    execa: ^1.0.0
+    execa: ^5.0.0
+    fast-xml-parser: ^4.0.12
     glob: ^7.1.3
-    js-yaml: ^3.13.1
-    lodash: ^4.17.15
     ora: ^5.4.1
-    plist: ^3.0.2
-  checksum: 3dff6efb4e3f6a486207aefa126de70930032d16c4a395cbc88f6e56640fec24209273b45b93c735a7c604dfb7edb980240a82026f135f4f59a74063cd834221
+  checksum: 2376a5c9e60f4b7df81b6c02169055a7f23230ce7935a33d1811c56dacb6a920b66bc1b0ad159eeb08b40d329e5d8df6fe82312037059100105285ef2d105dde
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-plugin-metro@npm:^8.0.4":
-  version: 8.0.4
-  resolution: "@react-native-community/cli-plugin-metro@npm:8.0.4"
+"@react-native-community/cli-plugin-metro@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-plugin-metro@npm:11.3.3"
   dependencies:
-    "@react-native-community/cli-server-api": ^8.0.4
-    "@react-native-community/cli-tools": ^8.0.4
+    "@react-native-community/cli-server-api": 11.3.3
+    "@react-native-community/cli-tools": 11.3.3
     chalk: ^4.1.2
-    metro: ^0.70.1
-    metro-config: ^0.70.1
-    metro-core: ^0.70.1
-    metro-react-native-babel-transformer: ^0.70.1
-    metro-resolver: ^0.70.1
-    metro-runtime: ^0.70.1
+    execa: ^5.0.0
+    metro: 0.76.5
+    metro-config: 0.76.5
+    metro-core: 0.76.5
+    metro-react-native-babel-transformer: 0.76.5
+    metro-resolver: 0.76.5
+    metro-runtime: 0.76.5
     readline: ^1.3.0
-  checksum: b37b101f0a485c69af51354a973378037c6b0630f15f10d785cc9c1e2ad8211427fb3c749262d16cb40629555c377c1ddb38a5977b34942f0406463354cfa836
+  checksum: 8fadae338b2ebe8f720d1f38b022d9b4b6226c2355d60d5a400bf589503050d27f962d12f0d130f6258a5dca63104163ddcb9ddfee327c28adb348afdd066b8e
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-server-api@npm:^8.0.4":
-  version: 8.0.4
-  resolution: "@react-native-community/cli-server-api@npm:8.0.4"
+"@react-native-community/cli-server-api@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-server-api@npm:11.3.3"
   dependencies:
-    "@react-native-community/cli-debugger-ui": ^8.0.0
-    "@react-native-community/cli-tools": ^8.0.4
+    "@react-native-community/cli-debugger-ui": 11.3.3
+    "@react-native-community/cli-tools": 11.3.3
     compression: ^1.7.1
     connect: ^3.6.5
-    errorhandler: ^1.5.0
+    errorhandler: ^1.5.1
     nocache: ^3.0.1
     pretty-format: ^26.6.2
     serve-static: ^1.13.1
     ws: ^7.5.1
-  checksum: b39249f12e1f926f3a060f6b6119a6f5002238e7c1b2de97c727c740e52130ec8a1056b78f39fad78a40dbb3d9de0e4adfcedbbde91bdf015b2c21cbde230728
+  checksum: 50eda1542774369c508ecbcf2ae22c803c5f560d1ff70d012ff9df86de563c34c71b219601c85180e30f7255de1575b5a525299cf8db3f154da2f45e3b83d6cd
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-tools@npm:^8.0.4":
-  version: 8.0.4
-  resolution: "@react-native-community/cli-tools@npm:8.0.4"
+"@react-native-community/cli-tools@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-tools@npm:11.3.3"
   dependencies:
     appdirsjs: ^1.2.4
     chalk: ^4.1.2
     find-up: ^5.0.0
-    lodash: ^4.17.15
     mime: ^2.4.1
     node-fetch: ^2.6.0
     open: ^6.2.0
     ora: ^5.4.1
     semver: ^6.3.0
     shell-quote: ^1.7.3
-  checksum: 77f481db1869f6e6f21c6e63c859d84b4d252ae2fa7fcfbf22aefe24b138cc769983228a457d719e50c7f5cc7b5c3d4fd37e868276804ff830a263a45d0929d9
+  checksum: 7e13394255e282d5f75971f753cde7b24ad632c019e8af4b64df8f0eda729202c43c2c821b45cc8a93a100e2b59614db191808c15344907f68abc24923533f64
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-types@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@react-native-community/cli-types@npm:8.0.0"
+"@react-native-community/cli-types@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli-types@npm:11.3.3"
   dependencies:
     joi: ^17.2.1
-  checksum: 536cdaf7decb67cc3f1008f11ccf334f761957c683a6e9b9e1a3fbc979f4960dc6e726d39e28f33a8ad2492cd1732eb102a52ecf25b2a760d735fc5d23c4d26a
+  checksum: 4d172ee8a3d4bf24adc237d0e6086f8545094f1a96ee64a61e3b533d69aeef8df5f61fd9ece36634b9617c37b8ecafa6b1af71cc3da8708388e492d52b8d78e9
   languageName: node
   linkType: hard
 
-"@react-native-community/cli@npm:^8.0.4":
-  version: 8.0.6
-  resolution: "@react-native-community/cli@npm:8.0.6"
+"@react-native-community/cli@npm:11.3.3":
+  version: 11.3.3
+  resolution: "@react-native-community/cli@npm:11.3.3"
   dependencies:
-    "@react-native-community/cli-clean": ^8.0.4
-    "@react-native-community/cli-config": ^8.0.6
-    "@react-native-community/cli-debugger-ui": ^8.0.0
-    "@react-native-community/cli-doctor": ^8.0.6
-    "@react-native-community/cli-hermes": ^8.0.5
-    "@react-native-community/cli-plugin-metro": ^8.0.4
-    "@react-native-community/cli-server-api": ^8.0.4
-    "@react-native-community/cli-tools": ^8.0.4
-    "@react-native-community/cli-types": ^8.0.0
+    "@react-native-community/cli-clean": 11.3.3
+    "@react-native-community/cli-config": 11.3.3
+    "@react-native-community/cli-debugger-ui": 11.3.3
+    "@react-native-community/cli-doctor": 11.3.3
+    "@react-native-community/cli-hermes": 11.3.3
+    "@react-native-community/cli-plugin-metro": 11.3.3
+    "@react-native-community/cli-server-api": 11.3.3
+    "@react-native-community/cli-tools": 11.3.3
+    "@react-native-community/cli-types": 11.3.3
     chalk: ^4.1.2
-    commander: ^2.19.0
-    execa: ^1.0.0
+    commander: ^9.4.1
+    execa: ^5.0.0
     find-up: ^4.1.0
     fs-extra: ^8.1.0
     graceful-fs: ^4.1.3
-    leven: ^3.1.0
-    lodash: ^4.17.15
-    minimist: ^1.2.0
     prompts: ^2.4.0
     semver: ^6.3.0
-  peerDependencies:
-    react-native: "*"
   bin:
     react-native: build/bin.js
-  checksum: 88cb297408e90f5b7f9858014cc74717553ad85f53fd84683dea6b2aa27cfde2203b4c43f89f9a6ead1a8493494d234e6861929c4d7628d1363ea0ec50e9efcb
+  checksum: df017a9b275b827790b8fdcf3dc808b50fd56983ceb928dff96f319853ea62eb0cf34f5351ebbcca540faace108335ca9e9f29a759fb4790bb6aa77776ba62e6
   languageName: node
   linkType: hard
 
-"@react-native/assets@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native/assets@npm:1.0.0"
-  checksum: 4525dd1704e98b753f8fdbbc1ca373299686100cddad1e0b80556d612b9812fa743ae9f83cfe55fd8fb51fb90a5c0caa7b27b3137515224bc7f9c2c09e8f6b5b
+"@react-native/assets-registry@npm:^0.72.0":
+  version: 0.72.0
+  resolution: "@react-native/assets-registry@npm:0.72.0"
+  checksum: 94c2b842f9fcc6e2817463dd5f26a40b69a5ff10d8d10a2af95b677f88c6645e833f985db9d85c9c3d8e66fb882b2065921ad8890fe6ac7b5eb3f9d04f6e17fa
   languageName: node
   linkType: hard
 
-"@react-native/normalize-color@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@react-native/normalize-color@npm:2.0.0"
-  checksum: 2da373297f0d22b700edb9ab1b2cca34684e94a5dfe172e1cfd114e74ac17e139e802bc671e9868e0a580190eccbf3fa804f67be8cc1d9cbd0e216e994495931
+"@react-native/codegen@npm:^0.72.6":
+  version: 0.72.6
+  resolution: "@react-native/codegen@npm:0.72.6"
+  dependencies:
+    "@babel/parser": ^7.20.0
+    flow-parser: ^0.206.0
+    jscodeshift: ^0.14.0
+    nullthrows: ^1.1.1
+  peerDependencies:
+    "@babel/preset-env": ^7.1.6
+  checksum: 56ef32546ac042069bba0ca8ee8cc21cfcb32500b8fcb01917d824ad5a78b0c4da9a336b1391217deb934224ee3f0f9f5590584c1387b94d44861369f2451449
   languageName: node
   linkType: hard
 
-"@react-native/polyfills@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@react-native/polyfills@npm:2.0.0"
-  checksum: 6f2a0d1c8c4df4f20e8adac92fcfaec0fb536d097f96fbfd56bdb21b0a3afc4157f82d084b6851093255f58d350818f7ad28098818d584f654533eeb9cba2656
+"@react-native/gradle-plugin@npm:^0.72.11":
+  version: 0.72.11
+  resolution: "@react-native/gradle-plugin@npm:0.72.11"
+  checksum: 1688e9b0f7571f142d9bea95339f1194c043f2230fd5018b69d69487bd4efdc4a0c7bce6e93cee2ac9ff8c7a382541186ca4d68b0e5086b5f4f2e78747978144
+  languageName: node
+  linkType: hard
+
+"@react-native/js-polyfills@npm:^0.72.1":
+  version: 0.72.1
+  resolution: "@react-native/js-polyfills@npm:0.72.1"
+  checksum: c81b0217cefdfda5cda34acf260a862711e0c9262c2503eb155d6e16050438b387242f7232b986890cb461d01ca61a8b6dab9a9bcc75e00f5509315006028286
+  languageName: node
+  linkType: hard
+
+"@react-native/normalize-colors@npm:*":
+  version: 0.73.0
+  resolution: "@react-native/normalize-colors@npm:0.73.0"
+  checksum: 0b98021f4d40e497f25e96d610d98602cb6d80d455e3a93676e99922c7cfa03829c531eae110b62585bfa567bb4d2b28f91f0b06f8539244619baac2c0bee9a9
+  languageName: node
+  linkType: hard
+
+"@react-native/normalize-colors@npm:^0.72.0":
+  version: 0.72.0
+  resolution: "@react-native/normalize-colors@npm:0.72.0"
+  checksum: c8ec577663394a3390eb34c3cd531350521172bcfad7de309ab111e5f9e3d27c966d4a4387f00972302107be3d8cad584c5794ccfa30939aecc56162e4ddbe25
+  languageName: node
+  linkType: hard
+
+"@react-native/virtualized-lists@npm:^0.72.4, @react-native/virtualized-lists@npm:^0.72.6":
+  version: 0.72.6
+  resolution: "@react-native/virtualized-lists@npm:0.72.6"
+  dependencies:
+    invariant: ^2.2.4
+    nullthrows: ^1.1.1
+  peerDependencies:
+    react-native: "*"
+  checksum: e9e0c0f75607e699bf79742ca98128698e27a0c05fe01e735876b444020e7578858ee6267e6913a7cad7aafb5d2bc25feeefda051ec3d178e6d2cd65b318b6f5
   languageName: node
   linkType: hard
 
@@ -6622,20 +6977,22 @@ __metadata:
   linkType: hard
 
 "@types/react-native@npm:*":
-  version: 0.71.3
-  resolution: "@types/react-native@npm:0.71.3"
+  version: 0.72.2
+  resolution: "@types/react-native@npm:0.72.2"
   dependencies:
+    "@react-native/virtualized-lists": ^0.72.4
     "@types/react": "*"
-  checksum: 5ee02f9c780c630e145c1887c80d1739d59e01d45ff9e862b475538376ddd17fc605a1245fea04813593c1c0153b5f4a41247283036adcdfbf4779555f956d93
+  checksum: b2915594381365ea379cb46b9a65219c6b6c7446d97d15f4da9615b8f180972bacba7cae584f4a8f83cce3a180f8a9a08a9c6b57081b37e2543f23f5717693d4
   languageName: node
   linkType: hard
 
-"@types/react-native@npm:0.69.5":
-  version: 0.69.5
-  resolution: "@types/react-native@npm:0.69.5"
+"@types/react-native@npm:0.72.1":
+  version: 0.72.1
+  resolution: "@types/react-native@npm:0.72.1"
   dependencies:
+    "@react-native/virtualized-lists": ^0.72.4
     "@types/react": "*"
-  checksum: 4ced60f7233e28d632061e86d7494319564b62db334d328056ecc1ac10904e286bd802f3152ec4a37106238fe99b5ea5b9ae89d8bcb14f4b336e836c6af2042e
+  checksum: fb2bcb0eb1fdd4afd0b45647d2b16b093cff7d0b40c3c7d39247942106d83f5f272ce979c15dce77dd4caf9e28713e351bd5a0ca4e9eed1a5a7c240bb6e2d255
   languageName: node
   linkType: hard
 
@@ -7755,13 +8112,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"absolute-path@npm:^0.0.0":
-  version: 0.0.0
-  resolution: "absolute-path@npm:0.0.0"
-  checksum: f707356265b46adb3a2f2c6505b0058f7786d3d2f6edc2aacfb8af6ba66d8d86166a281ed45081559579df2bb9977b2fe9df0925548a2f1b4d0d4d2b3eb062d2
-  languageName: node
-  linkType: hard
-
 "accepts@npm:^1.3.7, accepts@npm:~1.3.4, accepts@npm:~1.3.5, accepts@npm:~1.3.7, accepts@npm:~1.3.8":
   version: 1.3.8
   resolution: "accepts@npm:1.3.8"
@@ -7856,6 +8206,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: f790b99a1bf63ef160c967e23c46feea7787e531292bb827126334612c234ed489a0dc2c7ba33156416f0ffa8d25bf2b0fdb7f35c2ba60eb3e960572bece4001
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.8.2":
+  version: 8.9.0
+  resolution: "acorn@npm:8.9.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 25dfb94952386ecfb847e61934de04a4e7c2dc21c2e700fc4e2ef27ce78cb717700c4c4f279cd630bb4774948633c3859fc16063ec8573bda4568e0a312e6744
   languageName: node
   linkType: hard
 
@@ -8599,7 +8958,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-types@npm:0.14.2, ast-types@npm:^0.14.2":
+"ast-types@npm:0.15.2":
+  version: 0.15.2
+  resolution: "ast-types@npm:0.15.2"
+  dependencies:
+    tslib: ^2.0.1
+  checksum: 24f0d86bf9e4c8dae16fa24b13c1776f2c2677040bcfbd4eb4f27911db49020be4876885e45e6cfcc548ed4dfea3a0742d77e3346b84fae47379cb0b89e9daa0
+  languageName: node
+  linkType: hard
+
+"ast-types@npm:^0.14.2":
   version: 0.14.2
   resolution: "ast-types@npm:0.14.2"
   dependencies:
@@ -9327,6 +9695,15 @@ __metadata:
   version: 7.0.0-beta.0
   resolution: "babel-plugin-syntax-trailing-function-commas@npm:7.0.0-beta.0"
   checksum: e37509156ca945dd9e4b82c66dd74f2d842ad917bd280cb5aa67960942300cd065eeac476d2514bdcdedec071277a358f6d517c31d9f9244d9bbc3619a8ecf8a
+  languageName: node
+  linkType: hard
+
+"babel-plugin-transform-flow-enums@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "babel-plugin-transform-flow-enums@npm:0.0.2"
+  dependencies:
+    "@babel/plugin-syntax-flow": ^7.12.1
+  checksum: fd52aef54448e01948a9d1cca0c8f87d064970c8682458962b7a222c372704bc2ce26ae8109e0ab2566e7ea5106856460f04c1a5ed794ab3bcd2f42cae1d9845
   languageName: node
   linkType: hard
 
@@ -10499,7 +10876,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.0.0, camelcase@npm:^6.2.0, camelcase@npm:^6.3.0":
+"camelcase@npm:^6.2.0, camelcase@npm:^6.3.0":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
@@ -11281,6 +11658,13 @@ __metadata:
   version: 5.1.0
   resolution: "commander@npm:5.1.0"
   checksum: 0b7fec1712fbcc6230fcb161d8d73b4730fa91a21dc089515489402ad78810547683f058e2a9835929c212fead1d6a6ade70db28bbb03edbc2829a9ab7d69447
+  languageName: node
+  linkType: hard
+
+"commander@npm:^9.4.1":
+  version: 9.5.0
+  resolution: "commander@npm:9.5.0"
+  checksum: c7a3e27aa59e913b54a1bafd366b88650bc41d6651f0cbe258d4ff09d43d6a7394232a4dadd0bf518b3e696fdf595db1028a0d82c785b88bd61f8a440cecfade
   languageName: node
   linkType: hard
 
@@ -12447,17 +12831,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deepmerge@npm:^3.2.0":
-  version: 3.3.0
-  resolution: "deepmerge@npm:3.3.0"
-  checksum: 4322195389e0170a0443c07b36add19b90249802c4b47b96265fdc5f5d8beddf491d5e50cbc5bfd65f85ccf76598173083863c202f5463b3b667aca8be75d5ac
-  languageName: node
-  linkType: hard
-
 "deepmerge@npm:^4.2.2":
   version: 4.3.0
   resolution: "deepmerge@npm:4.3.0"
   checksum: c7980eb5c5be040b371f1df0d566473875cfabed9f672ccc177b81ba8eee5686ce2478de2f1d0076391621cbe729e5eacda397179a59ef0f68901849647db126
+  languageName: node
+  linkType: hard
+
+"deepmerge@npm:^4.3.0":
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 2024c6a980a1b7128084170c4cf56b0fd58a63f2da1660dcfe977415f27b17dbe5888668b59d0b063753f3220719d5e400b7f113609489c90160bb9a5518d052
   languageName: node
   linkType: hard
 
@@ -12586,6 +12970,17 @@ __metadata:
   version: 1.1.2
   resolution: "depd@npm:1.1.2"
   checksum: 6b406620d269619852885ce15965272b829df6f409724415e0002c8632ab6a8c0a08ec1f0bd2add05dc7bd7507606f7e2cc034fa24224ab829580040b835ecd9
+  languageName: node
+  linkType: hard
+
+"deprecated-react-native-prop-types@npm:4.1.0":
+  version: 4.1.0
+  resolution: "deprecated-react-native-prop-types@npm:4.1.0"
+  dependencies:
+    "@react-native/normalize-colors": "*"
+    invariant: "*"
+    prop-types: "*"
+  checksum: bba96622e196f650e782963598a2868a9c89b32e88fba1555fe1308d324eb387ab2a1f16235162b7bccc1900e8f43b7f8eae4f149a37f10cdf52e071990a7c9a
   languageName: node
   linkType: hard
 
@@ -13623,7 +14018,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"errorhandler@npm:^1.2.0, errorhandler@npm:^1.5.0":
+"errorhandler@npm:^1.2.0, errorhandler@npm:^1.5.1":
   version: 1.5.1
   resolution: "errorhandler@npm:1.5.1"
   dependencies:
@@ -14912,6 +15307,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-xml-parser@npm:^4.0.12":
+  version: 4.2.5
+  resolution: "fast-xml-parser@npm:4.2.5"
+  dependencies:
+    strnum: ^1.0.5
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: d32b22005504eeb207249bf40dc82d0994b5bb9ca9dcc731d335a1f425e47fe085b3cace3cf9d32172dd1a5544193c49e8615ca95b4bf95a4a4920a226b06d80
+  languageName: node
+  linkType: hard
+
 "fastq@npm:^1.6.0":
   version: 1.15.0
   resolution: "fastq@npm:1.15.0"
@@ -15292,6 +15698,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flow-enums-runtime@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "flow-enums-runtime@npm:0.0.5"
+  checksum: a2cdd6a3e86a1d113d9300fd210e379da5a20d9423a1b957cd17207a4434a866ca75d5eb400c9058afb1b5fe64a653c4ddd2e30bf9fb8477291f0d5e70c20539
+  languageName: node
+  linkType: hard
+
 "flow-parser@npm:0.*":
   version: 0.199.1
   resolution: "flow-parser@npm:0.199.1"
@@ -15299,10 +15712,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-parser@npm:^0.121.0":
-  version: 0.121.0
-  resolution: "flow-parser@npm:0.121.0"
-  checksum: 2d9a9724b903f4c2eae63f8e1442f97c8284516197bebd746cdbba938ff0a17f2dd7a2bc74ca9a987556af0f43d31a793b251ae30660d6b5e914f0c2e8501d2d
+"flow-parser@npm:^0.206.0":
+  version: 0.206.0
+  resolution: "flow-parser@npm:0.206.0"
+  checksum: 1b87d87b59815b09852a6981543ad222da7f4d0e0c26702f9d5e0065174f5f64d2563db76d07a487c6b55e1979344e3845ac42929db70f77a82e8c9171a62a86
   languageName: node
   linkType: hard
 
@@ -15534,17 +15947,6 @@ __metadata:
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
   checksum: 18f5b718371816155849475ac36c7d0b24d39a11d91348cfcb308b4494824413e03572c403c86d3a260e049465518c4f0d5bd00f0371cdfcad6d4f30a85b350d
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fs-extra@npm:1.0.0"
-  dependencies:
-    graceful-fs: ^4.1.2
-    jsonfile: ^2.1.0
-    klaw: ^1.0.0
-  checksum: 9d3642621f42c810e9a32e6ecf97f6f827fdffb001316504d2102d87b4505b8bda1197d43e38e5b1db1faa240b022380b489a0e378b739e1cadef0df9aad4b5f
   languageName: node
   linkType: hard
 
@@ -16359,7 +16761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
   checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
@@ -16664,26 +17066,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-engine@npm:~0.11.0":
-  version: 0.11.0
-  resolution: "hermes-engine@npm:0.11.0"
-  checksum: 34dcd016b373337306be0e5b15923fc2756b17253264443a1a07a14d3326d00eb433af13c08ae11f3a2ddcbcc44ae9a9ac9b071ce72efdd056745327dc3201d7
+"hermes-estree@npm:0.8.0":
+  version: 0.8.0
+  resolution: "hermes-estree@npm:0.8.0"
+  checksum: 3a169d1751d8bed000c665314205e4f033f9dd0506ac0f72528c31853f7ac3d0a13abd34c7cd69d8f5b57effd730d7da9fdadb0a3fb35303769a12f90dd0a61f
   languageName: node
   linkType: hard
 
-"hermes-estree@npm:0.6.0":
-  version: 0.6.0
-  resolution: "hermes-estree@npm:0.6.0"
-  checksum: 91b59543322a7c0c6d55b4e726d847eed3b9f362bc817d83098600bb72fde9f56b6fb455000f0a39f859c4d1152e1f0a45ca25a93f9716edff545b9f232eb436
-  languageName: node
-  linkType: hard
-
-"hermes-parser@npm:0.6.0":
-  version: 0.6.0
-  resolution: "hermes-parser@npm:0.6.0"
+"hermes-parser@npm:0.8.0":
+  version: 0.8.0
+  resolution: "hermes-parser@npm:0.8.0"
   dependencies:
-    hermes-estree: 0.6.0
-  checksum: ea3f566e613465aee70eda6fd022195afb77fa7d65c5370c9c9d204e3e62c4c68f76a86962f41b627d131cbf69f74dec9cf1a649574078edf8058589f5832b32
+    hermes-estree: 0.8.0
+  checksum: 0c992bdc6c98482aef0c8bc3b55c84769d80536aa6becf9c3e296caf19647ba4fa1c516e50e313dfe44dadce140c7dc9f9f5ceee36091cf9835bbcd101b1b974
   languageName: node
   linkType: hard
 
@@ -17210,12 +17605,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"image-size@npm:^0.6.0":
-  version: 0.6.3
-  resolution: "image-size@npm:0.6.3"
+"image-size@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "image-size@npm:1.0.2"
+  dependencies:
+    queue: 6.0.2
   bin:
     image-size: bin/image-size.js
-  checksum: cfd01d7672d584a4dd09d29bcf593c4bec3c9bb63769a51f735bd10673a7ddce7445da79771ea70b582a114b35bb4c148366b027ee9d1071c1a051aead54c788
+  checksum: 01745fdb47f87cecf538e69c63f9adc5bfab30a345345c2de91105f3afbd1bfcfba1256af02bf3323077b33b0004469a837e077bf0cbb9c907e9c1e9e7547585
   languageName: node
   linkType: hard
 
@@ -17510,7 +17907,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"invariant@npm:^2.2.3, invariant@npm:^2.2.4":
+"invariant@npm:*, invariant@npm:^2.2.3, invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
   dependencies:
@@ -19043,6 +19440,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-environment-node@npm:^29.2.1, jest-environment-node@npm:^29.5.0":
+  version: 29.5.0
+  resolution: "jest-environment-node@npm:29.5.0"
+  dependencies:
+    "@jest/environment": ^29.5.0
+    "@jest/fake-timers": ^29.5.0
+    "@jest/types": ^29.5.0
+    "@types/node": "*"
+    jest-mock: ^29.5.0
+    jest-util: ^29.5.0
+  checksum: 57981911cc20a4219b0da9e22b2e3c9f31b505e43f78e61c899e3227ded455ce1a3a9483842c69cfa4532f02cfb536ae0995bf245f9211608edacfc1e478d411
+  languageName: node
+  linkType: hard
+
 "jest-environment-node@npm:^29.4.1, jest-environment-node@npm:^29.4.3":
   version: 29.4.3
   resolution: "jest-environment-node@npm:29.4.3"
@@ -19071,31 +19482,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-environment-node@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-environment-node@npm:29.5.0"
-  dependencies:
-    "@jest/environment": ^29.5.0
-    "@jest/fake-timers": ^29.5.0
-    "@jest/types": ^29.5.0
-    "@types/node": "*"
-    jest-mock: ^29.5.0
-    jest-util: ^29.5.0
-  checksum: 57981911cc20a4219b0da9e22b2e3c9f31b505e43f78e61c899e3227ded455ce1a3a9483842c69cfa4532f02cfb536ae0995bf245f9211608edacfc1e478d411
-  languageName: node
-  linkType: hard
-
 "jest-get-type@npm:^25.2.6":
   version: 25.2.6
   resolution: "jest-get-type@npm:25.2.6"
   checksum: d1f59027b0baa6b8a6f4b3f900de1a77714647351907981ea57c16340e6a58a9c702b580055331af25ee3872768f1241c0616de9777a63e4eb32fc409dcbf9ac
-  languageName: node
-  linkType: hard
-
-"jest-get-type@npm:^26.3.0":
-  version: 26.3.0
-  resolution: "jest-get-type@npm:26.3.0"
-  checksum: 1cc6465ae4f5e880be22ba52fd270fa64c21994915f81b41f8f7553a7957dd8e077cc8d03035de9412e2d739f8bad6a032ebb5dab5805692a5fb9e20dd4ea666
   languageName: node
   linkType: hard
 
@@ -19137,7 +19527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:^27.3.1, jest-haste-map@npm:^27.5.1":
+"jest-haste-map@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-haste-map@npm:27.5.1"
   dependencies:
@@ -19471,7 +19861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-regex-util@npm:^27.5.1":
+"jest-regex-util@npm:^27.0.6, jest-regex-util@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-regex-util@npm:27.5.1"
   checksum: d45ca7a9543616a34f7f3079337439cf07566e677a096472baa2810e274b9808b76767c97b0a4029b8a5b82b9d256dee28ef9ad4138b2b9e5933f6fac106c418
@@ -19992,7 +20382,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^27.5.1":
+"jest-util@npm:^27.2.0, jest-util@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-util@npm:27.5.1"
   dependencies:
@@ -20062,17 +20452,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-validate@npm:^26.5.2":
-  version: 26.6.2
-  resolution: "jest-validate@npm:26.6.2"
+"jest-validate@npm:^29.2.1, jest-validate@npm:^29.5.0":
+  version: 29.5.0
+  resolution: "jest-validate@npm:29.5.0"
   dependencies:
-    "@jest/types": ^26.6.2
-    camelcase: ^6.0.0
+    "@jest/types": ^29.5.0
+    camelcase: ^6.2.0
     chalk: ^4.0.0
-    jest-get-type: ^26.3.0
+    jest-get-type: ^29.4.3
     leven: ^3.1.0
-    pretty-format: ^26.6.2
-  checksum: bac11d6586d9b8885328a4a66eec45b692e45ac23034a5c09eb0ee32de324f2d3d52b073e0c34e9c222b3642b083d1152a736cf24c52109e4957537d731ca62b
+    pretty-format: ^29.5.0
+  checksum: 43ca5df7cb75572a254ac3e92fbbe7be6b6a1be898cc1e887a45d55ea003f7a112717d814a674d37f9f18f52d8de40873c8f084f17664ae562736c78dd44c6a1
   languageName: node
   linkType: hard
 
@@ -20101,20 +20491,6 @@ __metadata:
     leven: ^3.1.0
     pretty-format: ^29.4.3
   checksum: 983e56430d86bed238448cae031535c1d908f760aa312cd4a4ec0e92f3bc1b6675415ddf57cdeceedb8ad9c698e5bcd10f0a856dfc93a8923bdecc7733f4ba80
-  languageName: node
-  linkType: hard
-
-"jest-validate@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-validate@npm:29.5.0"
-  dependencies:
-    "@jest/types": ^29.5.0
-    camelcase: ^6.2.0
-    chalk: ^4.0.0
-    jest-get-type: ^29.4.3
-    leven: ^3.1.0
-    pretty-format: ^29.5.0
-  checksum: 43ca5df7cb75572a254ac3e92fbbe7be6b6a1be898cc1e887a45d55ea003f7a112717d814a674d37f9f18f52d8de40873c8f084f17664ae562736c78dd44c6a1
   languageName: node
   linkType: hard
 
@@ -20337,17 +20713,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jetifier@npm:^1.6.2":
-  version: 1.6.8
-  resolution: "jetifier@npm:1.6.8"
-  bin:
-    jetifier: bin/jetify
-    jetifier-standalone: bin/jetifier-standalone
-    jetify: bin/jetify
-  checksum: 6cdecf7683bb2f6e89e48442365d8bac6244c74ffa286b1b45d97ffa2a833901d0f4b86d0b83d4babec2b71385104214248f1b8539d82e8909989adbf16d09b4
-  languageName: node
-  linkType: hard
-
 "jju@npm:^1.1.0":
   version: 1.4.0
   resolution: "jju@npm:1.4.0"
@@ -20419,16 +20784,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsc-android@npm:^250230.2.1":
-  version: 250230.2.1
-  resolution: "jsc-android@npm:250230.2.1"
-  checksum: 11b7c41a0a9192ea4697e61f72a65341afd143550159bbc951cfe8e08eaee4fb119a7f4b9241de15b7156a873f0faef677f6ee72c243ace013e537bfc819dd6d
+"jsc-android@npm:^250231.0.0":
+  version: 250231.0.0
+  resolution: "jsc-android@npm:250231.0.0"
+  checksum: 6c3f0f6f02fa37a19935b2fbe651e9d6ecc370eb30f2ecee76379337bbf084abb568a1ef1133fe622c5b76f43cf54bb7716f92a94dca010985da38edc48841e2
   languageName: node
   linkType: hard
 
-"jscodeshift@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "jscodeshift@npm:0.13.1"
+"jsc-safe-url@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "jsc-safe-url@npm:0.2.4"
+  checksum: 53b5741ba2c0a54da1722929dc80becb2c6fcc9525124fb6c2aec1a00f48e79afffd26816c278111e7b938e37ace029e33cbb8cdaa4ac1f528a87e58022284af
+  languageName: node
+  linkType: hard
+
+"jscodeshift@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "jscodeshift@npm:0.14.0"
   dependencies:
     "@babel/core": ^7.13.16
     "@babel/parser": ^7.13.16
@@ -20443,17 +20815,17 @@ __metadata:
     chalk: ^4.1.2
     flow-parser: 0.*
     graceful-fs: ^4.2.4
-    micromatch: ^3.1.10
+    micromatch: ^4.0.4
     neo-async: ^2.5.0
     node-dir: ^0.1.17
-    recast: ^0.20.4
+    recast: ^0.21.0
     temp: ^0.8.4
     write-file-atomic: ^2.3.0
   peerDependencies:
     "@babel/preset-env": ^7.1.6
   bin:
     jscodeshift: bin/jscodeshift.js
-  checksum: 1c35938de5fc29cafec80e2c37d5c3411f85cd5d40e0243b52f2da0c1ab4b659daddfd62de558eca5d562303616f7838097727b651f4ad8e32b1e96f169cdd76
+  checksum: 54ea6d639455883336f80b38a70648821c88b7942315dc0fbab01bc34a9ad0f0f78e3bd69304b5ab167e4262d6ed7e6284c6d32525ab01c89d9118df89b3e2a0
   languageName: node
   linkType: hard
 
@@ -20730,18 +21102,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonfile@npm:^2.1.0":
-  version: 2.4.0
-  resolution: "jsonfile@npm:2.4.0"
-  dependencies:
-    graceful-fs: ^4.1.6
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: f5064aabbc9e35530dc471d8b203ae1f40dbe949ddde4391c6f6a6d310619a15f0efdae5587df594d1d70c555193aaeee9d2ed4aec9ffd5767bd5e4e62d49c3d
-  languageName: node
-  linkType: hard
-
 "jsonfile@npm:^4.0.0":
   version: 4.0.0
   resolution: "jsonfile@npm:4.0.0"
@@ -20857,18 +21217,6 @@ __metadata:
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
   checksum: 3ab01e7b1d440b22fe4c31f23d8d38b4d9b91d9f291df683476576493d5dfd2e03848a8b05813dd0c3f0e835bc63f433007ddeceb71f05cb25c45ae1b19c6d3b
-  languageName: node
-  linkType: hard
-
-"klaw@npm:^1.0.0":
-  version: 1.3.1
-  resolution: "klaw@npm:1.3.1"
-  dependencies:
-    graceful-fs: ^4.1.9
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 8f69e4797c26e7c3f2426bfa85f38a3da3c2cb1b4c6bd850d2377aed440d41ce9d806f2885c2e2e224372c56af4b1d43b8a499adecf9a05e7373dc6b8b7c52e4
   languageName: node
   linkType: hard
 
@@ -22093,115 +22441,141 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-babel-transformer@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-babel-transformer@npm:0.70.3"
+"metro-babel-transformer@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-babel-transformer@npm:0.76.5"
   dependencies:
-    "@babel/core": ^7.14.0
-    hermes-parser: 0.6.0
-    metro-source-map: 0.70.3
+    "@babel/core": ^7.20.0
+    hermes-parser: 0.8.0
+    metro-source-map: 0.76.5
     nullthrows: ^1.1.1
-  checksum: 9bb4d9c9f571db110548e3662c5b061adfa1805f10c477392859bbab1da3cc6481784859e74c5ba013d48054b44c93762386375c523a72b711f3a255060a5761
+  checksum: 9a53ed3a3b167c79343047f529ab89c308ece3f1bcf1f4d7368d31653225bd515505bb5cc56d92ae93568f0dbf4308f21707fee03ebf59ca4e626283529432fa
   languageName: node
   linkType: hard
 
-"metro-cache-key@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-cache-key@npm:0.70.3"
-  checksum: 353548210ef16335840a4a00fa042f2ec053db49e1d603c13744237850b3b6da8e2cd1ed7b207d59228e55c5f2ca3d2fdd168de931ee09216b203fc8aee02ffd
+"metro-cache-key@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-cache-key@npm:0.76.5"
+  checksum: 87e0d6325dd0666d82d51adc7a5599cdddb56b637e212208c2ccee90b1f1fae2e5fbec4ac6b4960e3cfae462a6ffbe76a6d707b2c053420af52977305f2ed8b2
   languageName: node
   linkType: hard
 
-"metro-cache@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-cache@npm:0.70.3"
+"metro-cache@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-cache@npm:0.76.5"
   dependencies:
-    metro-core: 0.70.3
-    rimraf: ^2.5.4
-  checksum: b2675346d4c08feffe4e30092cb0ff1361eb0ed62b7c26d1e386b86f387eb6a9c0743373d56bbad9eee6a7eccbcebf80d0193cf56b2fcd08a868d37594d9994d
+    metro-core: 0.76.5
+    rimraf: ^3.0.2
+  checksum: a3eaefa2e9a1659463d34930eaa3ee38e09f3daca25142f3d72f99cf9ab74358503591f9941b432f803f59c181051ae01035f03fbeca4b4afd329dbfb32c2131
   languageName: node
   linkType: hard
 
-"metro-config@npm:0.70.3, metro-config@npm:^0.70.1":
-  version: 0.70.3
-  resolution: "metro-config@npm:0.70.3"
+"metro-config@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-config@npm:0.76.5"
   dependencies:
     cosmiconfig: ^5.0.5
-    jest-validate: ^26.5.2
-    metro: 0.70.3
-    metro-cache: 0.70.3
-    metro-core: 0.70.3
-    metro-runtime: 0.70.3
-  checksum: f4eeb78fd29a09400d5a23c94227c3c168079aaa81231d6bd0f4b4724cec22281c1e5a962851596a1c75de44f14fec28e2840c39afe8288667b120686019d788
+    jest-validate: ^29.2.1
+    metro: 0.76.5
+    metro-cache: 0.76.5
+    metro-core: 0.76.5
+    metro-runtime: 0.76.5
+  checksum: 464867bedd23aa277a8d9eb29f37179ae28b44637f120f2f747bba5ba7f06ee4796e4c7e3d3cd9b11f25bc30144ddfbb6d7b7fdd077c637c9a56a784b29642f5
   languageName: node
   linkType: hard
 
-"metro-core@npm:0.70.3, metro-core@npm:^0.70.1":
-  version: 0.70.3
-  resolution: "metro-core@npm:0.70.3"
+"metro-core@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-core@npm:0.76.5"
   dependencies:
-    jest-haste-map: ^27.3.1
     lodash.throttle: ^4.1.1
-    metro-resolver: 0.70.3
-  checksum: a49fbfdca3bbd43ee01e6557a695b747c20037291eff3cba9f633c738cd115814143a9578dbc869e1dc7b6b257dbb43672531aee8562222863e0651dba7988e1
+    metro-resolver: 0.76.5
+  checksum: ca1569f017049371401da85864ed1ae37cdab29edd71bb1a79c701b4420030616bdaf45294523dd6e7c244c0cf74abf6ef8a9808d785e1ca853cd2c271cee6a1
   languageName: node
   linkType: hard
 
-"metro-hermes-compiler@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-hermes-compiler@npm:0.70.3"
-  checksum: c7026a6e86ef53037e6b8b12eb67ac44aca883054dbe03dbdc79d7593ca9ba1a31ebee2f5971073e01666e8d9e63e05383e45b4801cd825ac24056086576067b
+"metro-file-map@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-file-map@npm:0.76.5"
+  dependencies:
+    anymatch: ^3.0.3
+    debug: ^2.2.0
+    fb-watchman: ^2.0.0
+    fsevents: ^2.3.2
+    graceful-fs: ^4.2.4
+    invariant: ^2.2.4
+    jest-regex-util: ^27.0.6
+    jest-util: ^27.2.0
+    jest-worker: ^27.2.0
+    micromatch: ^4.0.4
+    node-abort-controller: ^3.1.1
+    nullthrows: ^1.1.1
+    walker: ^1.0.7
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: d761ad5ef8766aeb30f6e49e1a104610a0a2e1c0d41894c9b9250102aac7c04f66085ec430f1667cb41b0d255ea71bcc7431adba6e72ad2460f4aaa573357bf0
   languageName: node
   linkType: hard
 
-"metro-inspector-proxy@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-inspector-proxy@npm:0.70.3"
+"metro-inspector-proxy@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-inspector-proxy@npm:0.76.5"
   dependencies:
     connect: ^3.6.5
     debug: ^2.2.0
+    node-fetch: ^2.2.0
     ws: ^7.5.1
-    yargs: ^15.3.1
+    yargs: ^17.6.2
   bin:
     metro-inspector-proxy: src/cli.js
-  checksum: 71b183f2f8157acfee3106faf87d40639cc58fc5920d0e0fa7eca056009b9323a4f5a13b1cd54b2a6596c75099c5cba433cc85abb488e4194b81add5b03ebc93
+  checksum: d242b975c1e95a4c2fd25acd52c8ad52e1a2c83aa12fc9217411639ecbe817a0f624888f54921b9c57e8df5d00727ca24c0db33e0b052f609568ffdb7a95534c
   languageName: node
   linkType: hard
 
-"metro-minify-uglify@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-minify-uglify@npm:0.70.3"
+"metro-minify-terser@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-minify-terser@npm:0.76.5"
+  dependencies:
+    terser: ^5.15.0
+  checksum: 5bc834413435b47bc4e90bde8943698a7c5ba8b2e188b9b6507a124844bcd541cb15723b58b77e825072e2da31083291f4484532b602a166e7608ae60e4f5e2b
+  languageName: node
+  linkType: hard
+
+"metro-minify-uglify@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-minify-uglify@npm:0.76.5"
   dependencies:
     uglify-es: ^3.1.9
-  checksum: 27f823f89c2653501c9b06e7c755bf46907541b201d691b86e1ed3171f2e398b5e25598d24079027b43012409e59919df959f7e73601e8132daf78b04d6db781
+  checksum: 79c5e9cd4e7e18986914fa092cb7a7ab6c134beb4e179cc6db180e4c72100187708991a19aef6d342ebd607052dd9cc3435f029884fe680093b2a88870478703
   languageName: node
   linkType: hard
 
-"metro-react-native-babel-preset@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-react-native-babel-preset@npm:0.70.3"
+"metro-react-native-babel-preset@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-react-native-babel-preset@npm:0.76.5"
   dependencies:
-    "@babel/core": ^7.14.0
+    "@babel/core": ^7.20.0
     "@babel/plugin-proposal-async-generator-functions": ^7.0.0
-    "@babel/plugin-proposal-class-properties": ^7.0.0
+    "@babel/plugin-proposal-class-properties": ^7.18.0
     "@babel/plugin-proposal-export-default-from": ^7.0.0
-    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.0.0
-    "@babel/plugin-proposal-object-rest-spread": ^7.0.0
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.18.0
+    "@babel/plugin-proposal-numeric-separator": ^7.0.0
+    "@babel/plugin-proposal-object-rest-spread": ^7.20.0
     "@babel/plugin-proposal-optional-catch-binding": ^7.0.0
-    "@babel/plugin-proposal-optional-chaining": ^7.0.0
-    "@babel/plugin-syntax-dynamic-import": ^7.0.0
+    "@babel/plugin-proposal-optional-chaining": ^7.20.0
+    "@babel/plugin-syntax-dynamic-import": ^7.8.0
     "@babel/plugin-syntax-export-default-from": ^7.0.0
-    "@babel/plugin-syntax-flow": ^7.2.0
+    "@babel/plugin-syntax-flow": ^7.18.0
     "@babel/plugin-syntax-nullish-coalescing-operator": ^7.0.0
     "@babel/plugin-syntax-optional-chaining": ^7.0.0
     "@babel/plugin-transform-arrow-functions": ^7.0.0
-    "@babel/plugin-transform-async-to-generator": ^7.0.0
+    "@babel/plugin-transform-async-to-generator": ^7.20.0
     "@babel/plugin-transform-block-scoping": ^7.0.0
     "@babel/plugin-transform-classes": ^7.0.0
     "@babel/plugin-transform-computed-properties": ^7.0.0
-    "@babel/plugin-transform-destructuring": ^7.0.0
-    "@babel/plugin-transform-exponentiation-operator": ^7.0.0
-    "@babel/plugin-transform-flow-strip-types": ^7.0.0
+    "@babel/plugin-transform-destructuring": ^7.20.0
+    "@babel/plugin-transform-flow-strip-types": ^7.20.0
     "@babel/plugin-transform-function-name": ^7.0.0
     "@babel/plugin-transform-literals": ^7.0.0
     "@babel/plugin-transform-modules-commonjs": ^7.0.0
@@ -22215,130 +22589,127 @@ __metadata:
     "@babel/plugin-transform-shorthand-properties": ^7.0.0
     "@babel/plugin-transform-spread": ^7.0.0
     "@babel/plugin-transform-sticky-regex": ^7.0.0
-    "@babel/plugin-transform-template-literals": ^7.0.0
     "@babel/plugin-transform-typescript": ^7.5.0
     "@babel/plugin-transform-unicode-regex": ^7.0.0
     "@babel/template": ^7.0.0
+    babel-plugin-transform-flow-enums: ^0.0.2
     react-refresh: ^0.4.0
   peerDependencies:
     "@babel/core": "*"
-  checksum: 9abd3d811ad49f5e14c5ac5a62635fffbe5c3a19f0465eb1b8ad2ad2a065f709004d14d892a2d3a336de2c559ba2ef9eb5ef56401bf9718e2a02e7f89eebd227
+  checksum: f93d6d7846fd18d39fd9d2d859eaf238f04691d6b01d718110b905bac46da603f251b0d86ef6dc10c595b899b367617da1333e53d396b768c09f2e7769ff6d42
   languageName: node
   linkType: hard
 
-"metro-react-native-babel-transformer@npm:0.70.3, metro-react-native-babel-transformer@npm:^0.70.1":
-  version: 0.70.3
-  resolution: "metro-react-native-babel-transformer@npm:0.70.3"
+"metro-react-native-babel-transformer@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-react-native-babel-transformer@npm:0.76.5"
   dependencies:
-    "@babel/core": ^7.14.0
+    "@babel/core": ^7.20.0
     babel-preset-fbjs: ^3.4.0
-    hermes-parser: 0.6.0
-    metro-babel-transformer: 0.70.3
-    metro-react-native-babel-preset: 0.70.3
-    metro-source-map: 0.70.3
+    hermes-parser: 0.8.0
+    metro-babel-transformer: 0.76.5
+    metro-react-native-babel-preset: 0.76.5
+    metro-source-map: 0.76.5
     nullthrows: ^1.1.1
   peerDependencies:
     "@babel/core": "*"
-  checksum: 454ece281e40816905eefbc3987af76ff1d96bc18a78badbcd1601603564fdf2bdcaefbcb5118127f1bd2999ad7a869fec782da368b4a99dbaf2ecc57447704a
+  checksum: 84956a63c834482c9d066431c63b645b037edb2b7bd3557858adc36bbbc724f38e48ed9db29e2b9c2d91a963b39161474ad4e117caed87a3f7c816ed072f892e
   languageName: node
   linkType: hard
 
-"metro-resolver@npm:0.70.3, metro-resolver@npm:^0.70.1":
-  version: 0.70.3
-  resolution: "metro-resolver@npm:0.70.3"
-  dependencies:
-    absolute-path: ^0.0.0
-  checksum: 863a9bcd26429557b5f60eb1e774e65618e77291fc2bf6151681156c1d0b5ab664ffd0daca7aec06bfd853b9b7d838861b12eb282561994422fa651c9f379367
+"metro-resolver@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-resolver@npm:0.76.5"
+  checksum: 6ff21c5d1f54a39b54a4c301e7a550c5d71923c5d179f2f457ca62b04609db25b272612ef29d25641b4adaeebbbbc3a4c6652fcb90665b6c6b0c4db6058b7648
   languageName: node
   linkType: hard
 
-"metro-runtime@npm:0.70.3, metro-runtime@npm:^0.70.1":
-  version: 0.70.3
-  resolution: "metro-runtime@npm:0.70.3"
+"metro-runtime@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-runtime@npm:0.76.5"
   dependencies:
     "@babel/runtime": ^7.0.0
-  checksum: 88641e298ee50825b22326e5c32cbce95b1b4acd9a1c22dd0fc1135a473a3ee8aa9c4d4843b68787ba5db792370a4f4c404eb3077e172ea0bbb7aecf02402b57
+    react-refresh: ^0.4.0
+  checksum: 4f431ad5f5e8025d342c44ff5d282b9a36615a6943f5ba50202f4efa55c2227e64fa2811e3fd36f922cbef623b8065acf9c4f340da384ad45b963d860141f8b6
   languageName: node
   linkType: hard
 
-"metro-source-map@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-source-map@npm:0.70.3"
+"metro-source-map@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-source-map@npm:0.76.5"
   dependencies:
-    "@babel/traverse": ^7.14.0
-    "@babel/types": ^7.0.0
+    "@babel/traverse": ^7.20.0
+    "@babel/types": ^7.20.0
     invariant: ^2.2.4
-    metro-symbolicate: 0.70.3
+    metro-symbolicate: 0.76.5
     nullthrows: ^1.1.1
-    ob1: 0.70.3
+    ob1: 0.76.5
     source-map: ^0.5.6
     vlq: ^1.0.0
-  checksum: 3ccf4864ec5644762d691ba7964ab9c7a30a33e91504b893169a3b0e51d8cf00c9269388ff13230703bd40f935be76158ab84e9b7b6b28895329338905d2af85
+  checksum: dc3bb22e068dc09bffab04f6697bb403d17d417bebaa9ca39749e0bf3d9cc54ca14de177555e4aa43d3dfc7f44340e08ac5f452d8595814248e95daa9cf0bf0a
   languageName: node
   linkType: hard
 
-"metro-symbolicate@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-symbolicate@npm:0.70.3"
+"metro-symbolicate@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-symbolicate@npm:0.76.5"
   dependencies:
     invariant: ^2.2.4
-    metro-source-map: 0.70.3
+    metro-source-map: 0.76.5
     nullthrows: ^1.1.1
     source-map: ^0.5.6
     through2: ^2.0.1
     vlq: ^1.0.0
   bin:
     metro-symbolicate: src/index.js
-  checksum: 6fd827a416ee640f9ef1f07f9601109f49dd73aa4b86592d72fc4d8b0e88a766e54eef710454b10b226bc893f31339b7d4502d995e6c9c28bb328dd5a871127e
+  checksum: c60c60c91bb7f7ed30f75652a1ee269a631788fa42c88f609895aee245b50c9c17230b586f6efe5a1181fd9e0813c05edb0a3f623a5eac86d2e4b3fffc14e703
   languageName: node
   linkType: hard
 
-"metro-transform-plugins@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-transform-plugins@npm:0.70.3"
+"metro-transform-plugins@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-transform-plugins@npm:0.76.5"
   dependencies:
-    "@babel/core": ^7.14.0
-    "@babel/generator": ^7.14.0
+    "@babel/core": ^7.20.0
+    "@babel/generator": ^7.20.0
     "@babel/template": ^7.0.0
-    "@babel/traverse": ^7.14.0
+    "@babel/traverse": ^7.20.0
     nullthrows: ^1.1.1
-  checksum: d3e8309618a5bd6a3c3867e033697efb6e9b34741b74feaa9afa86b9cbfed1236ff4923b611de0177023a37337678fc559d6672982c3fad43c71e6ce50a6f207
+  checksum: 4b00e7f61c0cfd38643c687eb33fe4d17abbf5a24731ed20150593e67bb270f59a097d07f1749fea6990badbffd06ac5fbda4e9425be8e53402e57decf07a01b
   languageName: node
   linkType: hard
 
-"metro-transform-worker@npm:0.70.3":
-  version: 0.70.3
-  resolution: "metro-transform-worker@npm:0.70.3"
+"metro-transform-worker@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro-transform-worker@npm:0.76.5"
   dependencies:
-    "@babel/core": ^7.14.0
-    "@babel/generator": ^7.14.0
-    "@babel/parser": ^7.14.0
-    "@babel/types": ^7.0.0
+    "@babel/core": ^7.20.0
+    "@babel/generator": ^7.20.0
+    "@babel/parser": ^7.20.0
+    "@babel/types": ^7.20.0
     babel-preset-fbjs: ^3.4.0
-    metro: 0.70.3
-    metro-babel-transformer: 0.70.3
-    metro-cache: 0.70.3
-    metro-cache-key: 0.70.3
-    metro-hermes-compiler: 0.70.3
-    metro-source-map: 0.70.3
-    metro-transform-plugins: 0.70.3
+    metro: 0.76.5
+    metro-babel-transformer: 0.76.5
+    metro-cache: 0.76.5
+    metro-cache-key: 0.76.5
+    metro-source-map: 0.76.5
+    metro-transform-plugins: 0.76.5
     nullthrows: ^1.1.1
-  checksum: 514eba1a994b2bad69f81dee48078693ab99e6885d8a8782b818629f33e9d3f5e35e75285dc7a2a0d3fdba1ff79d2577a43032425974452fa6e8dd1878101da4
+  checksum: a1c7d86410ed7591ce8ebc5d817045306d54995843025133709d104bd57fef67e39c8eb0db35d5b909fb3e82ba160ece7eb5829d985ea4ea406eacceedf40b14
   languageName: node
   linkType: hard
 
-"metro@npm:0.70.3, metro@npm:^0.70.1":
-  version: 0.70.3
-  resolution: "metro@npm:0.70.3"
+"metro@npm:0.76.5":
+  version: 0.76.5
+  resolution: "metro@npm:0.76.5"
   dependencies:
     "@babel/code-frame": ^7.0.0
-    "@babel/core": ^7.14.0
-    "@babel/generator": ^7.14.0
-    "@babel/parser": ^7.14.0
+    "@babel/core": ^7.20.0
+    "@babel/generator": ^7.20.0
+    "@babel/parser": ^7.20.0
     "@babel/template": ^7.0.0
-    "@babel/traverse": ^7.14.0
-    "@babel/types": ^7.0.0
-    absolute-path: ^0.0.0
+    "@babel/traverse": ^7.20.0
+    "@babel/types": ^7.20.0
     accepts: ^1.3.7
     async: ^3.2.2
     chalk: ^4.0.0
@@ -22347,43 +22718,42 @@ __metadata:
     debug: ^2.2.0
     denodeify: ^1.2.1
     error-stack-parser: ^2.0.6
-    fs-extra: ^1.0.0
     graceful-fs: ^4.2.4
-    hermes-parser: 0.6.0
-    image-size: ^0.6.0
+    hermes-parser: 0.8.0
+    image-size: ^1.0.2
     invariant: ^2.2.4
-    jest-haste-map: ^27.3.1
     jest-worker: ^27.2.0
+    jsc-safe-url: ^0.2.2
     lodash.throttle: ^4.1.1
-    metro-babel-transformer: 0.70.3
-    metro-cache: 0.70.3
-    metro-cache-key: 0.70.3
-    metro-config: 0.70.3
-    metro-core: 0.70.3
-    metro-hermes-compiler: 0.70.3
-    metro-inspector-proxy: 0.70.3
-    metro-minify-uglify: 0.70.3
-    metro-react-native-babel-preset: 0.70.3
-    metro-resolver: 0.70.3
-    metro-runtime: 0.70.3
-    metro-source-map: 0.70.3
-    metro-symbolicate: 0.70.3
-    metro-transform-plugins: 0.70.3
-    metro-transform-worker: 0.70.3
+    metro-babel-transformer: 0.76.5
+    metro-cache: 0.76.5
+    metro-cache-key: 0.76.5
+    metro-config: 0.76.5
+    metro-core: 0.76.5
+    metro-file-map: 0.76.5
+    metro-inspector-proxy: 0.76.5
+    metro-minify-terser: 0.76.5
+    metro-minify-uglify: 0.76.5
+    metro-react-native-babel-preset: 0.76.5
+    metro-resolver: 0.76.5
+    metro-runtime: 0.76.5
+    metro-source-map: 0.76.5
+    metro-symbolicate: 0.76.5
+    metro-transform-plugins: 0.76.5
+    metro-transform-worker: 0.76.5
     mime-types: ^2.1.27
     node-fetch: ^2.2.0
     nullthrows: ^1.1.1
-    rimraf: ^2.5.4
+    rimraf: ^3.0.2
     serialize-error: ^2.1.0
     source-map: ^0.5.6
     strip-ansi: ^6.0.0
-    temp: 0.8.3
     throat: ^5.0.0
     ws: ^7.5.1
-    yargs: ^15.3.1
+    yargs: ^17.6.2
   bin:
     metro: src/cli.js
-  checksum: 6fb5a543d52b469edb0baa245b001b735dfb1afe673dd7cdd8853b942007e2d0445b5e5952132e7f1c4d144fb9a79408abe52cc9894844b905b94af4b5a56260
+  checksum: ff8107c0f318bffad95d5709ab1d1b2279ebae485419c9b303ae1c1abd86a305329b903d9af1c2d43883b5577bcb1e7a98dd8fb562b31f4034f3cf7fefc1c16f
   languageName: node
   linkType: hard
 
@@ -23087,6 +23457,13 @@ __metadata:
   version: 3.0.4
   resolution: "nocache@npm:3.0.4"
   checksum: 6be9ee67eb561ecedc56d805c024c0fda55b9836ecba659c720073b067929aa4fe04bb7121480e004c9cf52989e62d8720f29a7fe0269f1a4941221a1e4be1c2
+  languageName: node
+  linkType: hard
+
+"node-abort-controller@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "node-abort-controller@npm:3.1.1"
+  checksum: 2c340916af9710328b11c0828223fc65ba320e0d082214a211311bf64c2891028e42ef276b9799188c4ada9e6e1c54cf7a0b7c05dd9d59fcdc8cd633304c8047
   languageName: node
   linkType: hard
 
@@ -23956,10 +24333,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ob1@npm:0.70.3":
-  version: 0.70.3
-  resolution: "ob1@npm:0.70.3"
-  checksum: 50531606767e07cc53d7a4af1070e380789b23c543773fae34952ba7f1885762fdb241c2031310aca6b24c1181db16698f4428a5621de7e705e9492d0e748049
+"ob1@npm:0.76.5":
+  version: 0.76.5
+  resolution: "ob1@npm:0.76.5"
+  checksum: 1f186035b6b6907048d3c96f5d08e1df58d95bf271ade5736433f447bc37e97ebd30bd5204511cdafd769f57df5113bbbb41ab984c3acdb7c799d4e777c1c4a3
   languageName: node
   linkType: hard
 
@@ -25074,7 +25451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"plist@npm:^3.0.1, plist@npm:^3.0.2, plist@npm:^3.0.4":
+"plist@npm:^3.0.1, plist@npm:^3.0.4":
   version: 3.0.6
   resolution: "plist@npm:3.0.6"
   dependencies:
@@ -25487,7 +25864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"promise@npm:^8.0.3":
+"promise@npm:^8.3.0":
   version: 8.3.0
   resolution: "promise@npm:8.3.0"
   dependencies:
@@ -25525,7 +25902,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.0.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.4, prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:*, prop-types@npm:^15.0.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.4, prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -25780,6 +26157,15 @@ __metadata:
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: b676f8c040cdc5b12723ad2f91414d267605b26419d5c821ff03befa817ddd10e238d22b25d604920340fd73efd8ba795465a0377c4adf45a4a41e4234e42dc4
+  languageName: node
+  linkType: hard
+
+"queue@npm:6.0.2":
+  version: 6.0.2
+  resolution: "queue@npm:6.0.2"
+  dependencies:
+    inherits: ~2.0.3
+  checksum: ebc23639248e4fe40a789f713c20548e513e053b3dc4924b6cb0ad741e3f264dcff948225c8737834dd4f9ec286dbc06a1a7c13858ea382d9379f4303bcc0916
   languageName: node
   linkType: hard
 
@@ -26045,13 +26431,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-devtools-core@npm:4.24.0":
-  version: 4.24.0
-  resolution: "react-devtools-core@npm:4.24.0"
+"react-devtools-core@npm:^4.27.2":
+  version: 4.27.8
+  resolution: "react-devtools-core@npm:4.27.8"
   dependencies:
     shell-quote: ^1.6.1
     ws: ^7
-  checksum: c9e21ff2621447a6de51d4a350f3859e8077634f8be327f006d8da73dba349e78432ef910e432f066c615938fed697231ed3daee8f9eae049004c14ebac85625
+  checksum: 83213d5f620e95cf9e60d21a186949f1a523253ea5cca3371d61cf74102efd5074e2e9431cebe4cd9be45a77db647af9c2cdb44c69907ed07441a3334ca19c8b
   languageName: node
   linkType: hard
 
@@ -26338,18 +26724,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-codegen@npm:^0.69.2":
-  version: 0.69.2
-  resolution: "react-native-codegen@npm:0.69.2"
-  dependencies:
-    "@babel/parser": ^7.14.0
-    flow-parser: ^0.121.0
-    jscodeshift: ^0.13.1
-    nullthrows: ^1.1.1
-  checksum: 73dc9464a90fde727a19ad4f002f3bc4ec948a948cd95b5f3bfbef24ff7cf2ca7282830fd99e6b1772804c1e0f172e64097190021b3a00ba27a1f9777e58cf77
-  languageName: node
-  linkType: hard
-
 "react-native-flipper@npm:0.164.0":
   version: 0.164.0
   resolution: "react-native-flipper@npm:0.164.0"
@@ -26357,13 +26731,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-native: ">0.62.0"
   checksum: 8730d7349bec27a23558760320082bd89b07fb404a87bf039a8d852455f28e4d5419f093bb7900ff5f6d85488274cfb246278b6700878bcabe574d5aacd88dac
-  languageName: node
-  linkType: hard
-
-"react-native-gradle-plugin@npm:^0.0.7":
-  version: 0.0.7
-  resolution: "react-native-gradle-plugin@npm:0.0.7"
-  checksum: 959ce3bcbc8362909210fae894e4b414a0afdff39fe1683463214b7feddae6beaf8584ebe62323b1e91ba31de00311e826588e0d807c93a949e445b1770cac27
   languageName: node
   linkType: hard
 
@@ -26377,48 +26744,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native@npm:0.69.5":
-  version: 0.69.5
-  resolution: "react-native@npm:0.69.5"
+"react-native@npm:0.72.1":
+  version: 0.72.1
+  resolution: "react-native@npm:0.72.1"
   dependencies:
-    "@jest/create-cache-key-function": ^27.0.1
-    "@react-native-community/cli": ^8.0.4
-    "@react-native-community/cli-platform-android": ^8.0.4
-    "@react-native-community/cli-platform-ios": ^8.0.4
-    "@react-native/assets": 1.0.0
-    "@react-native/normalize-color": 2.0.0
-    "@react-native/polyfills": 2.0.0
+    "@jest/create-cache-key-function": ^29.2.1
+    "@react-native-community/cli": 11.3.3
+    "@react-native-community/cli-platform-android": 11.3.3
+    "@react-native-community/cli-platform-ios": 11.3.3
+    "@react-native/assets-registry": ^0.72.0
+    "@react-native/codegen": ^0.72.6
+    "@react-native/gradle-plugin": ^0.72.11
+    "@react-native/js-polyfills": ^0.72.1
+    "@react-native/normalize-colors": ^0.72.0
+    "@react-native/virtualized-lists": ^0.72.6
     abort-controller: ^3.0.0
     anser: ^1.4.9
     base64-js: ^1.1.2
+    deprecated-react-native-prop-types: 4.1.0
     event-target-shim: ^5.0.1
-    hermes-engine: ~0.11.0
+    flow-enums-runtime: ^0.0.5
     invariant: ^2.2.4
-    jsc-android: ^250230.2.1
+    jest-environment-node: ^29.2.1
+    jsc-android: ^250231.0.0
     memoize-one: ^5.0.0
-    metro-react-native-babel-transformer: 0.70.3
-    metro-runtime: 0.70.3
-    metro-source-map: 0.70.3
+    metro-runtime: 0.76.5
+    metro-source-map: 0.76.5
     mkdirp: ^0.5.1
     nullthrows: ^1.1.1
     pretty-format: ^26.5.2
-    promise: ^8.0.3
-    react-devtools-core: 4.24.0
-    react-native-codegen: ^0.69.2
-    react-native-gradle-plugin: ^0.0.7
+    promise: ^8.3.0
+    react-devtools-core: ^4.27.2
     react-refresh: ^0.4.0
-    react-shallow-renderer: 16.15.0
+    react-shallow-renderer: ^16.15.0
     regenerator-runtime: ^0.13.2
-    scheduler: ^0.21.0
-    stacktrace-parser: ^0.1.3
+    scheduler: 0.24.0-canary-efb381bbf-20230505
+    stacktrace-parser: ^0.1.10
     use-sync-external-store: ^1.0.0
     whatwg-fetch: ^3.0.0
-    ws: ^6.1.4
+    ws: ^6.2.2
+    yargs: ^17.6.2
   peerDependencies:
-    react: 18.0.0
+    react: 18.2.0
   bin:
     react-native: cli.js
-  checksum: 4f7cfcd0d614cc6fe897a49197bd036210625c5eb547342ac7ebea45ab5febae73d6a9a7438f08f454d1e02c2e041b3f910461c4a6e5c6e0e44f5cfe70405990
+  checksum: a417056ecadc3a4d365cd3cec35acb18521cea7ed12f52f2a932e43a022a8c2616d7d94728ad4eeb89feee9b908e2a086cca68a61e45c44c34070b7a367f3cd9
   languageName: node
   linkType: hard
 
@@ -26549,7 +26919,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-shallow-renderer@npm:16.15.0, react-shallow-renderer@npm:^16.13.1":
+"react-shallow-renderer@npm:^16.13.1, react-shallow-renderer@npm:^16.15.0":
   version: 16.15.0
   resolution: "react-shallow-renderer@npm:16.15.0"
   dependencies:
@@ -27109,7 +27479,7 @@ __metadata:
     "@types/jest": 29.4.0
     "@types/node": 16.11.11
     "@types/react": 18.0.0
-    "@types/react-native": 0.69.5
+    "@types/react-native": 0.72.1
     "@typescript-eslint/eslint-plugin": ^5.54.0
     "@typescript-eslint/parser": ^5.40.0
     babel-eslint: ^10.1.0
@@ -27127,7 +27497,7 @@ __metadata:
     prettier: ^2.8.4
     query-string: 6.10.1
     react: ">=17.0.2"
-    react-native: 0.69.5
+    react-native: 0.72.1
     react-native-flipper: 0.164.0
     reactotron-core-client: "workspace:*"
     rimraf: 4.1.3
@@ -27462,15 +27832,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"recast@npm:^0.20.4":
-  version: 0.20.5
-  resolution: "recast@npm:0.20.5"
+"recast@npm:^0.21.0":
+  version: 0.21.5
+  resolution: "recast@npm:0.21.5"
   dependencies:
-    ast-types: 0.14.2
+    ast-types: 0.15.2
     esprima: ~4.0.0
     source-map: ~0.6.1
     tslib: ^2.0.1
-  checksum: 14c35115cd9965950724cb2968f069a247fa79ce890643ab6dc3795c705b363f7b92a45238e9f765387c306763be9955f72047bb9d15b5d60b0a55f9e7912d5a
+  checksum: 03cc7f57562238ba258d468be67bf7446ce7a707bc87a087891dad15afead46c36e9aaeedf2130e2ab5a465244a9c62bfd4127849761cf8f4085abe2f3e5f485
   languageName: node
   linkType: hard
 
@@ -28065,15 +28435,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:~2.2.6":
-  version: 2.2.8
-  resolution: "rimraf@npm:2.2.8"
-  bin:
-    rimraf: ./bin.js
-  checksum: 01804e1c0430eeece3fd778e836e9682c011e126d42a4f560e930f8cdc2d99c7e586e63d18c5a65accbd51f9ac57706177550de0538c1dd45c335755605de166
-  languageName: node
-  linkType: hard
-
 "ripemd160@npm:^2.0.0, ripemd160@npm:^2.0.1":
   version: 2.0.2
   resolution: "ripemd160@npm:2.0.2"
@@ -28514,6 +28875,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"scheduler@npm:0.24.0-canary-efb381bbf-20230505":
+  version: 0.24.0-canary-efb381bbf-20230505
+  resolution: "scheduler@npm:0.24.0-canary-efb381bbf-20230505"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: 232149125c10f10193b1340ec4bbf14a8e6a845152790d6fd6f58207642db801abdb5a21227561a0a93871b98ba47539a6233b4e6155aae72d6db6db9f9f09b3
+  languageName: node
+  linkType: hard
+
 "scheduler@npm:^0.19.1":
   version: 0.19.1
   resolution: "scheduler@npm:0.19.1"
@@ -28531,15 +28901,6 @@ __metadata:
     loose-envify: ^1.1.0
     object-assign: ^4.1.1
   checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.21.0":
-  version: 0.21.0
-  resolution: "scheduler@npm:0.21.0"
-  dependencies:
-    loose-envify: ^1.1.0
-  checksum: 4f8285076041ed2c81acdd1faa987f1655fdbd30554bc667c1ea64743fc74fb3a04ca7d27454b3d678735df5a230137a3b84756061b43dc5796e80701b66d124
   languageName: node
   linkType: hard
 
@@ -29639,7 +30000,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stacktrace-parser@npm:^0.1.3":
+"stacktrace-parser@npm:^0.1.10":
   version: 0.1.10
   resolution: "stacktrace-parser@npm:0.1.10"
   dependencies:
@@ -30132,6 +30493,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strnum@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "strnum@npm:1.0.5"
+  checksum: 651b2031db5da1bf4a77fdd2f116a8ac8055157c5420f5569f64879133825915ad461513e7202a16d7fec63c54fd822410d0962f8ca12385c4334891b9ae6dd2
+  languageName: node
+  linkType: hard
+
 "strong-log-transformer@npm:^2.1.0":
   version: 2.1.0
   resolution: "strong-log-transformer@npm:2.1.0"
@@ -30464,16 +30832,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"temp@npm:0.8.3":
-  version: 0.8.3
-  resolution: "temp@npm:0.8.3"
-  dependencies:
-    os-tmpdir: ^1.0.0
-    rimraf: ~2.2.6
-  checksum: bfc6f1223dd568c21efb279433f40dbb4fe269da2ca2c622f6f50276751325ba9a2888628a342bc2c56764164ee6430229319604cf0a862d480151f8ae65ca5b
-  languageName: node
-  linkType: hard
-
 "temp@npm:^0.8.4":
   version: 0.8.4
   resolution: "temp@npm:0.8.4"
@@ -30587,6 +30945,20 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: b342819bf7e82283059aaa3f22bb74deb1862d07573ba5a8947882190ad525fd9b44a15074986be083fd379c58b9a879457a330b66dcdb77b485c44267f9a55a
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.15.0":
+  version: 5.18.2
+  resolution: "terser@npm:5.18.2"
+  dependencies:
+    "@jridgewell/source-map": ^0.3.3
+    acorn: ^8.8.2
+    commander: ^2.20.0
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: 50988412533bfd5a07294df002d772ad5b1277a9d1164dd19c8876a2094ced7b78fcf36cb32122a9a5238ba2597d77178a2385dfc6c4d506622309493f613cf4
   languageName: node
   linkType: hard
 
@@ -32672,7 +33044,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^6.1.4, ws@npm:^6.2.1":
+"ws@npm:^6.2.1, ws@npm:^6.2.2":
   version: 6.2.2
   resolution: "ws@npm:6.2.2"
   dependencies:
@@ -32810,6 +33182,13 @@ __metadata:
   version: 2.2.1
   resolution: "yaml@npm:2.2.1"
   checksum: 84f68cbe462d5da4e7ded4a8bded949ffa912bc264472e5a684c3d45b22d8f73a3019963a32164023bdf3d83cfb6f5b58ff7b2b10ef5b717c630f40bd6369a23
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.2.1":
+  version: 2.3.1
+  resolution: "yaml@npm:2.3.1"
+  checksum: 2c7bc9a7cd4c9f40d3b0b0a98e370781b68b8b7c4515720869aced2b00d92f5da1762b4ffa947f9e795d6cd6b19f410bd4d15fdd38aca7bd96df59bd9486fb54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes the `trackGlobalError` plugin, which appears to have been broken for a while.

We rely on an internal utility called `parseErrorStack` that is provided by the `react-native` package. However, the signature got changed internally and this broke our usage: https://github.com/facebook/react-native/commit/9edfc43aad2f68be8a37c916779681cd9ad13fee

Additionally, the `DevTools` typescript definitions file is still incorrect.  This PR adds some manual type definitions of internals that are not provided by react-native, as well as some corrections of internal types.

This PR also removes the "swizzled" strategy for spying on internals in favor of using `Proxy`.

Related Issues:
- https://github.com/infinitered/reactotron/issues/1260
- https://github.com/infinitered/reactotron/issues/1253

Video of new usage:

https://github.com/infinitered/reactotron/assets/37849890/6fccedf5-df46-4391-aa16-8cb5351cd741

