### PR TITLE
fix(reactotron-app) Dev tools now opens automatically every time the app launches in dev mode

### DIFF
--- a/apps/reactotron-app/src/main/index.ts
+++ b/apps/reactotron-app/src/main/index.ts
@@ -44,15 +44,15 @@ function createMainWindow() {
   // Shows the main window once the web content is loaded.
   window.once("ready-to-show", () => {
     window.show()
+
+    if (isDevelopment) {
+      window.webContents.openDevTools()
+    }  
   })
 
   window.setBackgroundColor("#1e1e1e") // see reactotron-core-ui for background color
 
   mainWindowState.manage(window)
-
-  if (isDevelopment) {
-    window.webContents.openDevTools()
-  }
 
   if (isDevelopment) {
     window.loadURL(`http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}`)


### PR DESCRIPTION
The code was already in there to open the dev tools when the app was launched, but it wasn't happening because of electron's startup procedure. 

I moved the call to `window.webContents.openDevTools()` inside the `ready-to-show` lifecycle method and now in development mode, the reactotron app will automatically show the dev console.