### PR TITLE
Improve `reactotron-react-native` types

### DIFF
--- a/lib/reactotron-core-client/src/reactotron-core-client.ts
+++ b/lib/reactotron-core-client/src/reactotron-core-client.ts
@@ -91,7 +91,6 @@ export interface ReactotronCore {
     important?: boolean
   ) => void
   display: (config: DisplayConfig) => void
-  reportError: (this: any, error: Error) => void
   onCustomCommand: <Args extends CustomCommandArg[] = CustomCommand["args"]>(
     config: CustomCommand<Args>
   ) => () => void | ((config: string, optHandler?: () => void) => () => void)

--- a/lib/reactotron-core-contract/src/command.ts
+++ b/lib/reactotron-core-contract/src/command.ts
@@ -43,6 +43,8 @@ export const CommandType = {
   DevtoolsOpen: "devtools.open",
   DevtoolsReload: "devtools.reload",
   EditorOpen: "editor.open",
+  Storybook: "storybook",
+  Overlay: "overlay",
 } as const
 
 export type CommandTypeKey = (typeof CommandType)[keyof typeof CommandType]
@@ -89,6 +91,8 @@ export interface CommandMap {
   [CommandType.DevtoolsOpen]: undefined
   [CommandType.DevtoolsReload]: undefined
   [CommandType.EditorOpen]: EditorOpenPayload
+  [CommandType.Storybook]: boolean
+  [CommandType.Overlay]: boolean
 }
 
 export type CommandEvent = (command: Command) => void

--- a/lib/reactotron-react-native/package.json
+++ b/lib/reactotron-react-native/package.json
@@ -56,6 +56,7 @@
     "@babel/plugin-transform-react-jsx": "^7.21.0",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
+    "@react-native-async-storage/async-storage": "^1.19.1",
     "@types/jest": "29.4.0",
     "@types/node": "16.11.11",
     "@types/react": "18.0.0",

--- a/lib/reactotron-react-native/src/plugins/asyncStorage.ts
+++ b/lib/reactotron-react-native/src/plugins/asyncStorage.ts
@@ -1,4 +1,5 @@
 import type { ReactotronCore, Plugin } from "reactotron-core-client"
+import type { AsyncStorageStatic } from "@react-native-async-storage/async-storage"
 export interface AsyncStorageOptions {
   ignore?: string[]
 }
@@ -7,36 +8,25 @@ const PLUGIN_DEFAULTS: AsyncStorageOptions = {
   ignore: [],
 }
 
