### PR TITLE
Make plugin clients more generic, add types for state responses

### DIFF
--- a/lib/reactotron-core-client/src/plugins/state-responses.ts
+++ b/lib/reactotron-core-client/src/plugins/state-responses.ts
@@ -1,7 +1,11 @@
+import type {
+  StateActionCompletePayload,
+  StateBackupResponsePayload,
+  StateKeysResponsePayload,
+  StateValuesChangePayload,
+  StateValuesResponsePayload,
+} from "reactotron-core-contract"
 import type { ReactotronCore, Plugin, InferFeatures } from "../reactotron-core-client"
-
-type Action = Record<string, any>
-type State = Record<string, any>
 
 /**
  * Provides helper functions for send state responses.
@@ -9,20 +13,30 @@ type State = Record<string, any>
 const stateResponse = () => (reactotron: ReactotronCore) => {
   return {
     features: {
-      stateActionComplete: (name: string, action: Action, important = false) =>
-        reactotron.send("state.action.complete", { name, action }, !!important),
+      stateActionComplete: (
+        name: StateActionCompletePayload["name"],
+        action: StateActionCompletePayload["action"],
+        important = false
+      ) => reactotron.send("state.action.complete", { name, action }, !!important),
 
-      stateValuesResponse: (path: string, value, valid = true) =>
-        reactotron.send("state.values.response", { path, value, valid }),
+      stateValuesResponse: (
+        path: StateValuesResponsePayload["path"],
+        value: StateValuesResponsePayload["value"],
+        valid: StateValuesResponsePayload["value"] = true
+      ) => reactotron.send("state.values.response", { path, value, valid }),
 
-      stateKeysResponse: (path: string, keys: string[], valid = true) =>
-        reactotron.send("state.keys.response", { path, keys, valid }),
+      stateKeysResponse: (
+        path: StateKeysResponsePayload["path"],
+        keys: StateKeysResponsePayload["keys"],
+        valid: StateKeysResponsePayload["valid"] = true
+      ) => reactotron.send("state.keys.response", { path, keys, valid }),
 
-      stateValuesChange: (changes: Action[]) =>
+      stateValuesChange: (changes: StateValuesChangePayload["changes"]) =>
         changes.length > 0 && reactotron.send("state.values.change", { changes }),
 
       /** sends the state backup over to the server */
-      stateBackupResponse: (state: State) => reactotron.send("state.backup.response", { state }),
+      stateBackupResponse: (state: StateBackupResponsePayload["state"]) =>
+        reactotron.send("state.backup.response", { state }),
     },
   } satisfies Plugin<ReactotronCore>
 }

--- a/lib/reactotron-core-client/src/reactotron-core-client.ts
+++ b/lib/reactotron-core-client/src/reactotron-core-client.ts
@@ -19,9 +19,8 @@ export { assertHasStateResponsePlugin, hasStateResponsePlugin } from "./plugins/
 export type { StateResponsePlugin } from "./plugins/state-responses"
 
 // #region Plugin Types
-type OnCommandCommand = Record<string, any>
 export interface LifeCycleMethods {
-  onCommand?: (command: OnCommandCommand) => void
+  onCommand?: (command: Command) => void
   onConnect?: () => void
   onDisconnect?: () => void
 }

