### PR TITLE
Massively improve reactotron-core-client types

### DIFF
--- a/lib/reactotron-core-client/src/client-options.ts
+++ b/lib/reactotron-core-client/src/client-options.ts
@@ -1,16 +1,19 @@
-import type { ReactotronCore } from "./reactotron-core-client"
+import type { LifeCycleMethods, PluginCreator } from "./reactotron-core-client"
+import * as NodeWebSocket from "ws"
+
+type BrowserWebSocket = WebSocket
 
 /**
  * Configuration options for the Reactotron Client.
  */
-export interface ClientOptions {
+export interface ClientOptions<Client> extends LifeCycleMethods<Client> {
   /**
    * A function which returns a websocket.
    *
    * This is over-engineered because we need the ability to create different
    * types of websockets for React Native, React, and NodeJS.  :|
    */
-  createSocket?: (path?: string) => any
+  createSocket?: ((path: string) => BrowserWebSocket) | ((path: string) => NodeWebSocket)
 
   /**
    * The hostname or ip address of the server.  Default: localhost.
@@ -35,7 +38,7 @@ export interface ClientOptions {
   /**
    * A list of plugins.
    */
-  plugins?: ((reactotron: ReactotronCore) => any)[]
+  plugins?: PluginCreator<Client>[]
 
   /**
    * Performs safety checks when serializing.  Default: true.
@@ -72,12 +75,12 @@ export interface ClientOptions {
   /**
    * A way for the client libraries to identify themselves.
    */
-  client?: any
+  client?: Record<string, string | number | boolean>
 
   /**
    * Save the client id provided by the server
    */
-  setClientId?: (clientId) => Promise<void>
+  setClientId?: (clientId: string) => Promise<void>
 
   /**
    * Get the client id provided by the server

--- a/lib/reactotron-core-client/src/client-options.ts
+++ b/lib/reactotron-core-client/src/client-options.ts
@@ -6,7 +6,7 @@ type BrowserWebSocket = WebSocket
 /**
  * Configuration options for the Reactotron Client.
  */
-export interface ClientOptions<Client> extends LifeCycleMethods<Client> {
+export interface ClientOptions<Client> extends LifeCycleMethods {
   /**
    * A function which returns a websocket.
    *

--- a/lib/reactotron-core-client/src/plugins/api-response.ts
+++ b/lib/reactotron-core-client/src/plugins/api-response.ts
@@ -1,12 +1,13 @@
-import type { Reactotron } from "../reactotron-core-client"
+import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 
 /**
  * Sends API request/response information.
  */
-export default () => (reactotron: Reactotron) => {
+
+const apiResponse = () => (reactotron: ReactotronCore) => {
   return {
     features: {
-      apiResponse: (request, response, duration) => {
+      apiResponse: (request: {status: number}, response: any, duration: number) => {
         const ok =
           response &&
           response.status &&
@@ -17,5 +18,7 @@ export default () => (reactotron: Reactotron) => {
         reactotron.send("api.response", { request, response, duration }, important)
       },
     },
-  }
-}
+  } satisfies Plugin<ReactotronCore>
+} 
+
+export default apiResponse

--- a/lib/reactotron-core-client/src/plugins/api-response.ts
+++ b/lib/reactotron-core-client/src/plugins/api-response.ts
@@ -3,11 +3,10 @@ import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 /**
  * Sends API request/response information.
  */
-
 const apiResponse = () => (reactotron: ReactotronCore) => {
   return {
     features: {
-      apiResponse: (request: {status: number}, response: any, duration: number) => {
+      apiResponse: (request: { status: number }, response: any, duration: number) => {
         const ok =
           response &&
           response.status &&
@@ -19,6 +18,6 @@ const apiResponse = () => (reactotron: ReactotronCore) => {
       },
     },
   } satisfies Plugin<ReactotronCore>
-} 
+}
 
 export default apiResponse

--- a/lib/reactotron-core-client/src/plugins/benchmark.ts
+++ b/lib/reactotron-core-client/src/plugins/benchmark.ts
@@ -1,9 +1,9 @@
-import type { Reactotron } from "../reactotron-core-client"
+import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 
 /**
  * Runs small high-unscientific benchmarks for you.
  */
-export default () => (reactotron: Reactotron) => {
+export default () => (reactotron: ReactotronCore) => {
   const { startTimer } = reactotron
 
   const benchmark = (title) => {
@@ -24,5 +24,5 @@ export default () => (reactotron: Reactotron) => {
 
   return {
     features: { benchmark },
-  }
+  } satisfies Plugin<ReactotronCore>
 }

--- a/lib/reactotron-core-client/src/plugins/benchmark.ts
+++ b/lib/reactotron-core-client/src/plugins/benchmark.ts
@@ -3,19 +3,19 @@ import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 /**
  * Runs small high-unscientific benchmarks for you.
  */
-export default () => (reactotron: ReactotronCore) => {
+const benchmark = () => (reactotron: ReactotronCore) => {
   const { startTimer } = reactotron
 
-  const benchmark = (title) => {
+  const benchmark = (title: string) => {
     const steps = []
     const elapsed = startTimer()
-    const step = (stepTitle) => {
+    const step = (stepTitle: string) => {
       const previousTime = steps.length === 0 ? 0 : (steps[steps.length - 1] as any).time
       const nextTime = elapsed()
       steps.push({ title: stepTitle, time: nextTime, delta: nextTime - previousTime })
     }
     steps.push({ title, time: 0, delta: 0 })
-    const stop = (stopTitle) => {
+    const stop = (stopTitle: string) => {
       step(stopTitle)
       reactotron.send("benchmark.report", { title, steps })
     }
@@ -26,3 +26,5 @@ export default () => (reactotron: ReactotronCore) => {
     features: { benchmark },
   } satisfies Plugin<ReactotronCore>
 }
+
+export default benchmark

--- a/lib/reactotron-core-client/src/plugins/clear.ts
+++ b/lib/reactotron-core-client/src/plugins/clear.ts
@@ -1,12 +1,12 @@
-import type { Reactotron } from "../reactotron-core-client"
+import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 
 /**
  * Clears the reactotron server.
  */
-export default () => (reactotron: Reactotron) => {
+export default () => (reactotron: ReactotronCore) => {
   return {
     features: {
       clear: () => reactotron.send("clear"),
     },
-  }
+  } satisfies Plugin<ReactotronCore>
 }

--- a/lib/reactotron-core-client/src/plugins/clear.ts
+++ b/lib/reactotron-core-client/src/plugins/clear.ts
@@ -3,10 +3,12 @@ import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 /**
  * Clears the reactotron server.
  */
-export default () => (reactotron: ReactotronCore) => {
+const clear = () => (reactotron: ReactotronCore) => {
   return {
     features: {
       clear: () => reactotron.send("clear"),
     },
   } satisfies Plugin<ReactotronCore>
 }
+
+export default clear

--- a/lib/reactotron-core-client/src/plugins/image.ts
+++ b/lib/reactotron-core-client/src/plugins/image.ts
@@ -1,14 +1,14 @@
-import type { Reactotron } from "../reactotron-core-client"
+import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 
 /**
  * Provides an image.
  */
-export default () => (reactotron: Reactotron) => {
+export default () => (reactotron: ReactotronCore) => {
   return {
     features: {
       // expanded just to show the specs
       image: ({ uri, preview, filename, width, height, caption }) =>
         reactotron.send("image", { uri, preview, filename, width, height, caption }),
     },
-  }
+  } satisfies Plugin<ReactotronCore>
 }

--- a/lib/reactotron-core-client/src/plugins/image.ts
+++ b/lib/reactotron-core-client/src/plugins/image.ts
@@ -1,6 +1,6 @@
 import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 
-interface ImagePayload {
+export interface ImagePayload {
   uri: string
   preview: string
   caption?: string
@@ -16,8 +16,10 @@ const image = () => (reactotron: ReactotronCore) => {
   return {
     features: {
       // expanded just to show the specs
-      image: ({ uri, preview, filename, width, height, caption }: ImagePayload) =>
-        reactotron.send("image", { uri, preview, filename, width, height, caption }),
+      image: (payload: ImagePayload) => {
+        const { uri, preview, filename, width, height, caption } = payload
+        return reactotron.send("image", { uri, preview, filename, width, height, caption })
+      },
     },
   } satisfies Plugin<ReactotronCore>
 }

--- a/lib/reactotron-core-client/src/plugins/image.ts
+++ b/lib/reactotron-core-client/src/plugins/image.ts
@@ -1,14 +1,25 @@
 import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 
+interface ImagePayload {
+  uri: string
+  preview: string
+  caption?: string
+  width?: number
+  height?: number
+  filename?: string
+}
+
 /**
  * Provides an image.
  */
-export default () => (reactotron: ReactotronCore) => {
+const image = () => (reactotron: ReactotronCore) => {
   return {
     features: {
       // expanded just to show the specs
-      image: ({ uri, preview, filename, width, height, caption }) =>
+      image: ({ uri, preview, filename, width, height, caption }: ImagePayload) =>
         reactotron.send("image", { uri, preview, filename, width, height, caption }),
     },
   } satisfies Plugin<ReactotronCore>
 }
+
+export default image

--- a/lib/reactotron-core-client/src/plugins/logger.ts
+++ b/lib/reactotron-core-client/src/plugins/logger.ts
@@ -1,9 +1,9 @@
-import type { Reactotron } from "../reactotron-core-client"
+import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 
 /**
  * Provides 4 features for logging.  log & debug are the same.
  */
-export default () => (reactotron: Reactotron) => {
+export default () => (reactotron: ReactotronCore) => {
   return {
     features: {
       log: (...args) => {
@@ -19,5 +19,5 @@ export default () => (reactotron: Reactotron) => {
       warn: (message) => reactotron.send("log", { level: "warn", message }, true),
       error: (message, stack) => reactotron.send("log", { level: "error", message, stack }, true),
     },
-  }
+  } satisfies Plugin<ReactotronCore>
 }

--- a/lib/reactotron-core-client/src/plugins/logger.ts
+++ b/lib/reactotron-core-client/src/plugins/logger.ts
@@ -1,9 +1,9 @@
-import type { ReactotronCore, Plugin } from "../reactotron-core-client"
+import type { ReactotronCore, Plugin, InferFeatures } from "../reactotron-core-client"
 
 /**
  * Provides 4 features for logging.  log & debug are the same.
  */
-export default () => (reactotron: ReactotronCore) => {
+const logger = () => (reactotron: ReactotronCore) => {
   return {
     features: {
       log: (...args) => {
@@ -20,4 +20,37 @@ export default () => (reactotron: ReactotronCore) => {
       error: (message, stack) => reactotron.send("log", { level: "error", message, stack }, true),
     },
   } satisfies Plugin<ReactotronCore>
+}
+
+export default logger
+
+export type LoggerPlugin = ReturnType<typeof logger>
+
+export const hasLoggerPlugin = (
+  reactotron: ReactotronCore
+): reactotron is ReactotronCore & InferFeatures<ReactotronCore, ReturnType<typeof logger>> => {
+  return (
+    reactotron &&
+    "log" in reactotron &&
+    typeof reactotron.log === "function" &&
+    "logImportant" in reactotron &&
+    typeof reactotron.logImportant === "function" &&
+    "debug" in reactotron &&
+    typeof reactotron.debug === "function" &&
+    "warn" in reactotron &&
+    typeof reactotron.warn === "function" &&
+    "error" in reactotron &&
+    typeof reactotron.error === "function"
+  )
+}
+
+export const assertHasLoggerPlugin = (
+  reactotron: ReactotronCore
+): asserts reactotron is ReactotronCore &
+  InferFeatures<ReactotronCore, ReturnType<typeof logger>> => {
+  if (!hasLoggerPlugin(reactotron)) {
+    throw new Error(
+      "This Reactotron client has not had the logger plugin applied to it. Make sure that you add `use(logger())` before adding this plugin."
+    )
+  }
 }

--- a/lib/reactotron-core-client/src/plugins/repl.ts
+++ b/lib/reactotron-core-client/src/plugins/repl.ts
@@ -1,13 +1,13 @@
-import type { Reactotron } from "../reactotron-core-client"
+import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 
 export type AcceptableRepls = object | Function | string | number
 
-export default () => (reactotron: Reactotron) => {
+export default () => (reactotron: ReactotronCore) => {
   const myRepls: { [key: string]: AcceptableRepls } = {}
   // let currentContext = null
 
   return {
-    onCommand: ({ type, payload }: { type: string; payload?: any }) => {
+    onCommand: ({ type, payload }) => {
       if (type.substr(0, 5) !== "repl.") return
 
       switch (type.substr(5)) {
@@ -64,5 +64,5 @@ export default () => (reactotron: Reactotron) => {
         myRepls[name] = value
       },
     },
-  }
+  } satisfies Plugin<ReactotronCore>
 }

--- a/lib/reactotron-core-client/src/plugins/repl.ts
+++ b/lib/reactotron-core-client/src/plugins/repl.ts
@@ -2,10 +2,9 @@ import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 
 export type AcceptableRepls = object | Function | string | number
 
-export default () => (reactotron: ReactotronCore) => {
+const repl = () => (reactotron: ReactotronCore) => {
   const myRepls: { [key: string]: AcceptableRepls } = {}
   // let currentContext = null
-
   return {
     onCommand: ({ type, payload }) => {
       if (type.substr(0, 5) !== "repl.") return
@@ -16,14 +15,11 @@ export default () => (reactotron: ReactotronCore) => {
           break
         // case "cd":
         //   const changeTo = myRepls.find(r => r.name === payload)
-
         //   if (!changeTo) {
         //     reactotron.send("repl.cd.response", "That REPL does not exist")
         //     break
         //   }
-
         //   currentContext = payload
-
         //   reactotron.send("repl.cd.response", `Change REPL to "${payload}"`)
         //   break
         case "execute":
@@ -34,14 +30,11 @@ export default () => (reactotron: ReactotronCore) => {
           //   )
           //   break
           // }
-
           // const currentRepl = myRepls.find(r => r.name === currentContext)
-
           // if (!currentRepl) {
           //   reactotron.send("repl.execute.response", "The selected REPL no longer exists.")
           //   break
           // }
-
           reactotron.send(
             "repl.execute.response",
             function () {
@@ -66,3 +59,4 @@ export default () => (reactotron: ReactotronCore) => {
     },
   } satisfies Plugin<ReactotronCore>
 }
+export default repl

--- a/lib/reactotron-core-client/src/plugins/state-responses.ts
+++ b/lib/reactotron-core-client/src/plugins/state-responses.ts
@@ -1,9 +1,9 @@
-import type { Reactotron } from "../reactotron-core-client"
+import type { ReactotronCore, Plugin } from "../reactotron-core-client"
 
 /**
  * Provides helper functions for send state responses.
  */
-export default () => (reactotron: Reactotron) => {
+export default () => (reactotron: ReactotronCore) => {
   return {
     features: {
       stateActionComplete: (name, action, important = false) =>
@@ -21,5 +21,5 @@ export default () => (reactotron: Reactotron) => {
       // sends the state backup over to the server
       stateBackupResponse: (state) => reactotron.send("state.backup.response", { state }),
     },
-  }
+  } satisfies Plugin<ReactotronCore>
 }

--- a/lib/reactotron-core-client/src/plugins/state-responses.ts
+++ b/lib/reactotron-core-client/src/plugins/state-responses.ts
@@ -1,25 +1,58 @@
-import type { ReactotronCore, Plugin } from "../reactotron-core-client"
+import type { ReactotronCore, Plugin, InferFeatures } from "../reactotron-core-client"
+
+type Action = Record<string, any>
+type State = Record<string, any>
 
 /**
  * Provides helper functions for send state responses.
  */
-export default () => (reactotron: ReactotronCore) => {
+const stateResponse = () => (reactotron: ReactotronCore) => {
   return {
     features: {
-      stateActionComplete: (name, action, important = false) =>
+      stateActionComplete: (name: string, action: Action, important = false) =>
         reactotron.send("state.action.complete", { name, action }, !!important),
 
-      stateValuesResponse: (path, value, valid = true) =>
+      stateValuesResponse: (path: string, value, valid = true) =>
         reactotron.send("state.values.response", { path, value, valid }),
 
-      stateKeysResponse: (path, keys, valid = true) =>
+      stateKeysResponse: (path: string, keys: string[], valid = true) =>
         reactotron.send("state.keys.response", { path, keys, valid }),
 
-      stateValuesChange: (changes) =>
+      stateValuesChange: (changes: Action[]) =>
         changes.length > 0 && reactotron.send("state.values.change", { changes }),
 
       // sends the state backup over to the server
-      stateBackupResponse: (state) => reactotron.send("state.backup.response", { state }),
+      stateBackupResponse: (state: State) => reactotron.send("state.backup.response", { state }),
     },
   } satisfies Plugin<ReactotronCore>
+}
+
+export type StateResponsePlugin = ReturnType<typeof stateResponse>
+
+export default stateResponse
+
+export const hasStateResponsePlugin = (
+  reactotron: ReactotronCore
+): reactotron is ReactotronCore & InferFeatures<ReactotronCore, ReturnType<typeof stateResponse>> =>
+  reactotron &&
+  "stateActionComplete" in reactotron &&
+  typeof reactotron.stateActionComplete === "function" &&
+  "stateValuesResponse" in reactotron &&
+  typeof reactotron.stateValuesResponse === "function" &&
+  "stateKeysResponse" in reactotron &&
+  typeof reactotron.stateKeysResponse === "function" &&
+  "stateValuesChange" in reactotron &&
+  typeof reactotron.stateValuesChange === "function" &&
+  "stateBackupResponse" in reactotron &&
+  typeof reactotron.stateBackupResponse === "function"
+
+export const assertHasStateResponsePlugin = (
+  reactotron: ReactotronCore
+): asserts reactotron is ReactotronCore &
+  InferFeatures<ReactotronCore, ReturnType<typeof stateResponse>> => {
+  if (!hasStateResponsePlugin(reactotron)) {
+    throw new Error(
+      "This Reactotron client has not had the state responses plugin applied to it. Make sure that you add `use(stateResponse())` before adding this plugin."
+    )
+  }
 }

--- a/lib/reactotron-core-client/src/plugins/state-responses.ts
+++ b/lib/reactotron-core-client/src/plugins/state-responses.ts
@@ -21,7 +21,7 @@ const stateResponse = () => (reactotron: ReactotronCore) => {
       stateValuesChange: (changes: Action[]) =>
         changes.length > 0 && reactotron.send("state.values.change", { changes }),
 
-      // sends the state backup over to the server
+      /** sends the state backup over to the server */
       stateBackupResponse: (state: State) => reactotron.send("state.backup.response", { state }),
     },
   } satisfies Plugin<ReactotronCore>

--- a/lib/reactotron-core-client/src/reactotron-core-client.ts
+++ b/lib/reactotron-core-client/src/reactotron-core-client.ts
@@ -19,14 +19,14 @@ export type { StateResponsePlugin } from "./plugins/state-responses"
 
 // #region Plugin Types
 type OnCommandCommand = Record<string, any>
-export interface LifeCycleMethods<Client> {
+export interface LifeCycleMethods {
   onCommand?: (command: OnCommandCommand) => void
-  onConnect?: (client: Client) => void
-  onDisconnect?: (client: Client) => void
+  onConnect?: () => void
+  onDisconnect?: () => void
 }
 
 type AnyFunction = (...args: any[]) => any
-export interface Plugin<Client> extends LifeCycleMethods<Client> {
+export interface Plugin<Client> extends LifeCycleMethods {
   features?: {
     [key: string]: AnyFunction
   }
@@ -171,7 +171,7 @@ export class ReactotronImpl implements ReactotronCore {
   /**
    * Messages that need to be sent.
    */
-  sendQueue: any[] = []
+  sendQueue: string[] = []
 
   /**
    * Are we ready to start communicating?
@@ -266,7 +266,7 @@ export class ReactotronImpl implements ReactotronCore {
       onConnect && onConnect()
 
       // trigger our plugins onConnect
-      this.plugins.forEach((p) => p.onConnect && p.onConnect(this))
+      this.plugins.forEach((p) => p.onConnect && p.onConnect())
 
       const getClientIdPromise = getClientId || emptyPromise
 
@@ -297,7 +297,7 @@ export class ReactotronImpl implements ReactotronCore {
       onDisconnect && onDisconnect()
 
       // as well as the plugin's onDisconnect
-      this.plugins.forEach((p) => p.onDisconnect && p.onDisconnect(this))
+      this.plugins.forEach((p) => p.onDisconnect && p.onDisconnect())
     }
 
     const decodeCommandData = (data: unknown) => {

--- a/lib/reactotron-core-client/src/reactotron-core-client.ts
+++ b/lib/reactotron-core-client/src/reactotron-core-client.ts
@@ -91,7 +91,9 @@ export interface ReactotronCore {
   send: (type: ActionType, payload?: ActionPayload, important?: boolean) => void
   display: (config: DisplayConfig) => void
   reportError: (this: any, error: Error) => void
-  onCustomCommand: (config: CustomCommand | string, optHandler?: () => void) => () => void
+  onCustomCommand: <Args extends CustomCommandArg[] = CustomCommand["args"]>(
+    config: CustomCommand<Args>
+  ) => () => void | ((config: string, optHandler?: () => void) => () => void)
   /**
    * Set the configuration options.
    */
@@ -139,10 +141,18 @@ export interface CustomCommandArg {
   type: ArgType
 }
 
+export type CustomCommandArgs<Args extends CustomCommandArg[]> = UnionToIntersection<
+  Args extends Array<infer U>
+    ? U extends CustomCommandArg
+      ? { [K in U as U["name"]]: U["type"] }
+      : never
+    : never
+>
+
 export interface CustomCommand<Args extends CustomCommandArg[] = CustomCommandArg[]> {
   id?: number
   command: string
-  handler: (args?: Record<keyof Args[number], Args[number]>) => void
+  handler: (args?: CustomCommandArgs<Args>) => void
 
   title?: string
   description?: string

--- a/lib/reactotron-core-client/src/reactotron-core-client.ts
+++ b/lib/reactotron-core-client/src/reactotron-core-client.ts
@@ -78,10 +78,10 @@ export interface ReactotronCore {
    * Set the configuration options.
    */
   configure: (
-    options?: ClientOptions<this>
+    options: ClientOptions<this>
   ) => this & InferFeaturesFromPlugins<this, ClientOptions<this>["plugins"]>
 
-  use: (pluginCreator?: PluginCreator<this>) => this & PluginFeatures<this, typeof pluginCreator>
+  use: (pluginCreator: PluginCreator<this>) => this & PluginFeatures<this, typeof pluginCreator>
 
   connect: () => this
 }
@@ -146,7 +146,7 @@ export class ReactotronImpl<Options extends ClientOptions<ReactotronCore>>
   /**
    * Available plugins.
    */
-  plugins: Plugin<ReactotronCore>[] = []
+  plugins: Plugin<this>[] = []
 
   /**
    * Messages that need to be sent.
@@ -181,9 +181,7 @@ export class ReactotronImpl<Options extends ClientOptions<ReactotronCore>>
   /**
    * Set the configuration options.
    */
-  configure(
-    options?: Options
-  ): this & InferFeaturesFromPlugins<ReactotronCore, Options["plugins"]> {
+  configure(options: Options): this & InferFeaturesFromPlugins<ReactotronCore, Options["plugins"]> {
     // options get merged & validated before getting set
     const newOptions = Object.assign(
       {
@@ -209,7 +207,7 @@ export class ReactotronImpl<Options extends ClientOptions<ReactotronCore>>
       this.options.plugins.forEach((p) => this.use(p))
     }
 
-    return this as this & InferFeaturesFromPlugins<ReactotronCore, Options["plugins"]>
+    return this as this & InferFeaturesFromPlugins<this, Options["plugins"]>
   }
 
   close() {
@@ -399,7 +397,7 @@ export class ReactotronImpl<Options extends ClientOptions<ReactotronCore>>
   /**
    * Adds a plugin to the system
    */
-  use(pluginCreator?: PluginCreator<this>): this & PluginFeatures<this, typeof pluginCreator> {
+  use(pluginCreator: PluginCreator<this>): this & PluginFeatures<this, typeof pluginCreator> {
     // we're supposed to be given a function
     if (typeof pluginCreator !== "function") {
       throw new Error("plugins must be a function")
@@ -552,8 +550,9 @@ export class ReactotronImpl<Options extends ClientOptions<ReactotronCore>>
 
 // convenience factory function
 export function createClient<
-  O extends ClientOptions<ReactotronCore> = ClientOptions<ReactotronCore>
->(options?: O) {
-  const client = new ReactotronImpl<O>()
-  return client.configure(options)
+  Client extends ReactotronCore = ReactotronCore,
+  Options extends ClientOptions<Client> = ClientOptions<Client>
+>(options?: Options) {
+  const client = new ReactotronImpl<Options>()
+  return client.configure(options) as Client
 }

--- a/lib/reactotron-core-client/src/validate.ts
+++ b/lib/reactotron-core-client/src/validate.ts
@@ -1,7 +1,9 @@
-import * as WebSocket from "ws"
 import type { ClientOptions } from "./client-options"
+import type { ReactotronCore } from "./reactotron-core-client"
 
-const isCreateSocketValid = (createSocket: (path: string) => WebSocket) =>
+const isCreateSocketValid = (
+  createSocket: unknown
+): createSocket is ClientOptions<ReactotronCore>["createSocket"] =>
   typeof createSocket !== "undefined" && createSocket !== null
 const isHostValid = (host: string): boolean => typeof host === "string" && host && host !== ""
 const isPortValid = (port: number): boolean =>
@@ -12,7 +14,7 @@ const onCommandValid = (fn: (cmd: string) => any) => typeof fn === "function"
  * Ensures the options are sane to run this baby.  Throw if not.  These
  * are basically sanity checks.
  */
-const validate = (options: ClientOptions) => {
+const validate = (options: ClientOptions<ReactotronCore>) => {
   const { createSocket, host, port, onCommand } = options
 
   if (!isCreateSocketValid(createSocket)) {

--- a/lib/reactotron-core-client/test/api-response.test.ts
+++ b/lib/reactotron-core-client/test/api-response.test.ts
@@ -2,10 +2,11 @@ import { createClient, corePlugins } from "../src/reactotron-core-client"
 import plugin from "../src/plugins/state-responses"
 import * as WebSocket from "ws"
 
-const createSocket = (path) => new WebSocket(path)
+const createSocket = (path: string) => new WebSocket(path)
 
 test("stateActionComplete", () => {
-  const client: any = createClient({ createSocket })
+  const options = { createSocket, plugins: [plugin()] }
+  const client = createClient(options)
   let type
   let name
   let action
@@ -14,7 +15,6 @@ test("stateActionComplete", () => {
     name = y.name
     action = y.action
   }
-  client.use(plugin())
   expect(client.plugins.length).toBe(corePlugins.length + 1)
   expect(typeof client.stateActionComplete).toBe("function")
 
@@ -26,7 +26,7 @@ test("stateActionComplete", () => {
 })
 
 test("stateValuesResponse", () => {
-  const client: any = createClient({ createSocket })
+  const client = createClient({ createSocket, plugins: [plugin()] })
   let type
   let path
   let value
@@ -37,7 +37,6 @@ test("stateValuesResponse", () => {
     value = y.value
     valid = y.valid
   }
-  client.use(plugin())
   expect(client.plugins.length).toBe(corePlugins.length + 1)
   expect(typeof client.stateValuesResponse).toBe("function")
 

--- a/lib/reactotron-core-client/test/api-response.test.ts
+++ b/lib/reactotron-core-client/test/api-response.test.ts
@@ -5,8 +5,8 @@ import * as WebSocket from "ws"
 const createSocket = (path: string) => new WebSocket(path)
 
 test("stateActionComplete", () => {
-  const options = { createSocket, plugins: [plugin()] }
-  const client = createClient(options)
+  const options = { createSocket }
+  const client = createClient(options).use(plugin())
   let type
   let name
   let action
@@ -26,7 +26,7 @@ test("stateActionComplete", () => {
 })
 
 test("stateValuesResponse", () => {
-  const client = createClient({ createSocket, plugins: [plugin()] })
+  const client = createClient({ createSocket }).use(plugin())
   let type
   let path
   let value
@@ -49,7 +49,7 @@ test("stateValuesResponse", () => {
 })
 
 test("stateKeysResponse", () => {
-  const client: any = createClient({ createSocket })
+  const client = createClient({ createSocket }).use(plugin())
   let type
   let path
   let keys
@@ -60,7 +60,6 @@ test("stateKeysResponse", () => {
     keys = y.keys
     valid = y.valid
   }
-  client.use(plugin())
 
   expect(client.plugins.length).toBe(corePlugins.length + 1)
   expect(typeof client.stateKeysResponse).toBe("function")

--- a/lib/reactotron-core-client/test/on-disconnect.test.ts
+++ b/lib/reactotron-core-client/test/on-disconnect.test.ts
@@ -3,7 +3,7 @@ import * as WebSocket from "ws"
 import * as getPort from "get-port"
 import { createClosingServer } from "./create-closing-server"
 
-const createSocket = (path) => new WebSocket(path)
+const createSocket = (path: string) => new WebSocket(path)
 
 let port: number
 beforeEach(async () => {

--- a/lib/reactotron-core-client/test/plugin-benchmark.test.ts
+++ b/lib/reactotron-core-client/test/plugin-benchmark.test.ts
@@ -2,13 +2,13 @@ import { createClient, corePlugins } from "../src/reactotron-core-client"
 import plugin from "../src/plugins/benchmark"
 import * as WebSocket from "ws"
 
-const createSocket = (path) => new WebSocket(path)
+const createSocket = (path: string) => new WebSocket(path)
 
 // a promise based delay that's not accurate at all
-const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 test("adds benchmarks to a report", async () => {
-  const client = createClient({ createSocket })
+  const client = createClient({ createSocket }).use(plugin())
   let commandType = ""
   let report: any
 
@@ -19,7 +19,6 @@ test("adds benchmarks to a report", async () => {
   }
 
   // register
-  client.use(plugin())
 
   expect(client.plugins.length).toBe(corePlugins.length + 1)
   expect(typeof client.benchmark).toBe("function")

--- a/lib/reactotron-core-client/test/plugin-features.test.ts
+++ b/lib/reactotron-core-client/test/plugin-features.test.ts
@@ -5,7 +5,10 @@ const createSocket = (path) => new WebSocket(path)
 
 test("features must be an object if they appear", () => {
   const client = createClient({ createSocket })
-  const badPlugin = () => client.use(() => ({ features: 1 }))
+
+  const badPlugin = () =>
+    // @ts-expect-error
+    client.use(() => ({ features: 1 }))
   expect(badPlugin).toThrow()
 })
 
@@ -31,23 +34,20 @@ test("some names are not allowed", () => {
 })
 
 test("features can be added and called", () => {
-  const client: any = createClient({ createSocket })
   const plugin = () => () => {
     const features = {
       magic: () => 42,
     }
     return { features }
   }
-  client.use(plugin())
+  const client = createClient({ createSocket }).use(plugin())
   expect(typeof client.magic).toBe("function")
   expect(client.magic()).toBe(42)
 })
 
 test("you can overwrite other feature names", () => {
-  const client: any = createClient({ createSocket })
   const createPlugin = (number) => () => ({ features: { hello: () => number } })
-  client.use(createPlugin(69))
+  const client = createClient({ createSocket }).use(createPlugin(69))
   expect(client.hello()).toBe(69)
-  client.use(createPlugin(9001))
-  expect(client.hello()).toBe(9001)
+  expect(client.use(createPlugin(9001)).hello()).toBe(9001)
 })

--- a/lib/reactotron-core-client/test/plugin-image.test.ts
+++ b/lib/reactotron-core-client/test/plugin-image.test.ts
@@ -2,15 +2,17 @@ import { createClient, corePlugins } from "../src/reactotron-core-client"
 import plugin from "../src/plugins/image"
 import * as WebSocket from "ws"
 
-const createSocket = (path) => new WebSocket(path)
+const createSocket = (path: string) => new WebSocket(path)
 
 test("the image function send the right data", () => {
-  const client: any = createClient({ createSocket })
-  const results = []
+  const client = createClient({ createSocket }).use(plugin())
+  const results: {
+    type: Parameters<typeof client.send>[0]
+    payload: Parameters<typeof client.send>[1]
+  }[] = []
   client.send = (type, payload) => {
     results.push({ type, payload })
   }
-  client.use(plugin())
   expect(client.plugins.length).toBe(corePlugins.length + 1)
   expect(typeof client.image).toBe("function")
   client.image({
@@ -20,15 +22,18 @@ test("the image function send the right data", () => {
     filename: "f",
     preview: "p",
     caption: "c",
+    // @ts-expect-error
     zoo: "lol",
   })
   expect(results.length).toBe(1)
-  expect(results[0].type).toBe("image")
-  expect(results[0].payload.uri).toBe("a")
-  expect(results[0].payload.width).toBe(1)
-  expect(results[0].payload.height).toBe(2)
-  expect(results[0].payload.filename).toBe("f")
-  expect(results[0].payload.preview).toBe("p")
-  expect(results[0].payload.caption).toBe("c")
-  expect(results[0].payload.zoo).toBe(undefined)
+
+  const result = results[0]
+  expect(result.type).toBe("image")
+  expect(result?.payload?.uri).toBe("a")
+  expect(result?.payload?.width).toBe(1)
+  expect(result?.payload?.height).toBe(2)
+  expect(result?.payload?.filename).toBe("f")
+  expect(result?.payload?.preview).toBe("p")
+  expect(result?.payload?.caption).toBe("c")
+  expect(result?.payload?.zoo).toBe(undefined)
 })

--- a/lib/reactotron-core-client/test/plugin-interface.test.ts
+++ b/lib/reactotron-core-client/test/plugin-interface.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
 import { createClient, corePlugins, ReactotronCore } from "../src/reactotron-core-client"
 import * as WebSocket from "ws"
 
@@ -21,7 +22,7 @@ test("client accepts plugins", () => {
 test("plugins are functions", () => {
   // @ts-expect-error
   expect(() => client.use()).toThrow()
-  // @ts-expect-error
+  // @ts-ignore should be ts-expect-error but jest doesn't like it for null or undefined values for some reason
   expect(() => client.use(null)).toThrow()
   // @ts-expect-error
   expect(() => client.use("")).toThrow()
@@ -30,13 +31,13 @@ test("plugins are functions", () => {
 })
 
 test("plugins are invoke and return an object", () => {
-  // @ts-expect-error
+  // @ts-ignore should be ts-expect-error but jest doesn't like it for null or undefined values for some reason
   expect(() => client.use(() => null)).toThrow()
   // @ts-expect-error
   expect(() => client.use(() => 1)).toThrow()
   // @ts-expect-error
   expect(() => client.use(() => "")).toThrow()
-  // @ts-expect-error
+  // @ts-ignore should be ts-expect-error but jest doesn't like it for null or undefined values for some reason
   expect(() => client.use(() => undefined)).toThrow()
   client.use(() => ({}))
 })

--- a/lib/reactotron-core-client/test/plugin-interface.test.ts
+++ b/lib/reactotron-core-client/test/plugin-interface.test.ts
@@ -19,8 +19,10 @@ test("client accepts plugins", () => {
 })
 
 test("plugins are functions", () => {
+  // @ts-expect-error
   expect(() => client.use()).toThrow()
-  expect(() => client.use(null as any)).toThrow()
+  // @ts-expect-error
+  expect(() => client.use(null)).toThrow()
   // @ts-expect-error
   expect(() => client.use("")).toThrow()
   // @ts-expect-error
@@ -28,9 +30,13 @@ test("plugins are functions", () => {
 })
 
 test("plugins are invoke and return an object", () => {
+  // @ts-expect-error
   expect(() => client.use(() => null)).toThrow()
+  // @ts-expect-error
   expect(() => client.use(() => 1)).toThrow()
+  // @ts-expect-error
   expect(() => client.use(() => "")).toThrow()
+  // @ts-expect-error
   expect(() => client.use(() => undefined)).toThrow()
   client.use(() => ({}))
 })

--- a/lib/reactotron-core-client/test/plugin-on-disconnect.test.ts
+++ b/lib/reactotron-core-client/test/plugin-on-disconnect.test.ts
@@ -1,21 +1,21 @@
-import { createClient } from "../src/reactotron-core-client"
+import { Plugin, ReactotronCore, createClient } from "../src/reactotron-core-client"
 import * as WebSocket from "ws"
 import * as getPort from "get-port"
 import { createClosingServer } from "./create-closing-server"
 
-const createSocket = (path) => new WebSocket(path)
+const createSocket = (path: string) => new WebSocket(path)
 
 let port: number
 beforeEach(async () => {
   port = await getPort()
 })
 
-test("plugins support onConnect", (done) => {
+test("plugins support onDisconnect", (done) => {
   createClosingServer(port)
 
   // this plugin supports onDisconnect
-  const plugin = () => ({ onDisconnect: done })
+  const plugin = () => ({ onDisconnect: done } satisfies Plugin<ReactotronCore>)
 
   // create a client & add the plugin
-  createClient({ createSocket, port }).use(plugin).connect()
+  createClient({ createSocket, port, plugins: [plugin] }).connect()
 })

--- a/lib/reactotron-core-client/test/plugin-send.test.ts
+++ b/lib/reactotron-core-client/test/plugin-send.test.ts
@@ -1,6 +1,7 @@
-import { createClient } from "../src/reactotron-core-client"
+import { ReactotronCore, createClient } from "../src/reactotron-core-client"
 import * as WebSocket from "ws"
 import * as getPort from "get-port"
+import { PluginCreator } from "reactotron-core-client"
 
 const createSocket = (path) => new WebSocket(path)
 const mock = { type: "type", payload: "payload" }
@@ -21,7 +22,7 @@ test("plugins support send", (done) => {
   let capturedSend: any
 
   // the plugin to extract the send function
-  const plugin = (reactotron) => {
+  const plugin: PluginCreator<ReactotronCore> = (reactotron) => {
     capturedSend = reactotron.send
     return {}
   }

--- a/lib/reactotron-mst/test/mocks/create-mock-reactotron.ts
+++ b/lib/reactotron-mst/test/mocks/create-mock-reactotron.ts
@@ -1,3 +1,4 @@
+import { Reactotron } from "reactotron-core-client"
 import * as td from "testdouble"
 
 /**
@@ -5,12 +6,33 @@ import * as td from "testdouble"
  */
 export function createMockReactotron() {
   // just enough of the interface to work
-  const reactotron = {
-    startTimer: td.func(),
-    stateValuesChange: td.func(),
-    send: td.func(),
-    stateKeysResponse: td.func(),
-    stateValuesResponse: td.func(),
+  const reactotron: Reactotron = {
+    startTimer: td.func<Reactotron["startTimer"]>(),
+    stateValuesChange: td.func<Reactotron["stateValuesChange"]>(),
+    send: td.func<Reactotron["send"]>(),
+    stateKeysResponse: td.func<Reactotron["send"]>(),
+    stateValuesResponse: td.func<Reactotron["stateValuesResponse"]>(),
+    apiResponse: td.func<Reactotron["apiResponse"]>(),
+    stateActionComplete: td.func<Reactotron["stateActionComplete"]>(),
+    stateBackupResponse: td.func<Reactotron["stateBackupResponse"]>(),
+    configure: td.func<Reactotron["configure"]>(),
+    close: td.func<Reactotron["close"]>(),
+    connect: td.func<Reactotron["connect"]>(),
+    display: td.func<Reactotron["display"]>(),
+    reportError: td.func<Reactotron["reportError"]>(),
+    use: td.func<Reactotron["use"]>(),
+    clear: td.func<Reactotron["clear"]>(),
+    log: td.func<Reactotron["log"]>(),
+    logImportant: td.func<Reactotron["logImportant"]>(),
+    benchmark: td.func<Reactotron["benchmark"]>(),
+    debug: td.func<Reactotron["debug"]>(),
+    error: td.func<Reactotron["error"]>(),
+    image: td.func<Reactotron["image"]>(),
+    warn: td.func<Reactotron["warn"]>(),
+    onCustomCommand: td.func<Reactotron["onCustomCommand"]>(),
+    plugins: [],
+    options: {},
+    repl: td.func<Reactotron["repl"]>(),
   }
 
   // the timer returns a function that returns 1

--- a/lib/reactotron-mst/test/plugin-interface.test.ts
+++ b/lib/reactotron-mst/test/plugin-interface.test.ts
@@ -1,4 +1,5 @@
 import { mst } from "../src/reactotron-mst"
+import { createMockReactotron } from "./mocks/create-mock-reactotron"
 
 describe("plugin-interface", () => {
   it("factory interface", () => {
@@ -6,7 +7,7 @@ describe("plugin-interface", () => {
   })
 
   it("plugin interface", () => {
-    const plugin = mst()({})
+    const plugin = mst()(createMockReactotron())
 
     expect(typeof plugin).toEqual("object")
     expect(typeof plugin.onCommand).toEqual("function")

--- a/lib/reactotron-react-js/package.json
+++ b/lib/reactotron-react-js/package.json
@@ -67,7 +67,7 @@
     "semantic-release": "16.0.4",
     "trash-cli": "4.0.0",
     "ts-jest": "29.0.5",
-    "typescript": "4.5.2"
+    "typescript": "4.9.5"
   },
   "eslintConfig": {
     "root": false,

--- a/lib/reactotron-react-native-mmkv/src/reactotron-react-native-mmkv.ts
+++ b/lib/reactotron-react-native-mmkv/src/reactotron-react-native-mmkv.ts
@@ -35,7 +35,13 @@ export default function mmkvPlugin(config: MmkvPluginConfig) {
   let listener: Listener | undefined
 
   return (reactotron: Reactotron) => {
-    const log = ({ value, preview }: { value: unknown; preview: string }) => {
+    const log = ({
+      value,
+      preview,
+    }: {
+      value: string | number | boolean | object
+      preview: string
+    }) => {
       reactotron.display({
         name: "MMKV",
         value,

--- a/lib/reactotron-react-native/src/plugins/asyncStorage.ts
+++ b/lib/reactotron-react-native/src/plugins/asyncStorage.ts
@@ -1,6 +1,4 @@
-import { Reactotron } from "reactotron-core-client"
-import type { ReactotronReactNative } from "../reactotron-react-native"
-
+import type { ReactotronCore } from "reactotron-core-client"
 export interface AsyncStorageOptions {
   ignore?: string[]
 }
@@ -9,146 +7,202 @@ const PLUGIN_DEFAULTS: AsyncStorageOptions = {
   ignore: [],
 }
 
-export default <ReactotronSubtype = ReactotronReactNative>(options: AsyncStorageOptions) =>
-  (reactotron: Reactotron<ReactotronSubtype> & ReactotronReactNative) => {
-    // setup configuration
-    const config = Object.assign({}, PLUGIN_DEFAULTS, options || {})
-    const ignore = config.ignore || PLUGIN_DEFAULTS.ignore
+export interface AsyncStorageHandler {
+  getItem: (key: string) => string
+  setItem: (key: string, value: string, callback?: (error: Error) => void) => void
+  removeItem: (key: string, callback?: (error: Error) => void) => void
+  mergeItem: (key: string, value: string, callback?: (error: Error) => void) => void
+  clear: (callback: (error: Error) => void) => void
+  multiSet: (pairs: string[][], callback?: (error: Error) => void) => void
+  multiRemove: (keys: string[], callback?: (error: Error) => void) => void
+  multiMerge: (pairs: string[][], callback?: (error: Error) => void) => void
+}
 
-    let swizzSetItem
-    let swizzRemoveItem
-    let swizzMergeItem
-    let swizzClear
-    let swizzMultiSet
-    let swizzMultiRemove
-    let swizzMultiMerge
-    let isSwizzled = false
+const asyncStorage = (options: AsyncStorageOptions) => (reactotron: ReactotronCore) => {
+  // setup configuration
+  const config = Object.assign({}, PLUGIN_DEFAULTS, options || {})
+  const ignore = config.ignore || PLUGIN_DEFAULTS.ignore
 
-    const sendToReactotron = (action: string, data?: any) => {
-      reactotron.send("asyncStorage.mutation", { action, data })
-    }
+  let swizzSetItem: AsyncStorageHandler["setItem"]
+  let swizzRemoveItem: AsyncStorageHandler["removeItem"]
+  let swizzMergeItem: AsyncStorageHandler["mergeItem"]
+  let swizzClear: AsyncStorageHandler["clear"]
+  let swizzMultiSet: AsyncStorageHandler["multiSet"]
+  let swizzMultiRemove: AsyncStorageHandler["multiRemove"]
+  let swizzMultiMerge: AsyncStorageHandler["multiMerge"]
+  let isSwizzled = false
 
-    const setItem = async (key, value, callback) => {
-      try {
-        if (ignore.indexOf(key) < 0) {
-          sendToReactotron("setItem", { key, value })
-        }
-      } catch (e) {}
-      return swizzSetItem(key, value, callback)
-    }
-
-    const removeItem = async (key, callback) => {
-      try {
-        if (ignore.indexOf(key) < 0) {
-          sendToReactotron("removeItem", { key })
-        }
-      } catch (e) {}
-      return swizzRemoveItem(key, callback)
-    }
-
-    const mergeItem = async (key, value, callback) => {
-      try {
-        if (ignore.indexOf(key) < 0) {
-          sendToReactotron("mergeItem", { key, value })
-        }
-      } catch (e) {}
-      return swizzMergeItem(key, value, callback)
-    }
-
-    const clear = async (callback) => {
-      try {
-        sendToReactotron("clear")
-      } catch (e) {}
-      return swizzClear(callback)
-    }
-
-    const multiSet = async (pairs, callback) => {
-      try {
-        const shippablePairs = (pairs || []).filter(
-          (pair) => pair && pair[0] && ignore.indexOf(pair[0]) < 0
-        )
-        if (shippablePairs.length > 0) {
-          sendToReactotron("multiSet", { pairs: shippablePairs })
-        }
-      } catch (e) {}
-      return swizzMultiSet(pairs, callback)
-    }
-
-    const multiRemove = async (keys, callback) => {
-      try {
-        const shippableKeys = (keys || []).filter((key) => ignore.indexOf(key) < 0)
-        if (shippableKeys.length > 0) {
-          sendToReactotron("multiRemove", { keys: shippableKeys })
-        }
-      } catch (e) {}
-      return swizzMultiRemove(keys, callback)
-    }
-
-    const multiMerge = async (pairs, callback) => {
-      try {
-        const shippablePairs = (pairs || []).filter(
-          (pair) => pair && pair[0] && ignore.indexOf(pair[0]) < 0
-        )
-        if (shippablePairs.length > 0) {
-          sendToReactotron("multiMerge", { pairs: shippablePairs })
-        }
-      } catch (e) {}
-      return swizzMultiMerge(pairs, callback)
-    }
-
-    /**
-     * Hijacks the AsyncStorage API.
-     */
-    const trackAsyncStorage = () => {
-      if (isSwizzled) return
-
-      swizzSetItem = reactotron.asyncStorageHandler.setItem
-      reactotron.asyncStorageHandler.setItem = setItem
-
-      swizzRemoveItem = reactotron.asyncStorageHandler.removeItem
-      reactotron.asyncStorageHandler.removeItem = removeItem
-
-      swizzMergeItem = reactotron.asyncStorageHandler.mergeItem
-      reactotron.asyncStorageHandler.mergeItem = mergeItem
-
-      swizzClear = reactotron.asyncStorageHandler.clear
-      reactotron.asyncStorageHandler.clear = clear
-
-      swizzMultiSet = reactotron.asyncStorageHandler.multiSet
-      reactotron.asyncStorageHandler.multiSet = multiSet
-
-      swizzMultiRemove = reactotron.asyncStorageHandler.multiRemove
-      reactotron.asyncStorageHandler.multiRemove = multiRemove
-
-      swizzMultiMerge = reactotron.asyncStorageHandler.multiMerge
-      reactotron.asyncStorageHandler.multiMerge = multiMerge
-
-      isSwizzled = true
-    }
-
-    const untrackAsyncStorage = () => {
-      if (!isSwizzled) return
-
-      reactotron.asyncStorageHandler.setItem = swizzSetItem
-      reactotron.asyncStorageHandler.removeItem = swizzRemoveItem
-      reactotron.asyncStorageHandler.mergeItem = swizzMergeItem
-      reactotron.asyncStorageHandler.clear = swizzClear
-      reactotron.asyncStorageHandler.multiSet = swizzMultiSet
-      reactotron.asyncStorageHandler.multiRemove = swizzMultiRemove
-      reactotron.asyncStorageHandler.multiMerge = swizzMultiMerge
-
-      isSwizzled = false
-    }
-
-    // reactotronShipStorageValues()
-    if (reactotron.asyncStorageHandler) {
-      trackAsyncStorage()
-    }
-
-    return {
-      features: {
-        trackAsyncStorage,
-        untrackAsyncStorage,
-      },
-    }
+  const sendToReactotron = (action: string, data?: any) => {
+    reactotron.send("asyncStorage.mutation", { action, data })
   }
+
+  const setItem: AsyncStorageHandler["setItem"] = async (key, value, callback) => {
+    try {
+      if (ignore.indexOf(key) < 0) {
+        sendToReactotron("setItem", { key, value })
+      }
+    } catch (e) {}
+    return swizzSetItem(key, value, callback)
+  }
+
+  const removeItem: AsyncStorageHandler["removeItem"] = async (key, callback) => {
+    try {
+      if (ignore.indexOf(key) < 0) {
+        sendToReactotron("removeItem", { key })
+      }
+    } catch (e) {}
+    return swizzRemoveItem(key, callback)
+  }
+
+  const mergeItem: AsyncStorageHandler["mergeItem"] = async (key, value, callback) => {
+    try {
+      if (ignore.indexOf(key) < 0) {
+        sendToReactotron("mergeItem", { key, value })
+      }
+    } catch (e) {}
+    return swizzMergeItem(key, value, callback)
+  }
+
+  const clear: AsyncStorageHandler["clear"] = async (callback) => {
+    try {
+      sendToReactotron("clear")
+    } catch (e) {}
+    return swizzClear(callback)
+  }
+
+  const multiSet: AsyncStorageHandler["multiSet"] = async (pairs, callback) => {
+    try {
+      const shippablePairs = (pairs || []).filter(
+        (pair) => pair && pair[0] && ignore.indexOf(pair[0]) < 0
+      )
+      if (shippablePairs.length > 0) {
+        sendToReactotron("multiSet", { pairs: shippablePairs })
+      }
+    } catch (e) {}
+    return swizzMultiSet(pairs, callback)
+  }
+
+  const multiRemove: AsyncStorageHandler["multiRemove"] = async (keys, callback) => {
+    try {
+      const shippableKeys = (keys || []).filter((key) => ignore.indexOf(key) < 0)
+      if (shippableKeys.length > 0) {
+        sendToReactotron("multiRemove", { keys: shippableKeys })
+      }
+    } catch (e) {}
+    return swizzMultiRemove(keys, callback)
+  }
+
+  const multiMerge: AsyncStorageHandler["multiMerge"] = async (pairs, callback) => {
+    try {
+      const shippablePairs = (pairs || []).filter(
+        (pair) => pair && pair[0] && ignore.indexOf(pair[0]) < 0
+      )
+      if (shippablePairs.length > 0) {
+        sendToReactotron("multiMerge", { pairs: shippablePairs })
+      }
+    } catch (e) {}
+    return swizzMultiMerge(pairs, callback)
+  }
+
+  /**
+   * Hijacks the AsyncStorage API.
+   */
+  const trackAsyncStorage = () => {
+    if (isSwizzled) return
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    swizzSetItem = reactotron.asyncStorageHandler.setItem
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.setItem = setItem
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    swizzRemoveItem = reactotron.asyncStorageHandler.removeItem
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.removeItem = removeItem
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    swizzMergeItem = reactotron.asyncStorageHandler.mergeItem
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.mergeItem = mergeItem
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    swizzClear = reactotron.asyncStorageHandler.clear
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.clear = clear
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    swizzMultiSet = reactotron.asyncStorageHandler.multiSet
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.multiSet = multiSet
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    swizzMultiRemove = reactotron.asyncStorageHandler.multiRemove
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.multiRemove = multiRemove
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    swizzMultiMerge = reactotron.asyncStorageHandler.multiMerge
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.multiMerge = multiMerge
+
+    isSwizzled = true
+  }
+
+  const untrackAsyncStorage = () => {
+    if (!isSwizzled) return
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.setItem = swizzSetItem
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.removeItem = swizzRemoveItem
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.mergeItem = swizzMergeItem
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.clear = swizzClear
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.multiSet = swizzMultiSet
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.multiRemove = swizzMultiRemove
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: reactotron-apis
+    reactotron.asyncStorageHandler.multiMerge = swizzMultiMerge
+
+    isSwizzled = false
+  }
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore: reactotron-apis
+  if (reactotron.asyncStorageHandler) {
+    trackAsyncStorage()
+  }
+
+  return {
+    features: {
+      trackAsyncStorage,
+      untrackAsyncStorage,
+    },
+  }
+}
+
+export default asyncStorage

--- a/lib/reactotron-react-native/src/plugins/asyncStorage.ts
+++ b/lib/reactotron-react-native/src/plugins/asyncStorage.ts
@@ -1,4 +1,4 @@
-import type { ReactotronCore } from "reactotron-core-client"
+import type { ReactotronCore, Plugin } from "reactotron-core-client"
 export interface AsyncStorageOptions {
   ignore?: string[]
 }
@@ -202,7 +202,7 @@ const asyncStorage = (options: AsyncStorageOptions) => (reactotron: ReactotronCo
       trackAsyncStorage,
       untrackAsyncStorage,
     },
-  }
+  } satisfies Plugin<ReactotronCore>
 }
 
 export default asyncStorage

--- a/lib/reactotron-react-native/src/plugins/devTools.ts
+++ b/lib/reactotron-react-native/src/plugins/devTools.ts
@@ -1,8 +1,9 @@
+import type { ReactotronCore, Plugin } from "reactotron-core-client"
 import { NativeModules } from "react-native"
 
-export default () => () => {
+const devTools = () => () => {
   return {
-    onCommand: (command: any) => {
+    onCommand: (command) => {
       if (command.type !== "devtools.open" && command.type !== "devtools.reload") return
 
       if (command.type === "devtools.open") {
@@ -13,5 +14,7 @@ export default () => () => {
         NativeModules.DevMenu.reload()
       }
     },
-  }
+  } satisfies Plugin<ReactotronCore>
 }
+
+export default devTools

--- a/lib/reactotron-react-native/src/plugins/networking.ts
+++ b/lib/reactotron-react-native/src/plugins/networking.ts
@@ -1,6 +1,6 @@
-import XHRInterceptor from 'react-native/Libraries/Network/XHRInterceptor'
-import queryString from 'query-string'
-import { Reactotron, ReactotronCore } from 'reactotron-core-client'
+import XHRInterceptor from "react-native/Libraries/Network/XHRInterceptor"
+import queryString from "query-string"
+import { ReactotronCore } from "reactotron-core-client"
 
 /**
  * Don't include the response bodies for images by default.
@@ -8,143 +8,144 @@ import { Reactotron, ReactotronCore } from 'reactotron-core-client'
 const DEFAULT_CONTENT_TYPES_RX = /^(image)\/.*$/i
 
 export interface NetworkingOptions {
-    ignoreContentTypes?: RegExp
-    ignoreUrls?: RegExp
+  ignoreContentTypes?: RegExp
+  ignoreUrls?: RegExp
 }
 
 const DEFAULTS: NetworkingOptions = {}
 
-export default <ReactotronSubtype = ReactotronCore>(pluginConfig: NetworkingOptions = {}) => (reactotron: Reactotron<ReactotronSubtype> & ReactotronSubtype) => {
-  const options = Object.assign({}, DEFAULTS, pluginConfig)
+const networking =
+  (pluginConfig: NetworkingOptions = {}) =>
+  (reactotron: ReactotronCore) => {
+    const options = Object.assign({}, DEFAULTS, pluginConfig)
 
-  // a RegExp to suppess adding the body cuz it costs a lot to serialize
-  const ignoreContentTypes = options.ignoreContentTypes || DEFAULT_CONTENT_TYPES_RX
+    // a RegExp to suppess adding the body cuz it costs a lot to serialize
+    const ignoreContentTypes = options.ignoreContentTypes || DEFAULT_CONTENT_TYPES_RX
 
-  // a XHR call tracker
-  let reactotronCounter = 1000
+    // a XHR call tracker
+    let reactotronCounter = 1000
 
-  // a temporary cache to hold requests so we can match up the data
-  const requestCache = {}
+    // a temporary cache to hold requests so we can match up the data
+    const requestCache = {}
 
-  /**
-   * Fires when we talk to the server.
-   *
-   * @param {*} data - The data sent to the server.
-   * @param {*} instance - The XMLHTTPRequest instance.
-   */
-  function onSend (data, xhr) {
-    if (options.ignoreUrls && options.ignoreUrls.test(xhr._url)) {
-      xhr._skipReactotron = true
-      return
-    }
-
-    // bump the counter
-    reactotronCounter++
-
-    // tag
-    xhr._trackingName = reactotronCounter
-
-    // cache
-    requestCache[reactotronCounter] = {
-      data: data,
-      xhr,
-      stopTimer: reactotron.startTimer()
-    }
-  }
-
-  /**
-   * Fires when the server gives us a response.
-   *
-   * @param {number} status - The HTTP response status.
-   * @param {boolean} timeout - Did we timeout?
-   * @param {*} response - The response data.
-   * @param {string} url - The URL we talked to.
-   * @param {*} type - Not sure.
-   * @param {*} xhr - The XMLHttpRequest instance.
-   */
-  function onResponse (status, timeout, response, url, type, xhr) {
-    if (xhr._skipReactotron) {
-      return
-    }
-
-    let params = null;
-    const queryParamIdx = url ? url.indexOf('?') : -1
-
-    if (queryParamIdx > -1) {
-      params = queryString.parse(url.substr(queryParamIdx))
-    }
-
-    // fetch and clear the request data from the cache
-    const rid = xhr._trackingName
-    const cachedRequest = requestCache[rid] || { xhr }
-    requestCache[rid] = null
-
-    // assemble the request object
-    const { data, stopTimer } = cachedRequest
-    const tronRequest = {
-      url: url || cachedRequest.xhr._url,
-      method: xhr._method || null,
-      data,
-      headers: xhr._headers || null,
-      params
-    }
-
-    // what type of content is this?
-    const contentType =
-      (xhr.responseHeaders && xhr.responseHeaders['content-type']) ||
-      (xhr.responseHeaders && xhr.responseHeaders['Content-Type']) ||
-      ''
-
-    const sendResponse = responseBodyText => {
-      let body = `~~~ skipped ~~~`
-      if (responseBodyText) {
-        try {
-          // all i am saying, is give JSON a chance...
-          body = JSON.parse(responseBodyText)
-        } catch (boom) {
-          body = response
-        }
-      }
-      const tronResponse = {
-        body,
-        status,
-        headers: xhr.responseHeaders || null
+    /**
+     * Fires when we talk to the server.
+     *
+     * @param {*} data - The data sent to the server.
+     * @param {*} instance - The XMLHTTPRequest instance.
+     */
+    function onSend(data, xhr) {
+      if (options.ignoreUrls && options.ignoreUrls.test(xhr._url)) {
+        xhr._skipReactotron = true
+        return
       }
 
-      // send this off to Reactotron
-      ;(reactotron as any).apiResponse(tronRequest, tronResponse, stopTimer ? stopTimer() : null) // TODO: Fix
+      // bump the counter
+      reactotronCounter++
+
+      // tag
+      xhr._trackingName = reactotronCounter
+
+      // cache
+      requestCache[reactotronCounter] = {
+        data: data,
+        xhr,
+        stopTimer: reactotron.startTimer(),
+      }
     }
 
-    // can we use the real response?
-    const useRealResponse =
-      (typeof response === 'string' || typeof response === 'object') &&
-      !ignoreContentTypes.test(contentType || '')
+    /**
+     * Fires when the server gives us a response.
+     *
+     * @param {number} status - The HTTP response status.
+     * @param {boolean} timeout - Did we timeout?
+     * @param {*} response - The response data.
+     * @param {string} url - The URL we talked to.
+     * @param {*} type - Not sure.
+     * @param {*} xhr - The XMLHttpRequest instance.
+     */
+    function onResponse(status, timeout, response, url, type, xhr) {
+      if (xhr._skipReactotron) {
+        return
+      }
 
-    // prepare the right body to send
-    if (useRealResponse) {
-      if (type === 'blob' && typeof FileReader !== 'undefined' && response) {
-        // Disable reason: FileReader should be in global scope since RN 0.54
-        // eslint-disable-next-line no-undef
-        const bReader = new FileReader()
-        const brListener = () => {
-          sendResponse(bReader.result)
-          bReader.removeEventListener('loadend', brListener)
+      let params = null
+      const queryParamIdx = url ? url.indexOf("?") : -1
+
+      if (queryParamIdx > -1) {
+        params = queryString.parse(url.substr(queryParamIdx))
+      }
+
+      // fetch and clear the request data from the cache
+      const rid = xhr._trackingName
+      const cachedRequest = requestCache[rid] || { xhr }
+      requestCache[rid] = null
+
+      // assemble the request object
+      const { data, stopTimer } = cachedRequest
+      const tronRequest = {
+        url: url || cachedRequest.xhr._url,
+        method: xhr._method || null,
+        data,
+        headers: xhr._headers || null,
+        params,
+      }
+
+      // what type of content is this?
+      const contentType =
+        (xhr.responseHeaders && xhr.responseHeaders["content-type"]) ||
+        (xhr.responseHeaders && xhr.responseHeaders["Content-Type"]) ||
+        ""
+
+      const sendResponse = (responseBodyText) => {
+        let body = `~~~ skipped ~~~`
+        if (responseBodyText) {
+          try {
+            // all i am saying, is give JSON a chance...
+            body = JSON.parse(responseBodyText)
+          } catch (boom) {
+            body = response
+          }
         }
-        bReader.addEventListener('loadend', brListener)
-        bReader.readAsText(response)
+        const tronResponse = {
+          body,
+          status,
+          headers: xhr.responseHeaders || null,
+        }
+        ;(reactotron as any).apiResponse(tronRequest, tronResponse, stopTimer ? stopTimer() : null) // TODO: Fix
+      }
+
+      // can we use the real response?
+      const useRealResponse =
+        (typeof response === "string" || typeof response === "object") &&
+        !ignoreContentTypes.test(contentType || "")
+
+      // prepare the right body to send
+      if (useRealResponse) {
+        if (type === "blob" && typeof FileReader !== "undefined" && response) {
+          // Disable reason: FileReader should be in global scope since RN 0.54
+          // eslint-disable-next-line no-undef
+          const bReader = new FileReader()
+          const brListener = () => {
+            sendResponse(bReader.result)
+            bReader.removeEventListener("loadend", brListener)
+          }
+          bReader.addEventListener("loadend", brListener)
+          bReader.readAsText(response)
+        } else {
+          sendResponse(response)
+        }
       } else {
-        sendResponse(response)
+        sendResponse("")
       }
-    } else {
-      sendResponse('')
     }
+
+    // register our monkey-patch
+    XHRInterceptor.setSendCallback(onSend)
+    XHRInterceptor.setResponseCallback(onResponse)
+    XHRInterceptor.enableInterception()
+
+    // nothing of use to offer to the plugin
+    return {}
   }
-
-  // register our monkey-patch
-  XHRInterceptor.setSendCallback(onSend)
-  XHRInterceptor.setResponseCallback(onResponse)
-  XHRInterceptor.enableInterception()
-
-  // nothing of use to offer to the plugin
-  return {}
-}
+export default networking

--- a/lib/reactotron-react-native/src/plugins/networking.ts
+++ b/lib/reactotron-react-native/src/plugins/networking.ts
@@ -1,6 +1,6 @@
 import XHRInterceptor from "react-native/Libraries/Network/XHRInterceptor"
 import queryString from "query-string"
-import { ReactotronCore } from "reactotron-core-client"
+import type { ReactotronCore, Plugin } from "reactotron-core-client"
 
 /**
  * Don't include the response bodies for images by default.
@@ -19,7 +19,7 @@ const networking =
   (reactotron: ReactotronCore) => {
     const options = Object.assign({}, DEFAULTS, pluginConfig)
 
-    // a RegExp to suppess adding the body cuz it costs a lot to serialize
+    // a RegExp to suppress adding the body cuz it costs a lot to serialize
     const ignoreContentTypes = options.ignoreContentTypes || DEFAULT_CONTENT_TYPES_RX
 
     // a XHR call tracker
@@ -146,6 +146,6 @@ const networking =
     XHRInterceptor.enableInterception()
 
     // nothing of use to offer to the plugin
-    return {}
+    return {} satisfies Plugin<ReactotronCore>
   }
 export default networking

--- a/lib/reactotron-react-native/src/plugins/openInEditor.ts
+++ b/lib/reactotron-react-native/src/plugins/openInEditor.ts
@@ -1,3 +1,5 @@
+import type { ReactotronCore, Plugin } from "reactotron-core-client"
+
 export interface OpenInEditorOptions {
   url?: string
 }
@@ -6,19 +8,22 @@ const DEFAULTS: OpenInEditorOptions = {
   url: "http://localhost:8081",
 }
 
-export default (pluginConfig: OpenInEditorOptions = {}) => () => {
-  const options = Object.assign({}, DEFAULTS, pluginConfig)
+const openInEditor =
+  (pluginConfig: OpenInEditorOptions = {}) =>
+  () => {
+    const options = Object.assign({}, DEFAULTS, pluginConfig)
 
-  return {
-    onCommand: (command: any) => {
-      if (command.type !== "editor.open") return
-      const { payload } = command
-      const { file, lineNumber } = payload
-      const url = `${options.url}/open-stack-frame`
-      const body = { file, lineNumber: lineNumber || 1 }
-      const method = "POST"
+    return {
+      onCommand: (command) => {
+        if (command.type !== "editor.open") return
+        const { payload } = command
+        const { file, lineNumber } = payload
+        const url = `${options.url}/open-stack-frame`
+        const body = { file, lineNumber: lineNumber || 1 }
+        const method = "POST"
 
-      fetch(url, { method, body: JSON.stringify(body) })
-    },
+        fetch(url, { method, body: JSON.stringify(body) })
+      },
+    } satisfies Plugin<ReactotronCore>
   }
-}
+export default openInEditor

--- a/lib/reactotron-react-native/src/reactotron-react-native.ts
+++ b/lib/reactotron-react-native/src/reactotron-react-native.ts
@@ -1,6 +1,6 @@
 import { Platform, NativeModules } from "react-native"
 import { createClient } from "reactotron-core-client"
-import type { ReactotronCore, ClientOptions } from "reactotron-core-client"
+import type { ClientOptions, Reactotron } from "reactotron-core-client"
 import getHost from "rn-host-detect"
 
 import getReactNativeVersion from "./helpers/getReactNativeVersion"
@@ -71,7 +71,7 @@ export interface UseReactNativeOptions {
   devTools?: boolean
 }
 
-export interface ReactotronReactNative extends ReactotronCore {
+export interface ReactotronReactNative extends Reactotron {
   useReactNative: (options?: UseReactNativeOptions) => this
   overlay: OverlayFeatures["overlay"]
   storybookSwitcher: (App: React.ReactNode) => (Root: React.ReactNode) => React.ReactNode

--- a/lib/reactotron-react-native/src/reactotron-react-native.ts
+++ b/lib/reactotron-react-native/src/reactotron-react-native.ts
@@ -1,5 +1,6 @@
 import { Platform, NativeModules } from "react-native"
-import { createClient, Reactotron } from "reactotron-core-client"
+import { createClient } from "reactotron-core-client"
+import type { ReactotronCore, ClientOptions } from "reactotron-core-client"
 import getHost from "rn-host-detect"
 
 import getReactNativeVersion from "./helpers/getReactNativeVersion"
@@ -12,7 +13,6 @@ import trackGlobalErrors, { TrackGlobalErrorsOptions } from "./plugins/trackGlob
 import networking, { NetworkingOptions } from "./plugins/networking"
 import storybook from "./plugins/storybook"
 import devTools from "./plugins/devTools"
-import ConnectionManager from "./connection-manager"
 
 const constants = NativeModules.PlatformConstants || {}
 
@@ -20,8 +20,8 @@ const REACTOTRON_ASYNC_CLIENT_ID = "@REACTOTRON/clientId"
 
 let tempClientId = null
 
-const DEFAULTS = {
-  createSocket: (path: string) => new ConnectionManager(path), // eslint-disable-line
+const DEFAULTS: ClientOptions<ReactotronReactNative> = {
+  createSocket: (path: string) => new WebSocket(path), // eslint-disable-line
   host: getHost("localhost"),
   port: 9090,
   name: "React Native App",
@@ -73,19 +73,17 @@ export interface UseReactNativeOptions {
   devTools?: boolean
 }
 
-export interface ReactotronReactNative {
-  useReactNative: (
-    options?: UseReactNativeOptions
-  ) => Reactotron<ReactotronReactNative> & ReactotronReactNative
+export interface ReactotronReactNative extends ReactotronCore {
+  useReactNative: (options?: UseReactNativeOptions) => this
   overlay: OverlayFeatures["overlay"]
   storybookSwitcher: (App: React.ReactNode) => (Root: React.ReactNode) => React.ReactNode
   asyncStorageHandler?: any
-  setAsyncStorageHandler?: (
-    asyncStorage: any
-  ) => Reactotron<ReactotronReactNative> & ReactotronReactNative
+  setAsyncStorageHandler?: (asyncStorage: any) => this
 }
 
-const reactotron: Reactotron<ReactotronReactNative> & ReactotronReactNative = createClient(DEFAULTS)
+const reactotron = createClient<ReactotronReactNative, ClientOptions<ReactotronReactNative>>(
+  DEFAULTS
+)
 
 function getPluginOptions<T>(options?: T | boolean): T {
   return typeof options === "object" ? options : null
@@ -130,5 +128,7 @@ reactotron.setAsyncStorageHandler = (asyncStorage) => {
 }
 
 export { asyncStorage, trackGlobalErrors, openInEditor, overlay, networking, storybook, devTools }
+
+export type { ClientOptions }
 
 export default reactotron

--- a/lib/reactotron-redux/src/index.ts
+++ b/lib/reactotron-redux/src/index.ts
@@ -1,5 +1,5 @@
 import type { StoreEnhancer } from "redux"
-import { Reactotron } from "reactotron-core-client"
+import { Plugin, Reactotron } from "reactotron-core-client"
 
 import createCommandHander from "./commandHandler"
 import createSendAction from "./sendAction"
@@ -34,7 +34,7 @@ function reactotronRedux(pluginConfig: PluginConfig = {}) {
         },
         reportReduxAction: createSendAction(reactotron),
       },
-    }
+    } satisfies Plugin<Reactotron>
   }
 }
 

--- a/lib/reactotron-redux/src/testHelpers.ts
+++ b/lib/reactotron-redux/src/testHelpers.ts
@@ -1,6 +1,6 @@
 import type { Reactotron } from "reactotron-core-client"
 
-export const defaultReactotronMock = {
+export const defaultReactotronMock: Reactotron = {
   startTimer: jest.fn(),
   configure: jest.fn(),
   close: jest.fn(),
@@ -10,4 +10,24 @@ export const defaultReactotronMock = {
   reportError: jest.fn(),
   use: jest.fn(),
   onCustomCommand: jest.fn(),
-} as unknown as Reactotron
+  clear: jest.fn(),
+  apiResponse: jest.fn(),
+  benchmark: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  image: jest.fn(),
+  log: jest.fn(),
+  logImportant: jest.fn(),
+  plugins: [],
+  options: {},
+  repl: jest.fn(),
+  stateActionComplete: jest.fn(),
+  stateBackupResponse: jest.fn(),
+  stateKeysResponse: jest.fn(),
+  stateValuesChange: jest.fn(),
+  stateValuesResponse: jest.fn(),
+  warn: jest.fn(),
+  createEnhancer: jest.fn(),
+  reduxStore: jest.fn(),
+  setReduxStore: jest.fn(),
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -27419,7 +27419,7 @@ __metadata:
     stacktrace-js: 2.0.1
     trash-cli: 4.0.0
     ts-jest: 29.0.5
-    typescript: 4.5.2
+    typescript: 4.9.5
   languageName: unknown
   linkType: soft
 
@@ -31677,16 +31677,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.5.2":
-  version: 4.5.2
-  resolution: "typescript@npm:4.5.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 74f9ce65d532bdf5d0214b3f60cf37992180023388c87a11ee6f838a803067ef0b63c600fa501b0deb07f989257dce1e244c9635ed79feca40bbccf6e0aa1ebc
-  languageName: node
-  linkType: hard
-
 "typescript@npm:4.9.5, typescript@npm:^4.9.5":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
@@ -31694,16 +31684,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@4.5.2#~builtin<compat/typescript>":
-  version: 4.5.2
-  resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=bcec9a"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: e25e689eba64f7da7cfc43f8ea76cac7176b56caba42655f0a4cb29c0b7c36e67ca54f33df95902859f56108464245d8b45bcdfe21e3d66d9560feb8db780246
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR embarks on a re-write of the internal types for reactotron-core-client.

This PR allows Reactotron to infer features based on the plugins provided to the client.

<img width="814" alt="Screenshot 2023-07-06 at 10 07 16 AM" src="https://github.com/infinitered/reactotron/assets/37849890/ea8a9dee-5aa1-4829-9a88-53e7fe616e5c">

This PR also introduces guards to ensure that when a plugin depends on another plugin, that it will be load or fail.