-export interface AsyncStorageHandler {
-  getItem: (key: string) => string
-  setItem: (key: string, value: string, callback?: (error: Error) => void) => void
-  removeItem: (key: string, callback?: (error: Error) => void) => void
-  mergeItem: (key: string, value: string, callback?: (error: Error) => void) => void
-  clear: (callback: (error: Error) => void) => void
-  multiSet: (pairs: string[][], callback?: (error: Error) => void) => void
-  multiRemove: (keys: string[], callback?: (error: Error) => void) => void
-  multiMerge: (pairs: string[][], callback?: (error: Error) => void) => void
-}
-
 const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronCore) => {
   // setup configuration
   const config = Object.assign({}, PLUGIN_DEFAULTS, options || {})
   const ignore = config.ignore || PLUGIN_DEFAULTS.ignore
 
-  let swizzSetItem: AsyncStorageHandler["setItem"]
-  let swizzRemoveItem: AsyncStorageHandler["removeItem"]
-  let swizzMergeItem: AsyncStorageHandler["mergeItem"]
-  let swizzClear: AsyncStorageHandler["clear"]
-  let swizzMultiSet: AsyncStorageHandler["multiSet"]
-  let swizzMultiRemove: AsyncStorageHandler["multiRemove"]
-  let swizzMultiMerge: AsyncStorageHandler["multiMerge"]
+  let swizzSetItem: AsyncStorageStatic["setItem"]
+  let swizzRemoveItem: AsyncStorageStatic["removeItem"]
+  let swizzMergeItem: AsyncStorageStatic["mergeItem"]
+  let swizzClear: AsyncStorageStatic["clear"]
+  let swizzMultiSet: AsyncStorageStatic["multiSet"]
+  let swizzMultiRemove: AsyncStorageStatic["multiRemove"]
+  let swizzMultiMerge: AsyncStorageStatic["multiMerge"]
   let isSwizzled = false
 
   const sendToReactotron = (action: string, data?: any) => {
     reactotron.send("asyncStorage.mutation", { action, data })
   }
 
-  const setItem: AsyncStorageHandler["setItem"] = async (key, value, callback) => {
+  const setItem: AsyncStorageStatic["setItem"] = async (key, value, callback) => {
     try {
       if (ignore.indexOf(key) < 0) {
         sendToReactotron("setItem", { key, value })
@@ -45,7 +35,7 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
     return swizzSetItem(key, value, callback)
   }
 
-  const removeItem: AsyncStorageHandler["removeItem"] = async (key, callback) => {
+  const removeItem: AsyncStorageStatic["removeItem"] = async (key, callback) => {
     try {
       if (ignore.indexOf(key) < 0) {
         sendToReactotron("removeItem", { key })
@@ -54,7 +44,7 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
     return swizzRemoveItem(key, callback)
   }
 
-  const mergeItem: AsyncStorageHandler["mergeItem"] = async (key, value, callback) => {
+  const mergeItem: AsyncStorageStatic["mergeItem"] = async (key, value, callback) => {
     try {
       if (ignore.indexOf(key) < 0) {
         sendToReactotron("mergeItem", { key, value })
@@ -63,14 +53,14 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
     return swizzMergeItem(key, value, callback)
   }
 
-  const clear: AsyncStorageHandler["clear"] = async (callback) => {
+  const clear: AsyncStorageStatic["clear"] = async (callback) => {
     try {
       sendToReactotron("clear")
     } catch (e) {}
     return swizzClear(callback)
   }
 
-  const multiSet: AsyncStorageHandler["multiSet"] = async (pairs, callback) => {
+  const multiSet: AsyncStorageStatic["multiSet"] = async (pairs, callback) => {
     try {
       const shippablePairs = (pairs || []).filter(
         (pair) => pair && pair[0] && ignore.indexOf(pair[0]) < 0
@@ -82,7 +72,7 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
     return swizzMultiSet(pairs, callback)
   }
 
-  const multiRemove: AsyncStorageHandler["multiRemove"] = async (keys, callback) => {
+  const multiRemove: AsyncStorageStatic["multiRemove"] = async (keys, callback) => {
     try {
       const shippableKeys = (keys || []).filter((key) => ignore.indexOf(key) < 0)
       if (shippableKeys.length > 0) {
@@ -92,7 +82,7 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
     return swizzMultiRemove(keys, callback)
   }
 
-  const multiMerge: AsyncStorageHandler["multiMerge"] = async (pairs, callback) => {
+  const multiMerge: AsyncStorageStatic["multiMerge"] = async (pairs, callback) => {
     try {
       const shippablePairs = (pairs || []).filter(
         (pair) => pair && pair[0] && ignore.indexOf(pair[0]) < 0

--- a/lib/reactotron-react-native/src/plugins/asyncStorage.ts
+++ b/lib/reactotron-react-native/src/plugins/asyncStorage.ts
@@ -18,7 +18,7 @@ export interface AsyncStorageHandler {
   multiMerge: (pairs: string[][], callback?: (error: Error) => void) => void
 }
 
-const asyncStorage = (options: AsyncStorageOptions) => (reactotron: ReactotronCore) => {
+const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronCore) => {
   // setup configuration
   const config = Object.assign({}, PLUGIN_DEFAULTS, options || {})
   const ignore = config.ignore || PLUGIN_DEFAULTS.ignore

--- a/lib/reactotron-react-native/src/plugins/networking.ts
+++ b/lib/reactotron-react-native/src/plugins/networking.ts
@@ -140,12 +140,13 @@ const networking =
       }
     }
 
-    // register our monkey-patch
-    XHRInterceptor.setSendCallback(onSend)
-    XHRInterceptor.setResponseCallback(onResponse)
-    XHRInterceptor.enableInterception()
-
-    // nothing of use to offer to the plugin
-    return {} satisfies Plugin<ReactotronCore>
+    return {
+      onConnect: () => {
+        // register our monkey-patch
+        XHRInterceptor.setSendCallback(onSend)
+        XHRInterceptor.setResponseCallback(onResponse)
+        XHRInterceptor.enableInterception()
+      },
+    } satisfies Plugin<ReactotronCore>
   }
 export default networking

--- a/lib/reactotron-react-native/src/plugins/overlay/index.tsx
+++ b/lib/reactotron-react-native/src/plugins/overlay/index.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { View } from "react-native"
 import mitt from "mitt"
+import type { ReactotronCore, Plugin } from "reactotron-core-client"
 
 import FullScreenOverlay from "./overlay"
 
@@ -11,8 +12,6 @@ export default function OverlayCreator() {
     return {
       /**
        * Fires when any Reactotron message arrives.
-       *
-       * @param {object} command The Reactotron command object.
        */
       onCommand: (command) => {
         if (command.type !== "overlay") return
@@ -31,7 +30,7 @@ export default function OverlayCreator() {
               </View>
             ),
       },
-    }
+    } satisfies Plugin<ReactotronCore>
   }
 }
 

--- a/lib/reactotron-react-native/src/plugins/storybook/index.tsx
+++ b/lib/reactotron-react-native/src/plugins/storybook/index.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import mitt from "mitt"
+import type { ReactotronCore, Plugin } from "reactotron-core-client"
 
 import StorybookSwitcher from "./storybook"
 
@@ -10,21 +11,23 @@ export default () => () => {
   const emitter = mitt()
 
   return {
-    onCommand: (command: any) => {
+    onCommand: (command) => {
       if (command.type !== "storybook") return
       // relay this payload on to the emitter
       emitter.emit("storybook", command.payload)
     },
 
     features: {
-      storybookSwitcher: (storybookUi: any) => (WrappedComponent: any) =>
-        function StorybookSwitcherContainer(props: any) {
-          return (
-            <StorybookSwitcher storybookUi={storybookUi} emitter={emitter}>
-              <WrappedComponent {...props} />
-            </StorybookSwitcher>
-          )
-        },
+      storybookSwitcher:
+        (storybookUi: StorybookSwitcher["props"]["storybookUi"]) =>
+        (WrappedComponent: React.ComponentType<any>) =>
+          function StorybookSwitcherContainer(props: any) {
+            return (
+              <StorybookSwitcher storybookUi={storybookUi} emitter={emitter}>
+                <WrappedComponent {...props} />
+              </StorybookSwitcher>
+            )
+          },
     },
-  }
+  } satisfies Plugin<ReactotronCore>
 }

--- a/lib/reactotron-react-native/src/plugins/storybook/storybook.tsx
+++ b/lib/reactotron-react-native/src/plugins/storybook/storybook.tsx
@@ -2,7 +2,7 @@ import React, { Component } from "react"
 import { View } from "react-native"
 
 interface Props {
-  storybookUi: any
+  storybookUi: React.ComponentType
   emitter: any
 }
 
@@ -14,12 +14,9 @@ class StorybookSwitcher extends Component<React.PropsWithChildren<Props>, State>
   /**
    * Creates an instance of FullScreenOverlay.
    *
-   * @param {any} props
-   * @param {Object} props.emitter An event emitter.
-   *
    * @memberOf FullScreenOverlay
    */
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
 
     this.state = {
@@ -27,7 +24,7 @@ class StorybookSwitcher extends Component<React.PropsWithChildren<Props>, State>
     }
 
     // when the server sends stuff
-    props.emitter.on("storybook", (payload) => {
+    props.emitter.on("storybook", (payload: boolean) => {
       this.setState({ showStorybook: payload })
     })
   }

--- a/lib/reactotron-react-native/src/plugins/trackGlobalErrors.ts
+++ b/lib/reactotron-react-native/src/plugins/trackGlobalErrors.ts
@@ -6,6 +6,7 @@ import {
   LoggerPlugin,
   ReactotronCore,
   assertHasLoggerPlugin,
+  Plugin,
 } from "reactotron-core-client"
 import _LogBox, {
   LogBoxStatic as LogBoxStaticPublic,
@@ -56,7 +57,7 @@ const objectifyError = (error: Error) => {
 
 // const reactNativeFrameFinder = frame => contains('/node_modules/react-native/', frame.fileName)
 
-const trackGlobalErrors = (options: TrackGlobalErrorsOptions) => (reactotron: ReactotronCore) => {
+const trackGlobalErrors = (options?: TrackGlobalErrorsOptions) => (reactotron: ReactotronCore) => {
   // make sure we have the logger plugin
   assertHasLoggerPlugin(reactotron)
   const client = reactotron as ReactotronCore & InferFeatures<ReactotronCore, LoggerPlugin>
@@ -131,7 +132,7 @@ const trackGlobalErrors = (options: TrackGlobalErrorsOptions) => (reactotron: Re
     features: {
       reportError,
     },
-  }
+  } satisfies Plugin<ReactotronCore>
 }
 
 export default trackGlobalErrors

--- a/lib/reactotron-react-native/src/reactotron-react-native.ts
+++ b/lib/reactotron-react-native/src/reactotron-react-native.ts
@@ -7,11 +7,12 @@ import type {
   Reactotron,
   ReactotronCore,
 } from "reactotron-core-client"
+import type { AsyncStorageStatic } from "@react-native-async-storage/async-storage"
 import getHost from "rn-host-detect"
 
 import getReactNativeVersion from "./helpers/getReactNativeVersion"
 import getReactNativeDimensions from "./helpers/getReactNativeDimensions"
-import asyncStorage, { AsyncStorageHandler, AsyncStorageOptions } from "./plugins/asyncStorage"
+import asyncStorage, { AsyncStorageOptions } from "./plugins/asyncStorage"
 import overlay from "./plugins/overlay"
 import openInEditor, { OpenInEditorOptions } from "./plugins/openInEditor"
 import trackGlobalErrors, { TrackGlobalErrorsOptions } from "./plugins/trackGlobalErrors"
@@ -76,7 +77,7 @@ export interface UseReactNativeOptions {
   devTools?: boolean
 }
 
-const reactNativeCorePlugins = [
+export const reactNativeCorePlugins = [
   asyncStorage(),
   trackGlobalErrors(),
   openInEditor(),
@@ -93,8 +94,8 @@ type ReactNativePluginFeatures = InferFeaturesFromPlugins<
 
 export interface ReactotronReactNative extends Reactotron, ReactNativePluginFeatures {
   useReactNative: (options?: UseReactNativeOptions) => this
-  asyncStorageHandler?: AsyncStorageHandler
-  setAsyncStorageHandler: (asyncStorage: AsyncStorageHandler) => this
+  asyncStorageHandler?: AsyncStorageStatic
+  setAsyncStorageHandler: (asyncStorage: AsyncStorageStatic) => this
 }
 
 const reactotron = createClient<ReactotronReactNative>(DEFAULTS)
@@ -135,7 +136,7 @@ reactotron.useReactNative = (options: UseReactNativeOptions = {}) => {
   return reactotron
 }
 
-reactotron.setAsyncStorageHandler = (asyncStorage: AsyncStorageHandler) => {
+reactotron.setAsyncStorageHandler = (asyncStorage: AsyncStorageStatic) => {
   reactotron.asyncStorageHandler = asyncStorage
 
   return reactotron

--- a/lib/reactotron-redux/src/testHelpers.ts
+++ b/lib/reactotron-redux/src/testHelpers.ts
@@ -7,7 +7,6 @@ export const defaultReactotronMock: Reactotron = {
   connect: jest.fn(),
   send: jest.fn(),
   display: jest.fn(),
-  reportError: jest.fn(),
   use: jest.fn(),
   onCustomCommand: jest.fn(),
   clear: jest.fn(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4466,6 +4466,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-async-storage/async-storage@npm:^1.19.1":
+  version: 1.19.1
+  resolution: "@react-native-async-storage/async-storage@npm:1.19.1"
+  dependencies:
+    merge-options: ^3.0.4
+  peerDependencies:
+    react-native: ^0.0.0-0 || 0.60 - 0.72 || 1000.0.0
+  checksum: 7367210e16f788999ca8ff96bd04bbd345f44c186cec7c50903d55637f572c73b8a79f9c948a549329ad489c08d77dd49367971691ed54dbc3839285e0194431
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-clean@npm:11.3.3":
   version: 11.3.3
   resolution: "@react-native-community/cli-clean@npm:11.3.3"
@@ -18487,6 +18498,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-obj@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "is-plain-obj@npm:2.1.0"
+  checksum: cec9100678b0a9fe0248a81743041ed990c2d4c99f893d935545cfbc42876cbe86d207f3b895700c690ad2fa520e568c44afc1605044b535a7820c1d40e38daa
+  languageName: node
+  linkType: hard
+
 "is-plain-object@npm:^2.0.1, is-plain-object@npm:^2.0.3, is-plain-object@npm:^2.0.4":
   version: 2.0.4
   resolution: "is-plain-object@npm:2.0.4"
@@ -22405,6 +22423,15 @@ __metadata:
   version: 1.0.1
   resolution: "merge-descriptors@npm:1.0.1"
   checksum: 5abc259d2ae25bb06d19ce2b94a21632583c74e2a9109ee1ba7fd147aa7362b380d971e0251069f8b3eb7d48c21ac839e21fa177b335e82c76ec172e30c31a26
+  languageName: node
+  linkType: hard
+
+"merge-options@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "merge-options@npm:3.0.4"
+  dependencies:
+    is-plain-obj: ^2.1.0
+  checksum: d86ddb3dd6e85d558dbf25dc944f3527b6bacb944db3fdda6e84a3f59c4e4b85231095f58b835758b9a57708342dee0f8de0dffa352974a48221487fe9f4584f
   languageName: node
   linkType: hard
 
@@ -27519,6 +27546,7 @@ __metadata:
     "@babel/plugin-transform-react-jsx": ^7.21.0
     "@babel/preset-env": ^7.20.2
     "@babel/preset-typescript": ^7.21.0
+    "@react-native-async-storage/async-storage": ^1.19.1
     "@types/jest": 29.4.0
     "@types/node": 16.11.11
     "@types/react": 18.0.0


### PR DESCRIPTION
This PR 
- removes `reportError` from the public types
- infers all the features from the `reactotron-react-native` plugins.
- adds explicit type dependency to `@react-native-async-storage/async-storage` for `asyncStorage`