### PR TITLE
fix(display-cmd): correct preview text

### DIFF
--- a/lib/reactotron-core-ui/src/timelineCommands/DisplayCommand/index.tsx
+++ b/lib/reactotron-core-ui/src/timelineCommands/DisplayCommand/index.tsx
@@ -68,7 +68,7 @@ const DisplayCommand: FunctionComponent<Props> = ({
       date={date}
       deltaTime={deltaTime}
       title={payload.name || "DISPLAY"}
-      preview={payload.name}
+      preview={payload.preview}
       toolbar={toolbar}
       isImportant={important}
       isTagged


### PR DESCRIPTION
Fixes the Display command showing the `title` prop in the `preview` portion of the Display command in the Timeline