### PR TITLE
fix(reactotron-react-native): remove rn-host-detect, use embedded snippet

### DIFF
--- a/lib/reactotron-react-native/package.json
+++ b/lib/reactotron-react-native/package.json
@@ -41,8 +41,7 @@
   "dependencies": {
     "mitt": "3.0.0",
     "query-string": "6.10.1",
-    "reactotron-core-client": "workspace:*",
-    "rn-host-detect": "1.2.0"
+    "reactotron-core-client": "workspace:*"
   },
   "optionalDependencies": {
     "react-native-flipper": "^0.164.0"

--- a/lib/reactotron-react-native/rollup.config.js
+++ b/lib/reactotron-react-native/rollup.config.js
@@ -22,7 +22,6 @@ const EXTERNALS = [
   "react",
   "react-native",
   "react-native/Libraries/Network/XHRInterceptor",
-  "rn-host-detect",
   "query-string",
 ]
 

--- a/lib/reactotron-react-native/src/reactotron-react-native.ts
+++ b/lib/reactotron-react-native/src/reactotron-react-native.ts
@@ -8,7 +8,6 @@ import type {
   ReactotronCore,
 } from "reactotron-core-client"
 import type { AsyncStorageStatic } from "@react-native-async-storage/async-storage"
-import getHost from "rn-host-detect"
 
 import getReactNativeVersion from "./helpers/getReactNativeVersion"
 import getReactNativeDimensions from "./helpers/getReactNativeDimensions"
@@ -25,6 +24,21 @@ const constants = NativeModules.PlatformConstants || {}
 const REACTOTRON_ASYNC_CLIENT_ID = "@REACTOTRON/clientId"
 
 let tempClientId: string | null = null
+
+/**
+ * Most of the time, host should be 'localhost'.
+ * But sometimes, it's not.  So we need to figure out what it is.
+ * @see https://github.com/infinitered/reactotron/issues/1107
+ *
+ * On an Android emulator, if you want to connect any servers of local, you will need run adb reverse on your terminal. This function gets the localhost IP of host machine directly to bypass this.
+ */
+const getHost = (defaultHost = "localhost") =>
+  typeof NativeModules?.SourceCode?.getConstants().scriptURL === "string" // type guard in case this ever breaks https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/NativeModules/specs/NativeSourceCode.js#L15-L21
+    ? NativeModules.SourceCode.scriptURL // Example: 'http://192.168.0.100:8081/index.bundle?platform=ios&dev=true&minify=false&modulesOnly=false&runModule=true&app=com.helloworld'
+        .split("://")[1] // Remove the scheme: '192.168.0.100:8081/index.bundle?platform=ios&dev=true&minify=false&modulesOnly=false&runModule=true&app=com.helloworld'
+        .split("/")[0] // Remove the path: '192.168.0.100:8081'
+        .split(":")[0] // Remove the port: '192.168.0.100'
+    : defaultHost
 
 const DEFAULTS: ClientOptions<ReactotronReactNative> = {
   createSocket: (path: string) => new WebSocket(path), // eslint-disable-line

--- a/yarn.lock
+++ b/yarn.lock
@@ -28114,7 +28114,6 @@ __metadata:
     react-native-flipper: 0.164.0
     reactotron-core-client: "workspace:*"
     rimraf: 4.1.3
-    rn-host-detect: 1.2.0
     rollup: 2.60.2
     rollup-plugin-babel: 4.4.0
     rollup-plugin-babel-minify: 10.0.0
@@ -29085,13 +29084,6 @@ __metadata:
     hash-base: ^3.0.0
     inherits: ^2.0.1
   checksum: 006accc40578ee2beae382757c4ce2908a826b27e2b079efdcd2959ee544ddf210b7b5d7d5e80467807604244e7388427330f5c6d4cd61e6edaddc5773ccc393
-  languageName: node
-  linkType: hard
-
-"rn-host-detect@npm:1.2.0":
-  version: 1.2.0
-  resolution: "rn-host-detect@npm:1.2.0"
-  checksum: 447b06d6726b665d9d7933b5da96232aad6ee01d1c8287e7b67e9ed1d07cde437127aaa4cf2f51ee2dfb4bb0f0cb398d2676220a392d990e99f6f2aefcc5f5b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There are several issues where users had trouble connecting to reactotron #1305, #1107, #815

This PR fixes them by upstreaming the fix into `reactotron-react-native` itself.

How to test:
1. `yarn`
2. `npx ignite-cli new PizzaApp --yes`
3. `npx zx scripts/install-workspace-packages-in-target.mjs ../PizzaApp`
4. `cd PizzaApp && yarn expo:android`
7. See that reactotron connects (without using `adb reverse tcp:9090 tcp:9090`)