### PR TITLE
fix(content-view): parse stringified object

### DIFF
--- a/lib/reactotron-core-ui/src/components/ContentView/index.tsx
+++ b/lib/reactotron-core-ui/src/components/ContentView/index.tsx
@@ -27,7 +27,14 @@ export default function ContentView({ value, treeLevel }: Props) {
   if (value === null) return <NullContainer>null</NullContainer>
   if (value === undefined) return <UndefinedContainer>undefined</UndefinedContainer>
 
-  if (typeof value === "string") {
+  let checkValue
+  try {
+    checkValue = JSON.parse(value)
+  } catch {
+    checkValue = value
+  }
+
+  if (typeof checkValue === "string") {
     return (
       <StringContainer>
         {value
@@ -43,9 +50,13 @@ export default function ContentView({ value, treeLevel }: Props) {
     )
   }
 
-  if (typeof value === "object") {
-    return isShallow(value) ? makeTable(value) : <TreeView value={value} level={treeLevel} />
+  if (typeof checkValue === "object") {
+    return isShallow(checkValue) ? (
+      makeTable(checkValue)
+    ) : (
+      <TreeView value={checkValue} level={treeLevel} />
+    )
   }
 
-  return <StringContainer>{String(value)}</StringContainer>
+  return <StringContainer>{String(checkValue)}</StringContainer>
 }

--- a/lib/reactotron-core-ui/src/timelineCommands/ApiResponseCommand/ApiResponseCommand.story.tsx
+++ b/lib/reactotron-core-ui/src/timelineCommands/ApiResponseCommand/ApiResponseCommand.story.tsx
@@ -14,9 +14,9 @@ const apiResponseCommand = {
     request: {
       url: "https://www.google.com/",
       method: "GET",
-      data: null,
+      data: '{"operationName":"LaunchList","variables":{"testing":{"nested":"thing"}},"query":"query LaunchList {\\n  launches {\\n    id\\n    mission_name\\n    launch_date_unix\\n    launch_success\\n    upcoming\\n    __typename\\n  }\\n}\\n"}',
       headers: {},
-      params: null,
+      params: { data: { test: 1 } },
     },
     response: {
       body: " skipped ",
@@ -95,5 +95,25 @@ export const OpenRequestHeaders = () => (
     isOpen
     setIsOpen={() => {}}
     initialTab={Tab.RequestHeaders}
+  />
+)
+
+export const OpenRequestParams = () => (
+  <ApiResponseCommand
+    command={apiResponseCommand}
+    copyToClipboard={() => {}}
+    isOpen
+    setIsOpen={() => {}}
+    initialTab={Tab.RequestParams}
+  />
+)
+
+export const OpenRequestBody = () => (
+  <ApiResponseCommand
+    command={apiResponseCommand}
+    copyToClipboard={() => {}}
+    isOpen
+    setIsOpen={() => {}}
+    initialTab={Tab.RequestBody}
   />
 )


### PR DESCRIPTION
## Why
- Closes #1317

Currently, if a request/response body comes back as a stringified JSON object (which at the very least, Apollo Client is doing for request bodies), the `TimelineCommand` displays it as a string.

However, there are times where that string is a stringified object and we could do better to give it the tree view we are used to in Reactotron.

## How

Check if the incoming value prop can be handled with `JSON.parse`, if so then display it as an object. Otherwise let all the other string and fallback formatters happen.

## Images

### Before

![image](https://github.com/infinitered/reactotron/assets/374022/5f92092b-2101-42da-87d4-1c22d9c93b5a)


### After

![image](https://github.com/infinitered/reactotron/assets/374022/366433bb-bd56-4a0a-a52b-75df1711fcf9)
