### PR TITLE
chore(dependencies) Update and align dependencies

### DIFF
--- a/apps/reactotron-app/package.json
+++ b/apps/reactotron-app/package.json
@@ -107,7 +107,7 @@
     "react-test-renderer": "17.0.2",
     "rimraf": "^5.0.1",
     "ts-jest": "^29.0.4",
-    "typescript": "4.9.5"
+    "typescript": "^4.9.5"
   },
   "build": {
     "productName": "Reactotron",

--- a/lib/reactotron-apisauce/package.json
+++ b/lib/reactotron-apisauce/package.json
@@ -35,7 +35,7 @@
     "ci:test": "yarn test --runInBand"
   },
   "dependencies": {
-    "apisauce": "^0.16.0"
+    "apisauce": "^3.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",
@@ -57,7 +57,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-standard": "^5.0.0",
     "jest": "^29.4.2",
-    "json-server": "^0.14.2",
+    "json-server": "^0.17.4",
     "prettier": "^2.8.4",
     "rimraf": "4.1.2",
     "rollup": "^1.2.3",

--- a/lib/reactotron-apisauce/package.json
+++ b/lib/reactotron-apisauce/package.json
@@ -69,7 +69,7 @@
     "rollup-plugin-resolve": "^0.0.1-predev.1",
     "trash-cli": "^5.0.0",
     "ts-jest": "^29.0.5",
-    "typescript": "4.9.5"
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "root": false,

--- a/lib/reactotron-apisauce/test/plugin.test.ts
+++ b/lib/reactotron-apisauce/test/plugin.test.ts
@@ -38,8 +38,8 @@ describe("plugin", () => {
       .get("/hey")
       .then(plugin.features.apisauce)
       .then(() => {
-        // can't seem to deep equals here... it's like we're getting a wierd Object()
-        expect(request.url).toEqual(`http://localhost:${port}/hey`)
+        // can't seem to deep equals here... it's like we're getting a weird Object()
+        expect(request.url).toEqual("/hey")
         expect(request.method).toEqual("get")
         // eslint-disable-next-line dot-notation
         expect(request.headers["Accept"]).toEqual("application/json")

--- a/lib/reactotron-core-server/package.json
+++ b/lib/reactotron-core-server/package.json
@@ -71,7 +71,7 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-resolve": "0.0.1-predev.1",
     "ts-jest": "29.0.5",
-    "typescript": "4.9.5"
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "root": false,

--- a/lib/reactotron-core-ui/package.json
+++ b/lib/reactotron-core-ui/package.json
@@ -103,7 +103,7 @@
     "storybook-chromatic": "^4.0.2",
     "styled-components": "^6.0.8",
     "ts-jest": "29.0.5",
-    "typescript": "4.9.5"
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "root": false,

--- a/lib/reactotron-mst/package.json
+++ b/lib/reactotron-mst/package.json
@@ -78,7 +78,7 @@
     "testdouble": "^3.16.8",
     "trash-cli": "^5.0.0",
     "ts-jest": "^29.0.5",
-    "typescript": "4.9.5"
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "root": false

--- a/lib/reactotron-react-js/package.json
+++ b/lib/reactotron-react-js/package.json
@@ -67,7 +67,7 @@
     "semantic-release": "16.0.4",
     "trash-cli": "4.0.0",
     "ts-jest": "29.0.5",
-    "typescript": "4.9.5"
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "root": false,

--- a/lib/reactotron-react-native-mmkv/package.json
+++ b/lib/reactotron-react-native-mmkv/package.json
@@ -74,7 +74,7 @@
     "testdouble": "^3.16.8",
     "trash-cli": "^5.0.0",
     "ts-jest": "^29.0.5",
-    "typescript": "4.9.5"
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "root": false

--- a/lib/reactotron-react-native-mmkv/package.json
+++ b/lib/reactotron-react-native-mmkv/package.json
@@ -38,16 +38,12 @@
     "react-native-mmkv": "*",
     "reactotron-core-client": "*"
   },
-  "dependencies": {
-    "ramda": "^0.25.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.21.0",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
     "@types/jest": "^29.4.0",
     "@types/node": "^11.9.5",
-    "@types/ramda": "^0.25.50",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
     "babel-eslint": "^10.1.0",
@@ -63,7 +59,7 @@
     "eslint-plugin-standard": "^5.0.0",
     "jest": "^29.4.3",
     "prettier": "^2.8.4",
-    "react-native-mmkv": "^2.8.0",
+    "react-native-mmkv": "^2.10.2",
     "reactotron-core-client": "workspace:*",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",

--- a/lib/reactotron-react-native/package.json
+++ b/lib/reactotron-react-native/package.json
@@ -86,7 +86,7 @@
     "rollup-plugin-resolve": "0.0.1-predev.1",
     "trash-cli": "^5.0.0",
     "ts-jest": "29.0.5",
-    "typescript": "4.9.5"
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "root": false,

--- a/lib/reactotron-redux/package.json
+++ b/lib/reactotron-redux/package.json
@@ -67,7 +67,7 @@
     "rollup-plugin-resolve": "0.0.1-predev.1",
     "trash-cli": "5.0.0",
     "ts-jest": "29.0.5",
-    "typescript": "4.9.5"
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "root": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -27690,7 +27690,7 @@ __metadata:
     rollup-plugin-resolve: ^0.0.1-predev.1
     trash-cli: ^5.0.0
     ts-jest: ^29.0.5
-    typescript: 4.9.5
+    typescript: ^4.9.5
   languageName: unknown
   linkType: soft
 
@@ -27751,7 +27751,7 @@ __metadata:
     source-map-support: ^0.5.21
     styled-components: ^6.0.8
     ts-jest: ^29.0.4
-    typescript: 4.9.5
+    typescript: ^4.9.5
     v8-compile-cache: ^2.4.0
   languageName: unknown
   linkType: soft
@@ -27874,7 +27874,7 @@ __metadata:
     rollup-plugin-node-resolve: 5.2.0
     rollup-plugin-resolve: 0.0.1-predev.1
     ts-jest: 29.0.5
-    typescript: 4.9.5
+    typescript: ^4.9.5
     ws: 8.12.1
   languageName: unknown
   linkType: soft
@@ -27936,7 +27936,7 @@ __metadata:
     stringify-object: 5.0.0
     styled-components: ^6.0.8
     ts-jest: 29.0.5
-    typescript: 4.9.5
+    typescript: ^4.9.5
   peerDependencies:
     react: ">=17.0.2"
     react-dom: ">=17.0.2"
@@ -27988,7 +27988,7 @@ __metadata:
     testdouble: ^3.16.8
     trash-cli: ^5.0.0
     ts-jest: ^29.0.5
-    typescript: 4.9.5
+    typescript: ^4.9.5
   peerDependencies:
     mobx: ^3.4.1 || ^4.1.0 || >6.0.0
     mobx-state-tree: ^1.4.0 || ^2.0.2 || >3.0.0
@@ -28031,7 +28031,7 @@ __metadata:
     stacktrace-js: 2.0.1
     trash-cli: 4.0.0
     ts-jest: 29.0.5
-    typescript: 4.9.5
+    typescript: ^4.9.5
   languageName: unknown
   linkType: soft
 
@@ -28072,7 +28072,7 @@ __metadata:
     testdouble: ^3.16.8
     trash-cli: ^5.0.0
     ts-jest: ^29.0.5
-    typescript: 4.9.5
+    typescript: ^4.9.5
   peerDependencies:
     react-native-mmkv: "*"
     reactotron-core-client: "*"
@@ -28122,7 +28122,7 @@ __metadata:
     rollup-plugin-resolve: 0.0.1-predev.1
     trash-cli: ^5.0.0
     ts-jest: 29.0.5
-    typescript: 4.9.5
+    typescript: ^4.9.5
   peerDependencies:
     react-native: ">=0.40.0"
   dependenciesMeta:
@@ -28162,7 +28162,7 @@ __metadata:
     rollup-plugin-resolve: 0.0.1-predev.1
     trash-cli: 5.0.0
     ts-jest: 29.0.5
-    typescript: 4.9.5
+    typescript: ^4.9.5
   peerDependencies:
     reactotron-core-client: "*"
     redux: ">=4.0.0"
@@ -32456,7 +32456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.9.5, typescript@npm:^4.0.2, typescript@npm:^4.9.5":
+"typescript@npm:^4.0.2, typescript@npm:^4.9.5":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
   bin:
@@ -32466,7 +32466,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.9.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.0.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.0.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
   version: 4.9.5
   resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -27261,13 +27261,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-mmkv@npm:^2.8.0":
-  version: 2.8.0
-  resolution: "react-native-mmkv@npm:2.8.0"
+"react-native-mmkv@npm:^2.10.2":
+  version: 2.10.2
+  resolution: "react-native-mmkv@npm:2.10.2"
   peerDependencies:
     react: "*"
     react-native: ">=0.71.0"
-  checksum: 993b486533b00c0b8092ea0b7682428fe704726ec03daf244fbd046bd772e3cfc0aba67b8a9eece31adcb6492c76d838f167eeed877657349a0cae51c8844b8d
+  checksum: ba1759c6898293db9db2ab1b9bb239840f4902d5a8f53672e02eeb23a81e15cb7f6b32d716bc46747868d8c241d3daad6b15af60a5d5cc7716af1d2c1597c17e
   languageName: node
   linkType: hard
 
@@ -27987,7 +27987,6 @@ __metadata:
     "@babel/preset-typescript": ^7.21.0
     "@types/jest": ^29.4.0
     "@types/node": ^11.9.5
-    "@types/ramda": ^0.25.50
     "@typescript-eslint/eslint-plugin": ^5.54.0
     "@typescript-eslint/parser": ^5.54.0
     babel-eslint: ^10.1.0
@@ -28003,8 +28002,7 @@ __metadata:
     eslint-plugin-standard: ^5.0.0
     jest: ^29.4.3
     prettier: ^2.8.4
-    ramda: ^0.25.0
-    react-native-mmkv: ^2.8.0
+    react-native-mmkv: ^2.10.2
     reactotron-core-client: "workspace:*"
     rollup: ^1.1.2
     rollup-plugin-babel: ^4.3.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -8777,13 +8777,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apisauce@npm:^0.16.0":
-  version: 0.16.0
-  resolution: "apisauce@npm:0.16.0"
+"apisauce@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "apisauce@npm:3.0.1"
   dependencies:
-    axios: ^0.18.0
-    ramda: ^0.25.0
-  checksum: 858cfa420174bd55d5da66adca5760bec375fd69e77cf9e95074c7382236a885cbc5566ffffdb7d15b8efd8efeaf6992b1f912db2cd3785d47cecc61e00674d0
+    axios: ^1.4.0
+  checksum: fbf689442b17e1bfcbce9aa105b4ca971ff5b1a264ae30d2ca33df2d074d5ea4a498070fb2be0d14000bb5ff2858351cd67bc20621207b1061cc5fa7113cd6e2
   languageName: node
   linkType: hard
 
@@ -9346,16 +9345,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.18.0":
-  version: 0.18.1
-  resolution: "axios@npm:0.18.1"
-  dependencies:
-    follow-redirects: 1.5.10
-    is-buffer: ^2.0.2
-  checksum: 4a27cea1e3c674d89d9097fe13b62081b692280401b9c4216f37c42dfa8b433091baa15832336523ddad1df2f3f21e1e38a4cff207b4926ead3076c91a8ec5fe
-  languageName: node
-  linkType: hard
-
 "axios@npm:^1.0.0":
   version: 1.3.3
   resolution: "axios@npm:1.3.3"
@@ -9364,6 +9353,17 @@ __metadata:
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
   checksum: b734a4bc348e2fa27150a7d4289d783fa405feb3f79f8daf28fd05813a12c8525ae9d3854aafe7ba041b005a4a751a0ba3b923331ceed41296ae14c7e54e2f26
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.4.0":
+  version: 1.5.1
+  resolution: "axios@npm:1.5.1"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 4444f06601f4ede154183767863d2b8e472b4a6bfc5253597ed6d21899887e1fd0ee2b3de792ac4f8459fe2e359d2aa07c216e45fd8b9e4e0688a6ebf48a5a8d
   languageName: node
   linkType: hard
 
@@ -10331,7 +10331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.1, body-parser@npm:^1.18.3":
+"body-parser@npm:1.20.1":
   version: 1.20.1
   resolution: "body-parser@npm:1.20.1"
   dependencies:
@@ -10348,6 +10348,26 @@ __metadata:
     type-is: ~1.6.18
     unpipe: 1.0.0
   checksum: f1050dbac3bede6a78f0b87947a8d548ce43f91ccc718a50dd774f3c81f2d8b04693e52acf62659fad23101827dd318da1fb1363444ff9a8482b886a3e4a5266
+  languageName: node
+  linkType: hard
+
+"body-parser@npm:^1.19.0":
+  version: 1.20.2
+  resolution: "body-parser@npm:1.20.2"
+  dependencies:
+    bytes: 3.1.2
+    content-type: ~1.0.5
+    debug: 2.6.9
+    depd: 2.0.0
+    destroy: 1.2.0
+    http-errors: 2.0.0
+    iconv-lite: 0.4.24
+    on-finished: 2.4.1
+    qs: 6.11.0
+    raw-body: 2.5.2
+    type-is: ~1.6.18
+    unpipe: 1.0.0
+  checksum: 14d37ec638ab5c93f6099ecaed7f28f890d222c650c69306872e00b9efa081ff6c596cd9afb9930656aae4d6c4e1c17537bea12bb73c87a217cb3cfea8896737
   languageName: node
   linkType: hard
 
@@ -11519,17 +11539,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "cliui@npm:4.1.0"
-  dependencies:
-    string-width: ^2.1.1
-    strip-ansi: ^4.0.0
-    wrap-ansi: ^2.0.0
-  checksum: 0f8a77e55c66ab4400f8cc24a46e496af186ebfbf301709341a24c26d398200c2ccc5cac892566d586c3c393a079974f34f0ce05210df336f97b70805c02865e
-  languageName: node
-  linkType: hard
-
 "cliui@npm:^5.0.0":
   version: 5.0.0
   resolution: "cliui@npm:5.0.0"
@@ -11894,7 +11903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compression@npm:^1.7.1, compression@npm:^1.7.3, compression@npm:^1.7.4":
+"compression@npm:^1.7.1, compression@npm:^1.7.4":
   version: 1.7.4
   resolution: "compression@npm:1.7.4"
   dependencies:
@@ -12055,7 +12064,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:~1.0.4":
+"content-type@npm:~1.0.4, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 566271e0a251642254cde0f845f9dd4f9856e52d988f4eb0d0dcffbb7a1f8ec98de7a5215fc628f3bce30fe2fb6fd2bc064b562d721658c59b544e2d34ea2766
@@ -14228,7 +14237,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"errorhandler@npm:^1.2.0, errorhandler@npm:^1.5.1":
+"errorhandler@npm:^1.5.1":
   version: 1.5.1
   resolution: "errorhandler@npm:1.5.1"
   dependencies:
@@ -15445,7 +15454,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express-urlrewrite@npm:^1.2.0":
+"express-urlrewrite@npm:^1.4.0":
   version: 1.4.0
   resolution: "express-urlrewrite@npm:1.4.0"
   dependencies:
@@ -15455,7 +15464,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.16.4, express@npm:^4.17.0, express@npm:^4.17.1":
+"express@npm:^4.17.0, express@npm:^4.17.1":
   version: 4.18.2
   resolution: "express@npm:4.18.2"
   dependencies:
@@ -16581,13 +16590,6 @@ __metadata:
     read-cmd-shim: ^1.0.1
     slide: ^1.1.6
   checksum: 3858fd6f700889ddffd7bb36923d054853121e5bd4930188142e4ac8ce81434e1b69a6c477fbe4b15a09f974b0f3a8cd75246d1dc75f3b6bdaf6f3d51d3cb26c
-  languageName: node
-  linkType: hard
-
-"get-caller-file@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "get-caller-file@npm:1.0.3"
-  checksum: 2b90a7f848896abcebcdc0acc627a435bcf05b9cd280599bc980ebfcdc222416c3df12c24c4845f69adc4346728e8966f70b758f9369f3534182791dfbc25c05
   languageName: node
   linkType: hard
 
@@ -18315,13 +18317,6 @@ __metadata:
   dependencies:
     loose-envify: ^1.0.0
   checksum: cc3182d793aad82a8d1f0af697b462939cb46066ec48bbf1707c150ad5fad6406137e91a262022c269702e01621f35ef60269f6c0d7fd178487959809acdfb14
-  languageName: node
-  linkType: hard
-
-"invert-kv@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "invert-kv@npm:2.0.0"
-  checksum: 52ea317354101ad6127c6e4c1c6a2d27ae8d3010b6438b60d76d6a920e55410e03547f97f9d1f52031becf5656bbef91d36ee7daa9e26ebc374a9cb342e1f127
   languageName: node
   linkType: hard
 
@@ -21521,35 +21516,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-server@npm:^0.14.2":
-  version: 0.14.2
-  resolution: "json-server@npm:0.14.2"
+"json-server@npm:^0.17.4":
+  version: 0.17.4
+  resolution: "json-server@npm:0.17.4"
   dependencies:
-    body-parser: ^1.18.3
-    chalk: ^2.4.1
-    compression: ^1.7.3
+    body-parser: ^1.19.0
+    chalk: ^4.1.2
+    compression: ^1.7.4
     connect-pause: ^0.1.1
     cors: ^2.8.5
-    errorhandler: ^1.2.0
-    express: ^4.16.4
-    express-urlrewrite: ^1.2.0
+    errorhandler: ^1.5.1
+    express: ^4.17.1
+    express-urlrewrite: ^1.4.0
     json-parse-helpfulerror: ^1.0.3
-    lodash: ^4.17.11
-    lodash-id: ^0.14.0
+    lodash: ^4.17.21
+    lodash-id: ^0.14.1
     lowdb: ^1.0.0
     method-override: ^3.0.0
-    morgan: ^1.9.1
-    nanoid: ^2.0.0
-    object-assign: ^4.0.1
-    please-upgrade-node: ^3.1.1
-    pluralize: ^7.0.0
-    request: ^2.88.0
+    morgan: ^1.10.0
+    nanoid: ^3.1.23
+    please-upgrade-node: ^3.2.0
+    pluralize: ^8.0.0
     server-destroy: ^1.0.1
-    update-notifier: ^2.5.0
-    yargs: ^12.0.2
+    yargs: ^17.0.1
   bin:
-    json-server: ./lib/cli/bin.js
-  checksum: 9ae23b5440e0fadaefde0695df1e93385eb9fd057d3519fcd1755ffc2baf3448d37624c926f89883743669963b41cf8176a36aae2fc2645081f5f6ce6aa13d11
+    json-server: lib/cli/bin.js
+  checksum: 9462010ac0d106c0ed8cc9b5446dad7c3977c9649b6854383a0d81f2259049614cb879808a9bb6cbb3f15f48fee7263eafd26d9a7cd2d2eba61dd9d7bd89dbf4
   languageName: node
   linkType: hard
 
@@ -21773,15 +21765,6 @@ __metadata:
   version: 1.0.5
   resolution: "lazy-val@npm:1.0.5"
   checksum: 31e12e0b118826dfae74f8f3ff8ebcddfe4200ff88d0d448db175c7265ee537e0ba55488d411728246337f3ed3c9ec68416f10889f632a2ce28fb7a970909fb5
-  languageName: node
-  linkType: hard
-
-"lcid@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "lcid@npm:2.0.0"
-  dependencies:
-    invert-kv: ^2.0.0
-  checksum: 278e27b5a0707cf9ab682146963ebff2328795be10cd6f8ea8edae293439325d345ac5e33079cce77ac3a86a3dcfb97a34f279dbc46b03f3e419aa39b5915a16
   languageName: node
   linkType: hard
 
@@ -22117,7 +22100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-id@npm:^0.14.0":
+"lodash-id@npm:^0.14.1":
   version: 0.14.1
   resolution: "lodash-id@npm:0.14.1"
   checksum: de4c96f5c3a0908a897f828dee70472b99861ad8d43a2b00b7fa5724684bf8c9b8e4c47eeb2d1fac63f2f01f0f34344335f0ea4fb6c8a4f02aa63a9a8715db9f
@@ -22621,15 +22604,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"map-age-cleaner@npm:^0.1.1":
-  version: 0.1.3
-  resolution: "map-age-cleaner@npm:0.1.3"
-  dependencies:
-    p-defer: ^1.0.0
-  checksum: cb2804a5bcb3cbdfe4b59066ea6d19f5e7c8c196cd55795ea4c28f792b192e4c442426ae52524e5e1acbccf393d3bddacefc3d41f803e66453f6c4eda3650bc1
-  languageName: node
-  linkType: hard
-
 "map-cache@npm:^0.2.2":
   version: 0.2.2
   resolution: "map-cache@npm:0.2.2"
@@ -22772,17 +22746,6 @@ __metadata:
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
   checksum: af1b38516c28ec95d6b0826f6c8f276c58aec391f76be42aa07646b4e39d317723e869700933ca6995b056db4b09a78c92d5440dc23657e6764be5d28874bba1
-  languageName: node
-  linkType: hard
-
-"mem@npm:^4.0.0":
-  version: 4.3.0
-  resolution: "mem@npm:4.3.0"
-  dependencies:
-    map-age-cleaner: ^0.1.1
-    mimic-fn: ^2.0.0
-    p-is-promise: ^2.0.0
-  checksum: cf488608e5d59c6cb68004b70de317222d4be9f857fd535dfa6a108e04f40821479c080bc763c417b1030569d303538c59d441280078cfce07fefd1c523f98ef
   languageName: node
   linkType: hard
 
@@ -23363,7 +23326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-fn@npm:^2.0.0, mimic-fn@npm:^2.1.0":
+"mimic-fn@npm:^2.1.0":
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
@@ -23753,7 +23716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"morgan@npm:^1.9.1":
+"morgan@npm:^1.10.0":
   version: 1.10.0
   resolution: "morgan@npm:1.10.0"
   dependencies:
@@ -23888,14 +23851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^2.0.0":
-  version: 2.1.11
-  resolution: "nanoid@npm:2.1.11"
-  checksum: 18cd14386816873849787eb4e65667021bfdeb019a8f14c74287c23594c67b7c0e8f42c7d69f6aedf05cd3d100f1ddc41184f9f9b6b17fbaea1c3ee3f0704eec
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.6":
+"nanoid@npm:^3.1.23, nanoid@npm:^3.3.6":
   version: 3.3.6
   resolution: "nanoid@npm:3.3.6"
   bin:
@@ -25204,17 +25160,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-locale@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "os-locale@npm:3.1.0"
-  dependencies:
-    execa: ^1.0.0
-    lcid: ^2.0.0
-    mem: ^4.0.0
-  checksum: 53c542b11af3c5fe99624b09c7882b6944f9ae7c69edbc6006b7d42cff630b1f7fd9d63baf84ed31d1ef02b34823b6b31f23a1ecdd593757873d716bc6374099
-  languageName: node
-  linkType: hard
-
 "os-name@npm:^3.1.0":
   version: 3.1.0
   resolution: "os-name@npm:3.1.0"
@@ -25265,13 +25210,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-defer@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "p-defer@npm:1.0.0"
-  checksum: 4271b935c27987e7b6f229e5de4cdd335d808465604644cb7b4c4c95bef266735859a93b16415af8a41fd663ee9e3b97a1a2023ca9def613dba1bad2a0da0c7b
-  languageName: node
-  linkType: hard
-
 "p-each-series@npm:^2.1.0":
   version: 2.2.0
   resolution: "p-each-series@npm:2.2.0"
@@ -25308,13 +25246,6 @@ __metadata:
   version: 2.0.1
   resolution: "p-finally@npm:2.0.1"
   checksum: 6306a2851c3b28f8b603624f395ae84dce76970498fed8aa6aae2d930595053746edf1e4ee0c4b78a97410d84aa4504d63179f5310d555511ecd226f53ed1e8e
-  languageName: node
-  linkType: hard
-
-"p-is-promise@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "p-is-promise@npm:2.1.0"
-  checksum: c9a8248c8b5e306475a5d55ce7808dbce4d4da2e3d69526e4991a391a7809bfd6cfdadd9bf04f1c96a3db366c93d9a0f5ee81d949e7b1684c4e0f61f747199ef
   languageName: node
   linkType: hard
 
@@ -26002,7 +25933,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"please-upgrade-node@npm:^3.1.1":
+"please-upgrade-node@npm:^3.2.0":
   version: 3.2.0
   resolution: "please-upgrade-node@npm:3.2.0"
   dependencies:
@@ -26032,10 +25963,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pluralize@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "pluralize@npm:7.0.0"
-  checksum: e3f694924b7c8c03dc9fa40b2312e17787998ac6e20fccace11efa1146046eb9931541bfd247b3ec5535e730d902a5aee7c32681d5bf9a00fc74a72039a3e609
+"pluralize@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "pluralize@npm:8.0.0"
+  checksum: 08931d4a6a4a5561a7f94f67a31c17e6632cb21e459ab3ff4f6f629d9a822984cf8afef2311d2005fbea5d7ef26016ebb090db008e2d8bce39d0a9a9d218736e
   languageName: node
   linkType: hard
 
@@ -26859,6 +26790,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"raw-body@npm:2.5.2":
+  version: 2.5.2
+  resolution: "raw-body@npm:2.5.2"
+  dependencies:
+    bytes: 3.1.2
+    http-errors: 2.0.0
+    iconv-lite: 0.4.24
+    unpipe: 1.0.0
+  checksum: ba1583c8d8a48e8fbb7a873fdbb2df66ea4ff83775421bfe21ee120140949ab048200668c47d9ae3880012f6e217052690628cf679ddfbd82c9fc9358d574676
+  languageName: node
+  linkType: hard
+
 "raw-loader@npm:^3.1.0":
   version: 3.1.0
   resolution: "raw-loader@npm:3.1.0"
@@ -27668,7 +27611,7 @@ __metadata:
     "@types/node": ^11.9.5
     "@typescript-eslint/eslint-plugin": ^1.4.1
     "@typescript-eslint/parser": ^1.4.1
-    apisauce: ^0.16.0
+    apisauce: ^3.0.1
     babel-jest: ^29.4.1
     eslint: ^8.34.0
     eslint-config-prettier: ^8.6.0
@@ -27678,7 +27621,7 @@ __metadata:
     eslint-plugin-promise: ^6.1.1
     eslint-plugin-standard: ^5.0.0
     jest: ^29.4.2
-    json-server: ^0.14.2
+    json-server: ^0.17.4
     prettier: ^2.8.4
     rimraf: 4.1.2
     rollup: ^1.2.3
@@ -28784,13 +28727,6 @@ __metadata:
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
   checksum: a03ef6895445f33a4015300c426699bc66b2b044ba7b670aa238610381b56d3f07c686251740d575e22f4c87531ba662d06937508f0f3c0f1ddc04db3130560b
-  languageName: node
-  linkType: hard
-
-"require-main-filename@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "require-main-filename@npm:1.0.1"
-  checksum: 1fef30754da961f4e13c450c3eb60c7ae898a529c6ad6fa708a70bd2eed01564ceb299187b2899f5562804d797a059f39a5789884d0ac7b7ae1defc68fba4abf
   languageName: node
   linkType: hard
 
@@ -33752,16 +33688,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "wrap-ansi@npm:2.1.0"
-  dependencies:
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-  checksum: 2dacd4b3636f7a53ee13d4d0fe7fa2ed9ad81e9967e17231924ea88a286ec4619a78288de8d41881ee483f4449ab2c0287cde8154ba1bd0126c10271101b2ee3
-  languageName: node
-  linkType: hard
-
 "wrap-ansi@npm:^5.1.0":
   version: 5.1.0
   resolution: "wrap-ansi@npm:5.1.0"
@@ -33951,7 +33877,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"y18n@npm:^3.2.1 || ^4.0.0, y18n@npm:^4.0.0":
+"y18n@npm:^4.0.0":
   version: 4.0.3
   resolution: "y18n@npm:4.0.3"
   checksum: 014dfcd9b5f4105c3bb397c1c8c6429a9df004aa560964fb36732bfb999bfe83d45ae40aeda5b55d21b1ee53d8291580a32a756a443e064317953f08025b1aa4
@@ -34014,16 +33940,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^11.1.1":
-  version: 11.1.1
-  resolution: "yargs-parser@npm:11.1.1"
-  dependencies:
-    camelcase: ^5.0.0
-    decamelize: ^1.2.0
-  checksum: 91a82f4e6295745269f5683d1ab11d636f1d2fa732fb1c1795ad4637f31feb54530c2072ca2c2e39d3c4d506c3645214ff08c781f4a5b48fc959788706a54f83
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^13.1.2":
   version: 13.1.2
   resolution: "yargs-parser@npm:13.1.2"
@@ -34058,26 +33974,6 @@ __metadata:
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
   checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^12.0.2":
-  version: 12.0.5
-  resolution: "yargs@npm:12.0.5"
-  dependencies:
-    cliui: ^4.0.0
-    decamelize: ^1.2.0
-    find-up: ^3.0.0
-    get-caller-file: ^1.0.1
-    os-locale: ^3.0.0
-    require-directory: ^2.1.1
-    require-main-filename: ^1.0.1
-    set-blocking: ^2.0.0
-    string-width: ^2.0.0
-    which-module: ^2.0.0
-    y18n: ^3.2.1 || ^4.0.0
-    yargs-parser: ^11.1.1
-  checksum: 716f467be3f4dd5ed346f7e07eabfbf4b915e818bf2e6582b27c8d23f17c6ee59126b1c6896234d0ca1f615ee09d1901602677c5ee294540e87f914cd27a3c9b
   languageName: node
   linkType: hard
 
@@ -34149,6 +34045,21 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^20.2.2
   checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.0.1":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
+  dependencies:
+    cliui: ^8.0.1
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.1.1
+  checksum: 73b572e863aa4a8cbef323dd911d79d193b772defd5a51aab0aca2d446655216f5002c42c5306033968193bdbf892a7a4c110b0d77954a7fdf563e653967b56a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR 

* Aligns all the typescript versions in `package.json` files
* Upgrades the `apisauce` and `json-server` deps in the `reactotron-apisauce` package
* Removes the unused `ramda` dep in the `reactotron-react-native-mmkv` package and updates the `react-native-mmkv` dep to the latest version.