--- a/lib/reactotron-core-contract/src/command.ts
+++ b/lib/reactotron-core-contract/src/command.ts
@@ -1,4 +1,17 @@
-import { LogPayload } from "./log"
+import type { LogPayload } from "./log"
+import type {
+  StateActionCompletePayload,
+  StateActionDispatchPayload,
+  StateBackupRequestPayload,
+  StateBackupResponsePayload,
+  StateKeysRequestPayload,
+  StateKeysResponsePayload,
+  StateRestoreRequestPayload,
+  StateValuesChangePayload,
+  StateValuesRequestPayload,
+  StateValuesResponsePayload,
+  StateValuesSubscribePayload,
+} from "./state"
 
 export const CommandType = {
   ApiResponse: "api.response",
@@ -14,6 +27,12 @@ export const CommandType = {
   StateValuesChange: "state.values.change",
   StateValuesResponse: "state.values.response",
   StateBackupResponse: "state.backup.response",
+  StateBackupRequest: "state.backup.request",
+  StateRestoreRequest: "state.restore.request",
+  StateActionDispatch: "state.action.dispatch",
+  StateValuesSubscribe: "state.values.subscribe",
+  StateKeysRequest: "state.keys.request",
+  StateValuesRequest: "state.values.request",
   CustomCommandRegister: "customCommand.register",
   CustomCommandUnregister: "customCommand.unregister",
   Clear: "clear",
@@ -46,11 +65,17 @@ export interface CommandMap {
   [CommandType.Image]: any
   [CommandType.Log]: LogPayload
   [CommandType.SagaTaskComplete]: any
-  [CommandType.StateActionComplete]: any
-  [CommandType.StateKeysResponse]: any
-  [CommandType.StateValuesChange]: any
-  [CommandType.StateValuesResponse]: any
-  [CommandType.StateBackupResponse]: any
+  [CommandType.StateActionComplete]: StateActionCompletePayload
+  [CommandType.StateKeysResponse]: StateKeysResponsePayload
+  [CommandType.StateValuesChange]: StateValuesChangePayload
+  [CommandType.StateValuesResponse]: StateValuesResponsePayload
+  [CommandType.StateBackupResponse]: StateBackupResponsePayload
+  [CommandType.StateBackupRequest]: StateBackupRequestPayload
+  [CommandType.StateRestoreRequest]: StateRestoreRequestPayload
+  [CommandType.StateActionDispatch]: StateActionDispatchPayload
+  [CommandType.StateValuesSubscribe]: StateValuesSubscribePayload
+  [CommandType.StateKeysRequest]: StateKeysRequestPayload
+  [CommandType.StateValuesRequest]: StateValuesRequestPayload
   [CommandType.CustomCommandRegister]: any
   [CommandType.CustomCommandUnregister]: any
   [CommandType.Clear]: any

--- a/lib/reactotron-core-contract/src/command.ts
+++ b/lib/reactotron-core-contract/src/command.ts
@@ -1,4 +1,5 @@
 import type { LogPayload } from "./log"
+import { EditorOpenPayload } from "./openInEditor"
 import type {
   StateActionCompletePayload,
   StateActionDispatchPayload,
@@ -38,6 +39,10 @@ export const CommandType = {
   Clear: "clear",
   ReplLsResponse: "repl.ls.response",
   ReplExecuteResponse: "repl.execute.response",
+  // these technically are commands only in reactotron-react-native, but I felt lazy so they can live here
+  DevtoolsOpen: "devtools.open",
+  DevtoolsReload: "devtools.reload",
+  EditorOpen: "editor.open",
 } as const
 
 export type CommandTypeKey = (typeof CommandType)[keyof typeof CommandType]
@@ -81,6 +86,9 @@ export interface CommandMap {
   [CommandType.Clear]: any
   [CommandType.ReplLsResponse]: any
   [CommandType.ReplExecuteResponse]: any
+  [CommandType.DevtoolsOpen]: undefined
+  [CommandType.DevtoolsReload]: undefined
+  [CommandType.EditorOpen]: EditorOpenPayload
 }
 
 export type CommandEvent = (command: Command) => void

--- a/lib/reactotron-core-contract/src/openInEditor.ts
+++ b/lib/reactotron-core-contract/src/openInEditor.ts
@@ -1,0 +1,4 @@
+export interface EditorOpenPayload {
+  file: string
+  lineNumber: string
+}

--- a/lib/reactotron-core-contract/src/reactotron-core-contract.ts
+++ b/lib/reactotron-core-contract/src/reactotron-core-contract.ts
@@ -1,4 +1,5 @@
 export * from "./command"
+export * from "./log"
+export * from "./openInEditor"
 export * from "./server-events"
 export * from "./state"
-export * from "./log"

--- a/lib/reactotron-core-contract/src/reactotron-core-contract.ts
+++ b/lib/reactotron-core-contract/src/reactotron-core-contract.ts
@@ -1,3 +1,4 @@
 export * from "./command"
 export * from "./server-events"
+export * from "./state"
 export * from "./log"

--- a/lib/reactotron-core-contract/src/state.ts
+++ b/lib/reactotron-core-contract/src/state.ts
@@ -1,0 +1,54 @@
+export interface StateBackupRequestPayload {
+  state: Record<string, any>
+}
+
+export interface StateBackupResponsePayload {
+  state: Record<string, any>
+}
+
+export interface StateRestoreRequestPayload {
+  state: Record<string, any>
+}
+
+export interface StateActionDispatchPayload {
+  type: string
+  payload: Record<string, any>
+}
+
+type Path = string
+
+type Value = any
+
+export interface StateKeysRequestPayload {
+  path: Path
+}
+
+export interface StateKeysResponsePayload {
+  path: Path
+  keys: string[]
+  valid: boolean
+}
+
+export interface StateValuesRequestPayload {
+  path: Path
+}
+
+export interface StateValuesResponsePayload {
+  path: Path
+  value: Value
+  valid: boolean
+}
+
+export interface StateValuesChangePayload {
+  changes: { path: Path; value: Value }[]
+}
+
+export interface StateValuesSubscribePayload {
+  paths: Path[]
+}
+
+export interface StateActionCompletePayload {
+  name: string
+  action: Record<string, any>
+  ms?: number
+}

--- a/lib/reactotron-core-contract/src/state.ts
+++ b/lib/reactotron-core-contract/src/state.ts
@@ -11,8 +11,16 @@ export interface StateRestoreRequestPayload {
 }
 
 export interface StateActionDispatchPayload {
-  type: string
-  payload: Record<string, any>
+  action:
+    | {
+        type: string
+        payload: Record<string, any>
+      }
+    | {
+        name: string
+        path?: string
+        args?: any[]
+      }
 }
 
 type Path = string

--- a/lib/reactotron-mst/src/reactotron-mst.ts
+++ b/lib/reactotron-mst/src/reactotron-mst.ts
@@ -53,7 +53,7 @@ import {
 
 // --- Helpers ---------------------------------
 
-const dotPath = (fullPath: string, o: any) => path(split(".", fullPath), o)
+const dotPath = (fullPath: string, o: Record<string, any>) => path(split(".", fullPath), o)
 const isNilOrEmpty = (value: any) => isNil(value) || isEmpty(value)
 const isReactNativeEvent = (value: any) =>
   typeof value !== "undefined" &&
@@ -78,12 +78,15 @@ const convertUnsafeArguments = (args: any) => {
   })
 }
 
-const isSerializedActionCall = (value: unknown): value is ISerializedActionCall =>
-  typeof value === "object" &&
-  "name" in value &&
-  value.name === "string" &&
-  ("path" in value ? typeof value.path === "string" : true) &&
-  ("args" in value ? Array.isArray(value.args) : true)
+const isSerializedActionCall = (value: unknown): value is ISerializedActionCall => {
+  return (
+    typeof value === "object" &&
+    "name" in value &&
+    typeof value.name === "string" &&
+    ("path" in value ? typeof value.path === "string" : true) &&
+    ("args" in value ? Array.isArray(value.args) : true)
+  )
+}
 
 const isSerializedActionCallArray = (value: unknown): value is ISerializedActionCall[] =>
   Array.isArray(value) && value.every(isSerializedActionCall)
@@ -334,12 +337,8 @@ export function mst(opts: MstPluginOptions = {}) {
             : "default"
         ]
       const action = command && command.payload && command.payload.action
-      if (
-        trackedNode &&
-        trackedNode.node &&
-        action &&
-        (isSerializedActionCall(action) || isSerializedActionCallArray(action))
-      ) {
+      const isValidAction = isSerializedActionCall(action) || isSerializedActionCallArray(action)
+      if (trackedNode && trackedNode.node && action && isValidAction) {
         const { node } = trackedNode
         try {
           applyAction(node, action)
@@ -387,8 +386,8 @@ export function mst(opts: MstPluginOptions = {}) {
             ? command.mstNodeName
             : "default"
         ]
-      const atPath = command && command.payload && command.payload.path
-      if (trackedNode && trackedNode.node && atPath) {
+      const atPath = command?.payload?.path
+      if (trackedNode && trackedNode.node) {
         const state = getSnapshot<IStateTreeNode>(trackedNode.node)
         if (isNilOrEmpty(atPath)) {
           client.stateKeysResponse(null, keys(state))
@@ -411,9 +410,9 @@ export function mst(opts: MstPluginOptions = {}) {
             ? command.mstNodeName
             : "default"
         ]
-      const atPath: string = command && command.payload && command.payload.path
-      if (trackedNode && trackedNode.node && atPath) {
-        const state = getSnapshot(trackedNode.node)
+      const atPath = command?.payload?.path
+      if (trackedNode && trackedNode.node) {
+        const state = getSnapshot<IStateTreeNode>(trackedNode.node)
         if (isNilOrEmpty(atPath)) {
           client.stateValuesResponse(null, state)
         } else {

--- a/lib/reactotron-mst/src/reactotron-mst.ts
+++ b/lib/reactotron-mst/src/reactotron-mst.ts
@@ -14,7 +14,6 @@ import {
 } from "mobx-state-tree"
 import type { IStateTreeNode, IType, IMiddlewareEvent } from "mobx-state-tree"
 import {
-  Reactotron,
   ReactotronCore,
   Plugin,
   assertHasStateResponsePlugin,
@@ -119,10 +118,10 @@ export function mst(opts: MstPluginOptions = {}) {
    *
    * @param reactotron The reactotron instance we're attaching to.
    */
-  function plugin(reactotron: Reactotron) {
+  function plugin<Client extends ReactotronCore = ReactotronCore>(reactotron: Client) {
     // make sure have loaded the StateResponsePlugin
     assertHasStateResponsePlugin(reactotron)
-    const client = reactotron as Reactotron & InferFeatures<Reactotron, StateResponsePlugin>
+    const client = reactotron as Client & InferFeatures<Client, StateResponsePlugin>
 
     // --- Plugin-scoped variables ---------------------------------
 
@@ -250,7 +249,7 @@ export function mst(opts: MstPluginOptions = {}) {
           })
         }
 
-        // return the result of the next middlware
+        // return the result of the next middleware
         return result
       })
     }
@@ -431,15 +430,8 @@ export function mst(opts: MstPluginOptions = {}) {
       // All keys in this object will be attached to the main Reactotron instance
       // and available to be called directly.
       features: { trackMstNode },
-    } satisfies Plugin<ReactotronCore>
+    } satisfies Plugin<Client>
   }
 
   return plugin
-}
-
-declare module "reactotron-core-client" {
-  // eslint-disable-next-line import/export
-  export interface Reactotron {
-    trackMstNode?: (node: IStateTreeNode, nodeName?: string) => { kind: string; message?: string }
-  }
 }

--- a/lib/reactotron-mst/test/backup.test.ts
+++ b/lib/reactotron-mst/test/backup.test.ts
@@ -1,9 +1,17 @@
 import * as td from "testdouble"
-import { TestUserModel, createMstPlugin } from "./fixtures"
+import { TestUserModel, commandMetadataFixture, createMstPlugin } from "./fixtures"
 import { Command } from "reactotron-core-contract"
 
-const INBOUND = { type: "state.backup.request" } as Command<"state.backup.request">
-const OUTBOUND = { type: "state.backup.response" } as Command<"state.backup.response">
+const INBOUND = {
+  ...commandMetadataFixture,
+  type: "state.backup.request",
+  payload: { state: { age: 100, name: "" } },
+} satisfies Command<"state.backup.request">
+const OUTBOUND = {
+  ...commandMetadataFixture,
+  type: "state.backup.response",
+  payload: { state: { age: 100, name: "" } },
+} satisfies Command<"state.backup.response">
 
 describe("backup", () => {
   it("responds with current state", () => {

--- a/lib/reactotron-mst/test/backup.test.ts
+++ b/lib/reactotron-mst/test/backup.test.ts
@@ -1,8 +1,9 @@
 import * as td from "testdouble"
 import { TestUserModel, createMstPlugin } from "./fixtures"
+import { Command } from "reactotron-core-contract"
 
-const INBOUND = { type: "state.backup.request" }
-const OUTBOUND = { type: "state.backup.response" }
+const INBOUND = { type: "state.backup.request" } as Command<"state.backup.request">
+const OUTBOUND = { type: "state.backup.response" } as Command<"state.backup.response">
 
 describe("backup", () => {
   it("responds with current state", () => {

--- a/lib/reactotron-mst/test/dispatch-action.test.ts
+++ b/lib/reactotron-mst/test/dispatch-action.test.ts
@@ -1,12 +1,13 @@
 import type { ISerializedActionCall } from "mobx-state-tree"
-import { TestUserModel, createMstPlugin } from "./fixtures"
-import { Command } from "reactotron-core-contract"
+import type { Command } from "reactotron-core-contract"
+import { TestUserModel, commandMetadataFixture, createMstPlugin } from "./fixtures"
 
 function createAction(action: ISerializedActionCall) {
   return {
+    ...commandMetadataFixture,
     type: "state.action.dispatch",
     payload: { action },
-  } as Command<"state.action.dispatch">
+  } satisfies Command<"state.action.dispatch">
 }
 
 describe("dispatch-action", () => {

--- a/lib/reactotron-mst/test/dispatch-action.test.ts
+++ b/lib/reactotron-mst/test/dispatch-action.test.ts
@@ -1,10 +1,12 @@
+import type { ISerializedActionCall } from "mobx-state-tree"
 import { TestUserModel, createMstPlugin } from "./fixtures"
+import { Command } from "reactotron-core-contract"
 
-function createAction(action: any) {
+function createAction(action: ISerializedActionCall) {
   return {
     type: "state.action.dispatch",
     payload: { action },
-  }
+  } as Command<"state.action.dispatch">
 }
 
 describe("dispatch-action", () => {

--- a/lib/reactotron-mst/test/fixtures/command.ts
+++ b/lib/reactotron-mst/test/fixtures/command.ts
@@ -1,0 +1,9 @@
+import { Command } from "reactotron-core-contract"
+
+export const commandMetadataFixture: Omit<Command, "payload" | "type" | "payload"> = {
+  connectionId: 1,
+  date: new Date("2019-01-01T00:00:00.000Z"),
+  deltaTime: 0,
+  important: false,
+  messageId: 1,
+}

--- a/lib/reactotron-mst/test/fixtures/index.ts
+++ b/lib/reactotron-mst/test/fixtures/index.ts
@@ -1,3 +1,4 @@
+export { commandMetadataFixture } from "./command"
 export { TestUserModel } from "./test-user-model"
 export { TestCompanyModel, createTestCompany } from "./test-company-model"
 export * from "./create-mst-plugin"

--- a/lib/reactotron-mst/test/mocks/create-mock-reactotron.ts
+++ b/lib/reactotron-mst/test/mocks/create-mock-reactotron.ts
@@ -10,7 +10,7 @@ export function createMockReactotron() {
     startTimer: td.func<Reactotron["startTimer"]>(),
     stateValuesChange: td.func<Reactotron["stateValuesChange"]>(),
     send: td.func<Reactotron["send"]>(),
-    stateKeysResponse: td.func<Reactotron["send"]>(),
+    stateKeysResponse: td.func<Reactotron["stateKeysResponse"]>(),
     stateValuesResponse: td.func<Reactotron["stateValuesResponse"]>(),
     apiResponse: td.func<Reactotron["apiResponse"]>(),
     stateActionComplete: td.func<Reactotron["stateActionComplete"]>(),

--- a/lib/reactotron-mst/test/mocks/create-mock-reactotron.ts
+++ b/lib/reactotron-mst/test/mocks/create-mock-reactotron.ts
@@ -30,8 +30,8 @@ export function createMockReactotron() {
     image: td.func<Reactotron["image"]>(),
     warn: td.func<Reactotron["warn"]>(),
     onCustomCommand: td.func<Reactotron["onCustomCommand"]>(),
-    plugins: [],
-    options: {},
+    plugins: td.object(),
+    options: td.object(),
     repl: td.func<Reactotron["repl"]>(),
   }
 

--- a/lib/reactotron-mst/test/request-keys.test.ts
+++ b/lib/reactotron-mst/test/request-keys.test.ts
@@ -1,9 +1,13 @@
 import * as td from "testdouble"
-import { TestUserModel, createMstPlugin } from "./fixtures"
-import { Command } from "reactotron-core-contract"
+import { TestUserModel, createMstPlugin, commandMetadataFixture } from "./fixtures"
+import type { Command } from "reactotron-core-contract"
 
 function createAction(path: string) {
-  return { type: "state.keys.request", payload: { path } } as Command<"state.keys.request">
+  return {
+    ...commandMetadataFixture,
+    type: "state.keys.request",
+    payload: { path },
+  } satisfies Command<"state.keys.request">
 }
 
 describe("request-keys", () => {

--- a/lib/reactotron-mst/test/request-keys.test.ts
+++ b/lib/reactotron-mst/test/request-keys.test.ts
@@ -1,8 +1,9 @@
 import * as td from "testdouble"
 import { TestUserModel, createMstPlugin } from "./fixtures"
+import { Command } from "reactotron-core-contract"
 
 function createAction(path: string) {
-  return { type: "state.keys.request", payload: { path } }
+  return { type: "state.keys.request", payload: { path } } as Command<"state.keys.request">
 }
 
 describe("request-keys", () => {

--- a/lib/reactotron-mst/test/request-values.test.ts
+++ b/lib/reactotron-mst/test/request-values.test.ts
@@ -1,9 +1,13 @@
 import * as td from "testdouble"
-import { TestUserModel, createMstPlugin } from "./fixtures"
+import { TestUserModel, commandMetadataFixture, createMstPlugin } from "./fixtures"
 import { Command } from "reactotron-core-contract"
 
 function createAction(path: string) {
-  return { type: "state.values.request", payload: { path } } as Command<"state.values.request">
+  return {
+    ...commandMetadataFixture,
+    type: "state.values.request",
+    payload: { path },
+  } satisfies Command<"state.values.request">
 }
 
 describe("request-values", () => {

--- a/lib/reactotron-mst/test/request-values.test.ts
+++ b/lib/reactotron-mst/test/request-values.test.ts
@@ -1,8 +1,9 @@
 import * as td from "testdouble"
 import { TestUserModel, createMstPlugin } from "./fixtures"
+import { Command } from "reactotron-core-contract"
 
 function createAction(path: string) {
-  return { type: "state.values.request", payload: { path } }
+  return { type: "state.values.request", payload: { path } } as Command<"state.values.request">
 }
 
 describe("request-values", () => {

--- a/lib/reactotron-mst/test/restore.test.ts
+++ b/lib/reactotron-mst/test/restore.test.ts
@@ -1,11 +1,12 @@
 import { getSnapshot } from "mobx-state-tree"
 import { TestUserModel, createMstPlugin } from "./fixtures"
+import { Command } from "reactotron-core-contract"
 
 const STATE = { age: 1, name: "i" }
 const INBOUND = {
   type: "state.restore.request",
   payload: { state: STATE },
-}
+} as unknown as Command<"state.restore.request">
 
 describe("restore", () => {
   it("responds with current state", () => {

--- a/lib/reactotron-mst/test/restore.test.ts
+++ b/lib/reactotron-mst/test/restore.test.ts
@@ -1,12 +1,13 @@
 import { getSnapshot } from "mobx-state-tree"
-import { TestUserModel, createMstPlugin } from "./fixtures"
+import { TestUserModel, commandMetadataFixture, createMstPlugin } from "./fixtures"
 import { Command } from "reactotron-core-contract"
 
 const STATE = { age: 1, name: "i" }
 const INBOUND = {
+  ...commandMetadataFixture,
   type: "state.restore.request",
   payload: { state: STATE },
-} as unknown as Command<"state.restore.request">
+} satisfies Command<"state.restore.request">
 
 describe("restore", () => {
   it("responds with current state", () => {

--- a/lib/reactotron-mst/test/subscribe.test.ts
+++ b/lib/reactotron-mst/test/subscribe.test.ts
@@ -1,12 +1,18 @@
 import * as td from "testdouble"
-import { TestUserModel, createMstPlugin, createTestCompany } from "./fixtures"
+import {
+  TestUserModel,
+  commandMetadataFixture,
+  createMstPlugin,
+  createTestCompany,
+} from "./fixtures"
 import { Command } from "reactotron-core-contract"
 
 function createAction(paths: string[]) {
   return {
+    ...commandMetadataFixture,
     type: "state.values.subscribe",
     payload: { paths },
-  } as Command<"state.values.subscribe">
+  } satisfies Command<"state.values.subscribe">
 }
 describe("subscribe", () => {
   it("won't die if we're not tracking nodes", () => {

--- a/lib/reactotron-mst/test/subscribe.test.ts
+++ b/lib/reactotron-mst/test/subscribe.test.ts
@@ -1,11 +1,12 @@
 import * as td from "testdouble"
 import { TestUserModel, createMstPlugin, createTestCompany } from "./fixtures"
+import { Command } from "reactotron-core-contract"
 
-function createAction(paths: any) {
+function createAction(paths: string[]) {
   return {
     type: "state.values.subscribe",
     payload: { paths },
-  }
+  } as Command<"state.values.subscribe">
 }
 describe("subscribe", () => {
   it("won't die if we're not tracking nodes", () => {


### PR DESCRIPTION
This PR makes changes to address this issue in Ignite: https://github.com/infinitered/ignite/pull/2446#issuecomment-1636506481

This PR resolves the need for `// @ts-expect-error` by:
- adding a generic to the `reactotron-mst` plugin types
- adding types to the payloads for the state messages for `reactotron-mst` and `reactotron-redux`
- adds missing `reactotron-react-native` commands to contracts