### PR TITLE
feat(reactotron): Add Android `adb` command interface to the Help page.

### DIFF
--- a/apps/reactotron-app/src/main/index.ts
+++ b/apps/reactotron-app/src/main/index.ts
@@ -6,6 +6,7 @@ import { autoUpdater } from "electron-updater"
 import windowStateKeeper from "electron-window-state"
 
 import createMenu from "./menu"
+import { setupAndroidDeviceIPCCommands } from "./utils"
 
 const isDevelopment = process.env.NODE_ENV !== "production"
 
@@ -32,8 +33,8 @@ function createMainWindow() {
     width: mainWindowState.width,
     height: mainWindowState.height,
     titleBarStyle: "hiddenInset",
-    webPreferences: { 
-      nodeIntegration: true, 
+    webPreferences: {
+      nodeIntegration: true,
       contextIsolation: false,
       webgl: false, // Disable webGL for performance reasons
       spellcheck: false, // Disable spellcheck for performance reasons
@@ -47,7 +48,7 @@ function createMainWindow() {
 
     if (isDevelopment) {
       window.webContents.openDevTools()
-    }  
+    }
   })
 
   window.setBackgroundColor("#1e1e1e") // see reactotron-core-ui for background color
@@ -97,4 +98,7 @@ app.on("activate", () => {
 // create main BrowserWindow when electron is ready
 app.on("ready", () => {
   mainWindow = createMainWindow()
+
+  // Sets up the electron IPC commands for android functionality on the Help screen.
+  setupAndroidDeviceIPCCommands(mainWindow)
 })

--- a/apps/reactotron-app/src/main/utils.ts
+++ b/apps/reactotron-app/src/main/utils.ts
@@ -32,8 +32,7 @@ export const setupAndroidDeviceIPCCommands = (mainWindow: BrowserWindow) => {
       }
     )
     reactotronReverseProcess.stdout.setEncoding("utf8")
-    reactotronReverseProcess.stdout.on("data", (data) => {
-      data = data.toString()
+    reactotronReverseProcess.stdout.on("data", () => {
       console.log(`Reverse Tunneling To Reactotron Port ${reactotronPort} Complete.`)
     })
 
@@ -46,8 +45,7 @@ export const setupAndroidDeviceIPCCommands = (mainWindow: BrowserWindow) => {
       }
     )
     metroReverseProcess.stdout.setEncoding("utf8")
-    metroReverseProcess.stdout.on("data", (data) => {
-      data = data.toString()
+    metroReverseProcess.stdout.on("data", () => {
       console.log(`Reverse Tunneling To Metro Port ${metroPort} Complete.`)
     })
   })
@@ -99,18 +97,16 @@ export const setupAndroidDeviceIPCCommands = (mainWindow: BrowserWindow) => {
   })
   trackDevicesProcess.stdout.setEncoding("utf8")
   trackDevicesProcess.stdout.on("data", (data) => {
-    // Here is the output
     data = data.toString()
     console.log("Got adb track-devices output: ", data)
     ipcMain.emit("get-device-list")
   })
   trackDevicesProcess.stderr.setEncoding("utf8")
   trackDevicesProcess.stderr.on("data", (data) => {
-    // Here is the error output from the command
     console.log(data)
   })
   trackDevicesProcess.on("close", (code) => {
-    //Here you can get the exit code of the script
+    // Warn the user if the process closes.
     switch (code) {
       case 0:
         dialog.showMessageBox({

--- a/apps/reactotron-app/src/main/utils.ts
+++ b/apps/reactotron-app/src/main/utils.ts
@@ -1,0 +1,124 @@
+import childProcess from "child_process"
+import { type BrowserWindow, dialog, ipcMain } from "electron"
+
+// This function sets up numerous IPC commands for communicating with android devices.
+// It also watches for android devices being plugged in and unplugged.
+//
+export const setupAndroidDeviceIPCCommands = (mainWindow: BrowserWindow) => {
+  // Allows the main renderer to communicate with the main process and get a list of connected android devices.
+  ipcMain.on("get-device-list", () => {
+    console.log("Getting Android device list")
+    const devicesProcess = childProcess.spawn("adb", ["devices"], {
+      shell: true,
+    })
+    devicesProcess.stdout.setEncoding("utf8")
+    devicesProcess.stdout.on("data", (data) => {
+      data = data.toString()
+      console.log("Got asb device list", data)
+      mainWindow.webContents.send("device-list", data)
+    })
+  })
+
+  // Creates a reverse tunnel to an android device for reactotron and metro.
+  ipcMain.on("reverse-tunnel-device", (_event, deviceId, reactotronPort, metroPort) => {
+    console.log("Reverse Tunneling Android device", deviceId, reactotronPort, metroPort)
+
+    // First do the reverse tunnel for reactotron:
+    const reactotronReverseProcess = childProcess.spawn(
+      "adb",
+      ["-s", deviceId, "reverse", `tcp:${reactotronPort}`, `tcp:${reactotronPort}`],
+      {
+        shell: true,
+      }
+    )
+    reactotronReverseProcess.stdout.setEncoding("utf8")
+    reactotronReverseProcess.stdout.on("data", (data) => {
+      data = data.toString()
+      console.log(`Reverse Tunneling To Reactotron Port ${reactotronPort} Complete.`)
+    })
+
+    // Now do the reverse tunnel for react native:
+    const metroReverseProcess = childProcess.spawn(
+      "adb",
+      ["-s", deviceId, "reverse", `tcp:${metroPort}`, `tcp:${metroPort}`],
+      {
+        shell: true,
+      }
+    )
+    metroReverseProcess.stdout.setEncoding("utf8")
+    metroReverseProcess.stdout.on("data", (data) => {
+      data = data.toString()
+      console.log(`Reverse Tunneling To Metro Port ${metroPort} Complete.`)
+    })
+  })
+
+  // Reloads the app on the android device
+  ipcMain.on("reload-app", (_event, arg) => {
+    console.log("Reloading App on device", arg)
+    const reloadAppProcess = childProcess.spawn(
+      "adb",
+      ["-s", arg, "shell", "input", "text", '"RR"'],
+      {
+        shell: true,
+      }
+    )
+    reloadAppProcess.stdout.setEncoding("utf8")
+    reloadAppProcess.stdout.on("data", (data) => {
+      data = data.toString()
+      console.log("Reloading App Complete", data)
+    })
+  })
+
+  // Reloads the app on the android device
+  ipcMain.on("shake-device", (_event, arg) => {
+    console.log("Showing react-native debug menu", arg)
+    const shakeDeviceProcess = childProcess.spawn(
+      "adb",
+      ["-s", arg, "shell", "input", "keyevent", "82"],
+      {
+        shell: true,
+      }
+    )
+    shakeDeviceProcess.stdout.setEncoding("utf8")
+    shakeDeviceProcess.stdout.on("data", (data) => {
+      data = data.toString()
+      console.log("Shaking Device Complete", data)
+    })
+  })
+
+  // Now we need to start watching for android devices being plugged and unplugged
+  const trackDevicesProcess = childProcess.spawn("adb", ["track-devices"], {
+    shell: true,
+  })
+  trackDevicesProcess.on("error", (error) => {
+    dialog.showMessageBox({
+      title: "Android communication problem",
+      type: "warning",
+      message: "Error occurred running adb track-devices.\n" + error,
+    })
+  })
+  trackDevicesProcess.stdout.setEncoding("utf8")
+  trackDevicesProcess.stdout.on("data", (data) => {
+    // Here is the output
+    data = data.toString()
+    console.log("Got adb track-devices output: ", data)
+    ipcMain.emit("get-device-list")
+  })
+  trackDevicesProcess.stderr.setEncoding("utf8")
+  trackDevicesProcess.stderr.on("data", (data) => {
+    // Here is the error output from the command
+    console.log(data)
+  })
+  trackDevicesProcess.on("close", (code) => {
+    //Here you can get the exit code of the script
+    switch (code) {
+      case 0:
+        dialog.showMessageBox({
+          title: "Closing adb track-devices",
+          type: "info",
+          message: "End process.\r\n",
+        })
+        break
+    }
+  })
+}

--- a/apps/reactotron-app/src/renderer/pages/help/SharedStyles.ts
+++ b/apps/reactotron-app/src/renderer/pages/help/SharedStyles.ts
@@ -1,0 +1,20 @@
+import styled from "styled-components"
+
+export const ItemContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 10px;
+  margin: 5px;
+  flex: 1;
+  background-color: ${(props) => props.theme.chrome};
+  border-radius: 5px;
+  border: 1px solid ${(props) => props.theme.chromeLine};
+`
+export const ItemIconContainer = styled.div`
+  color: ${(props) => props.theme.foregroundLight};
+  margin-bottom: 8px;
+`
+

--- a/apps/reactotron-app/src/renderer/pages/help/components/AndroidDeviceHelp.tsx
+++ b/apps/reactotron-app/src/renderer/pages/help/components/AndroidDeviceHelp.tsx
@@ -113,19 +113,6 @@ function AndroidDeviceHelp() {
 
     ipcRenderer.send("get-device-list")
 
-    var msg = {
-      title: "Awesome!",
-      message:
-        "Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>",
-      detail:
-        "PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>",
-      width: 440,
-      // height : 160, window will be autosized
-      timeout: 6000,
-      focus: true, // set focus back to main window
-    }
-    ipcRenderer.send("electron-toaster-message", msg)
-
     return () => {
       ipcRenderer.removeAllListeners("device-list")
     }
@@ -155,8 +142,9 @@ function AndroidDeviceHelp() {
         <HighlightedText>adb devices</HighlightedText> command.
       </Text>
       <Text>
-        Android devices can sometimes be tricky to connect to reactotron. Many issues can be
-        resolved by clicking "Reverse Tunnel" and then "Reload App".
+        Android devices can sometimes be tricky to connect to Reactotron. Many issues can be
+        resolved by clicking <HighlightedText>Reverse Tunnel</HighlightedText> and then{" "}
+        <HighlightedText>Reload App</HighlightedText>.
       </Text>
       <AndroidDeviceListContainer>
         {portsVisible && (

--- a/apps/reactotron-app/src/renderer/pages/help/components/AndroidDeviceHelp.tsx
+++ b/apps/reactotron-app/src/renderer/pages/help/components/AndroidDeviceHelp.tsx
@@ -1,0 +1,259 @@
+import React from "react"
+import { ipcRenderer } from "electron"
+import styled from "styled-components"
+import { GoGear as SettingsIcon } from "react-icons/go"
+import { MdCompareArrows as ReverseTunnelIcon } from "react-icons/md"
+import { CgSmartphoneShake as ShakeDeviceIcon } from "react-icons/cg"
+import { IoReloadOutline as ReloadAppIcon } from "react-icons/io5"
+import ReactTooltip from "react-tooltip"
+import { EmptyState } from "reactotron-core-ui"
+import { FaAndroid } from "react-icons/fa"
+import { ItemContainer, ItemIconContainer } from "../SharedStyles"
+
+const Title = styled.div`
+  font-size: 18px;
+  margin: 10px 0;
+  padding-bottom: 2px;
+  color: ${(props) => props.theme.foregroundLight};
+  border-bottom: 1px solid ${(props) => props.theme.highlight};
+`
+const AndroidDeviceListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  margin-top: 10px;
+  color: ${(props) => props.theme.foreground};
+`
+
+const AndroidDeviceButtonsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 0px;
+`
+const Text = styled.div`
+  margin-right: 4px;
+  color: ${(props) => props.theme.foregroundDark};
+`
+const DeviceID = styled.div`
+  font-size: 16px;
+  margin-top: 15px;
+  margin-bottom: 0px;
+  color: ${(props) => props.theme.tag};
+`
+const HighlightedText = styled.div`
+  display: inline-block;
+  border-radius: 5px;
+  border: 1px solid ${(props) => props.theme.highlight};
+  padding: 2px;
+  color: ${(props) => props.theme.tag};
+  background-color: ${(props) => props.theme.line};
+`
+const PortSettingsTitle = styled.div`
+  font-size: 18px;
+  margin: 10px 0;
+  padding-bottom: 2px;
+  color: ${(props) => props.theme.foregroundLight};
+  border-bottom: 1px solid ${(props) => props.theme.highlight};
+`
+const PortSettingsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 10px;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid ${(props) => props.theme.chromeLine};
+  background-color: ${(props) => props.theme.chrome};
+`
+const PortArgsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-top: 10px;
+`
+const ArgContainer = styled.div`
+  &:not(:last-child) {
+    margin-right: 12px;
+  }
+`
+const ArgName = styled.div`
+  margin-bottom: 8px;
+`
+const ArgInput = styled.input`
+  padding: 10px 12px;
+  outline: none;
+  border-radius: 4px;
+  width: 100px;
+  border: none;
+  font-size: 16px;
+`
+const PortSettingsIconContainer = styled.div`
+  float: right;
+  color: ${(props) => props.theme.foregroundLight};
+  margin-left: 10px;
+`
+
+function AndroidDeviceHelp() {
+  const [androidDevices, setAndroidDevices] = React.useState([])
+  const [portsVisible, setPortsVisible] = React.useState(false)
+  const [reactotronPort, setReactotronPort] = React.useState("9090")
+  const [metroPort, setMetroPort] = React.useState("8081")
+
+  // When the page loads, get the list of devices from ADB to help users debug android issues.
+  React.useEffect(() => {
+    ipcRenderer.on("device-list", (_event, arg) => {
+      arg = arg.replace(/(\r\n|\n|\r)/gm, "\n").trim() // Fix newlines
+      const rawDevices = arg.split("\n")
+      rawDevices.shift() // Remove the first line
+      const devices = rawDevices.map((device) => {
+        const [id, state] = device.split("\t")
+        return { id, state }
+      })
+      setAndroidDevices(devices)
+    })
+
+    ipcRenderer.send("get-device-list")
+
+    var msg = {
+      title: "Awesome!",
+      message:
+        "Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>",
+      detail:
+        "PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>",
+      width: 440,
+      // height : 160, window will be autosized
+      timeout: 6000,
+      focus: true, // set focus back to main window
+    }
+    ipcRenderer.send("electron-toaster-message", msg)
+
+    return () => {
+      ipcRenderer.removeAllListeners("device-list")
+    }
+  }, [])
+
+  const TitleComponent = React.useCallback(() => {
+    return (
+      <Title>
+        {androidDevices.length} Android Device{androidDevices.length !== 1 ? "s" : ""} Connected via
+        USB:
+      </Title>
+    )
+  }, [androidDevices.length])
+
+  return (
+    <>
+      <TitleComponent />
+      <PortSettingsIconContainer
+        data-tip="Advanced Port Settings"
+        onClick={() => setPortsVisible(!portsVisible)}
+      >
+        <SettingsIcon size={20} />
+        <ReactTooltip multiline place="bottom" />
+      </PortSettingsIconContainer>
+      <Text>
+        This shows all android devices connected to your machine via the{" "}
+        <HighlightedText>adb devices</HighlightedText> command.
+      </Text>
+      <Text>
+        Android devices can sometimes be tricky to connect to reactotron. Many issues can be
+        resolved by clicking "Reverse Tunnel" and then "Reload App".
+      </Text>
+      <AndroidDeviceListContainer>
+        {portsVisible && (
+          <PortSettingsContainer>
+            <PortSettingsTitle>Advanced Reverse Tunneling Settings:</PortSettingsTitle>
+            <Text>
+              Adjust these values to the ports you are using for Reactotron and Metro. Most users
+              will not need to change these values.
+            </Text>
+            <PortArgsContainer>
+              <ArgContainer key="reactotron-port">
+                <ArgName>Reactotron Port:</ArgName>
+                <ArgInput
+                  type="text"
+                  placeholder={reactotronPort}
+                  value={reactotronPort}
+                  onChange={(e) => setReactotronPort(e.target.value)}
+                />
+              </ArgContainer>
+              <ArgContainer key="metro-port">
+                <ArgName>Metro Port:</ArgName>
+                <ArgInput
+                  type="text"
+                  placeholder={metroPort}
+                  value={metroPort}
+                  onChange={(e) => setMetroPort(e.target.value)}
+                />
+              </ArgContainer>
+            </PortArgsContainer>
+          </PortSettingsContainer>
+        )}
+        {androidDevices.length === 0 ? (
+          <EmptyState icon={FaAndroid}>No Android devices connected via USB.</EmptyState>
+        ) : (
+          <AndroidDeviceList
+            devices={androidDevices}
+            reactotronPort={reactotronPort}
+            metroPort={metroPort}
+          />
+        )}
+      </AndroidDeviceListContainer>
+    </>
+  )
+}
+
+const AndroidDeviceList = ({
+  devices,
+  reactotronPort,
+  metroPort,
+}: {
+  devices: any[]
+  reactotronPort: string
+  metroPort: string
+}) => {
+  return (
+    <>
+      {devices.map((device) => (
+        <div key={device.id}>
+          <DeviceID>{device.id}</DeviceID>
+          <AndroidDeviceButtonsContainer>
+            <ItemContainer
+              onClick={() =>
+                ipcRenderer.send("reverse-tunnel-device", device.id, reactotronPort, metroPort)
+              }
+              data-tip={`This will allow reactotron to connect to your device via USB<br />by running adb reverse tcp:${reactotronPort} tcp:${reactotronPort}<br /><br />Reload your React Native app after pressing this.`}
+            >
+              <ItemIconContainer>
+                <ReverseTunnelIcon size={40} />
+              </ItemIconContainer>
+              Reverse Tunnel
+              <ReactTooltip multiline place="bottom" />
+            </ItemContainer>
+            <ItemContainer
+              onClick={() => ipcRenderer.send("reload-app", device.id)}
+              data-tip="This will reload the React Native app currently running on this device.<br />If you get the React Native red screen, relaunch the app from the build process."
+            >
+              <ItemIconContainer>
+                <ReloadAppIcon size={40} />
+              </ItemIconContainer>
+              Reload App
+              <ReactTooltip multiline place="bottom" />
+            </ItemContainer>
+            <ItemContainer
+              onClick={() => ipcRenderer.send("shake-device", device.id)}
+              data-tip="This will shake the device to bring up<br /> the React Native developer menu."
+            >
+              <ItemIconContainer>
+                <ShakeDeviceIcon size={40} />
+              </ItemIconContainer>
+              Shake
+              <ReactTooltip multiline place="bottom" />
+            </ItemContainer>
+          </AndroidDeviceButtonsContainer>
+        </div>
+      ))}
+    </>
+  )
+}
+
+export default AndroidDeviceHelp

--- a/apps/reactotron-app/src/renderer/pages/help/components/AndroidDeviceHelp.tsx
+++ b/apps/reactotron-app/src/renderer/pages/help/components/AndroidDeviceHelp.tsx
@@ -5,8 +5,7 @@ import { GoGear as SettingsIcon } from "react-icons/go"
 import { MdCompareArrows as ReverseTunnelIcon } from "react-icons/md"
 import { CgSmartphoneShake as ShakeDeviceIcon } from "react-icons/cg"
 import { IoReloadOutline as ReloadAppIcon } from "react-icons/io5"
-import ReactTooltip from "react-tooltip"
-import { EmptyState } from "reactotron-core-ui"
+import { EmptyState, Tooltip } from "reactotron-core-ui"
 import { FaAndroid } from "react-icons/fa"
 import { ItemContainer, ItemIconContainer } from "../SharedStyles"
 
@@ -132,10 +131,11 @@ function AndroidDeviceHelp() {
       <TitleComponent />
       <PortSettingsIconContainer
         data-tip="Advanced Port Settings"
+        data-for="port-settings"
         onClick={() => setPortsVisible(!portsVisible)}
       >
         <SettingsIcon size={20} />
-        <ReactTooltip multiline place="bottom" />
+        <Tooltip id="port-settings" />
       </PortSettingsIconContainer>
       <Text>
         This shows all android devices connected to your machine via the{" "}
@@ -210,32 +210,35 @@ const AndroidDeviceList = ({
                 ipcRenderer.send("reverse-tunnel-device", device.id, reactotronPort, metroPort)
               }
               data-tip={`This will allow reactotron to connect to your device via USB<br />by running adb reverse tcp:${reactotronPort} tcp:${reactotronPort}<br /><br />Reload your React Native app after pressing this.`}
+              data-for="reverse-tunnel"
             >
               <ItemIconContainer>
                 <ReverseTunnelIcon size={40} />
               </ItemIconContainer>
               Reverse Tunnel
-              <ReactTooltip multiline place="bottom" />
+              <Tooltip id="reverse-tunnel" multiline />
             </ItemContainer>
             <ItemContainer
               onClick={() => ipcRenderer.send("reload-app", device.id)}
               data-tip="This will reload the React Native app currently running on this device.<br />If you get the React Native red screen, relaunch the app from the build process."
+              data-for="reload-app"
             >
               <ItemIconContainer>
                 <ReloadAppIcon size={40} />
               </ItemIconContainer>
               Reload App
-              <ReactTooltip multiline place="bottom" />
+              <Tooltip id="reload-app" multiline />
             </ItemContainer>
             <ItemContainer
               onClick={() => ipcRenderer.send("shake-device", device.id)}
               data-tip="This will shake the device to bring up<br /> the React Native developer menu."
+              data-for="shake-device"
             >
               <ItemIconContainer>
                 <ShakeDeviceIcon size={40} />
               </ItemIconContainer>
               Shake
-              <ReactTooltip multiline place="bottom" />
+              <Tooltip id="shake-device" multiline />
             </ItemContainer>
           </AndroidDeviceButtonsContainer>
         </div>

--- a/apps/reactotron-app/src/renderer/pages/help/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/help/index.tsx
@@ -1,15 +1,19 @@
 import React from "react"
-import { shell } from "electron"
+import { ipcRenderer, shell } from "electron"
 import { Header } from "reactotron-core-ui"
 import styled from "styled-components"
 import {
   GoRepo as RepoIcon,
   GoComment as FeedbackIcon,
   GoSquirrel as ReleaseIcon,
+  GoGear as SettingsIcon,
 } from "react-icons/go"
 import { FaTwitter as TwitterIcon } from "react-icons/fa"
+import { MdCompareArrows as ReverseTunnelIcon } from "react-icons/md"
+import { CgSmartphoneShake as ShakeDeviceIcon } from "react-icons/cg"
+import { IoReloadOutline as ReloadAppIcon } from "react-icons/io5"
 import { getApplicationKeyMap } from "react-hotkeys"
-
+import ReactTooltip from "react-tooltip"
 import KeybindGroup from "./components/KeybindGroup"
 import { reactotronLogo } from "../../images"
 
@@ -51,7 +55,7 @@ const ConnectContainer = styled.div`
   color: ${(props) => props.theme.foreground};
   margin-bottom: 50px;
 `
-const ConnectItemContainer = styled.div`
+const ItemContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -60,14 +64,87 @@ const ConnectItemContainer = styled.div`
   padding: 10px;
   margin: 5px;
   flex: 1;
-  /* width: 90px; */
   background-color: ${(props) => props.theme.chrome};
   border-radius: 5px;
   border: 1px solid ${(props) => props.theme.chromeLine};
 `
-const ConnectItemIconContainer = styled.div`
+const ItemIconContainer = styled.div`
   color: ${(props) => props.theme.foregroundLight};
   margin-bottom: 8px;
+`
+const AndroidDeviceListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  margin-top: 10px;
+  color: ${(props) => props.theme.foreground};
+`
+
+const AndroidDeviceButtonsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 0px;
+`
+const Text = styled.div`
+  margin-right: 4px;
+  color: ${(props) => props.theme.foregroundDark};
+`
+const DeviceID = styled.div`
+  font-size: 16px;
+  margin-top: 15px;
+  margin-bottom: 0px;
+  color: ${(props) => props.theme.tag};
+`
+const HighlightedText = styled.div`
+  display: inline-block;
+  border-radius: 5px;
+  border: 1px solid ${(props) => props.theme.highlight};
+  padding: 2px;
+  color: ${(props) => props.theme.tag};
+  background-color: ${(props) => props.theme.line};
+`
+const PortSettingsTitle = styled.div`
+  font-size: 18px;
+  margin: 10px 0;
+  padding-bottom: 2px;
+  color: ${(props) => props.theme.foregroundLight};
+  border-bottom: 1px solid ${(props) => props.theme.highlight};
+`
+const PortSettingsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 10px;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid ${(props) => props.theme.chromeLine};
+  background-color: ${(props) => props.theme.chrome};
+`
+const PortArgsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-top: 10px;
+`
+const ArgContainer = styled.div`
+  &:not(:last-child) {
+    margin-right: 12px;
+  }
+`
+const ArgName = styled.div`
+  margin-bottom: 8px;
+`
+const ArgInput = styled.input`
+  padding: 10px 12px;
+  outline: none;
+  border-radius: 4px;
+  width: 100px;
+  border: none;
+  font-size: 16px;
+`
+const PortSettingsIconContainer = styled.div`
+  float: right;
+  color: ${(props) => props.theme.foregroundLight};
+  margin-left: 10px;
 `
 
 function openRepo() {
@@ -108,6 +185,44 @@ function Keybinds() {
 }
 
 function Help() {
+  const [androidDevices, setAndroidDevices] = React.useState([])
+  const [portsVisible, setPortsVisible] = React.useState(false)
+  const [reactotronPort, setReactotronPort] = React.useState(9090)
+  const [metroPort, setMetroPort] = React.useState(8081)
+
+  // When the page loads, get the list of devices from ADB to help users debug android issues.
+  React.useEffect(() => {
+    ipcRenderer.on("device-list", (_event, arg) => {
+      arg = arg.replace(/(\r\n|\n|\r)/gm, "\n").trim() // Fix newlines
+      const rawDevices = arg.split("\n")
+      rawDevices.shift() // Remove the first line
+      const devices = rawDevices.map((device) => {
+        const [id, state] = device.split("\t")
+        return { id, state }
+      })
+      setAndroidDevices(devices)
+    })
+
+    ipcRenderer.send("get-device-list")
+
+    var msg = {
+      title: "Awesome!",
+      message:
+        "Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>",
+      detail:
+        "PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>",
+      width: 440,
+      // height : 160, window will be autosized
+      timeout: 6000,
+      focus: true, // set focus back to main window
+    }
+    ipcRenderer.send("electron-toaster-message", msg)
+
+    return () => {
+      ipcRenderer.removeAllListeners("device-list")
+    }
+  }, [])
+
   return (
     <Container>
       <Header title={`Using Reactotron ${projectJson.version}`} isDraggable />
@@ -117,31 +232,118 @@ function Help() {
         </LogoContainer>
         <Title>Let&apos;s Connect!</Title>
         <ConnectContainer>
-          <ConnectItemContainer onClick={openRepo}>
-            <ConnectItemIconContainer>
+          <ItemContainer onClick={openRepo}>
+            <ItemIconContainer>
               <RepoIcon size={40} />
-            </ConnectItemIconContainer>
+            </ItemIconContainer>
             Repo
-          </ConnectItemContainer>
-          <ConnectItemContainer onClick={openFeedback}>
-            <ConnectItemIconContainer>
+          </ItemContainer>
+          <ItemContainer onClick={openFeedback}>
+            <ItemIconContainer>
               <FeedbackIcon size={40} />
-            </ConnectItemIconContainer>
+            </ItemIconContainer>
             Feedback
-          </ConnectItemContainer>
-          <ConnectItemContainer onClick={openUpdates}>
-            <ConnectItemIconContainer>
+          </ItemContainer>
+          <ItemContainer onClick={openUpdates}>
+            <ItemIconContainer>
               <ReleaseIcon size={40} />
-            </ConnectItemIconContainer>
+            </ItemIconContainer>
             Updates
-          </ConnectItemContainer>
-          <ConnectItemContainer onClick={openTwitter}>
-            <ConnectItemIconContainer>
+          </ItemContainer>
+          <ItemContainer onClick={openTwitter}>
+            <ItemIconContainer>
               <TwitterIcon size={40} />
-            </ConnectItemIconContainer>
+            </ItemIconContainer>
             @reactotron
-          </ConnectItemContainer>
+          </ItemContainer>
         </ConnectContainer>
+
+        <Title>{androidDevices.length} Android Devices Connected via USB:</Title>
+        <PortSettingsIconContainer
+          data-tip="Advanced Port Settings"
+          onClick={() => setPortsVisible(!portsVisible)}
+        >
+          <SettingsIcon size={20} />
+          <ReactTooltip multiline place="bottom" />
+        </PortSettingsIconContainer>
+        <Text>
+          This shows all android devices connected to your machine via the{" "}
+          <HighlightedText>adb devices</HighlightedText> command.
+        </Text>
+        <Text>
+          Android devices can sometimes be tricky to connect to reactotron. Many issues can be
+          resolved by clicking "Reverse Tunnel" and then "Reload App".
+        </Text>
+        <AndroidDeviceListContainer>
+          {portsVisible && (
+            <PortSettingsContainer>
+              <PortSettingsTitle>Advanced Reverse Tunneling Settings:</PortSettingsTitle>
+              <Text>
+                Adjust these values to the ports you are using for Reactotron and Metro. Most users
+                will not need to change these values.
+              </Text>
+              <PortArgsContainer>
+                <ArgContainer key="reactotron-port">
+                  <ArgName>Reactotron Port:</ArgName>
+                  <ArgInput
+                    type="text"
+                    placeholder={reactotronPort}
+                    value={reactotronPort}
+                    onChange={(e) => setReactotronPort(e.target.value)}
+                  />
+                </ArgContainer>
+                <ArgContainer key="metro-port">
+                  <ArgName>Metro Port:</ArgName>
+                  <ArgInput
+                    type="text"
+                    placeholder={metroPort}
+                    value={metroPort}
+                    onChange={(e) => setMetroPort(e.target.value)}
+                  />
+                </ArgContainer>
+              </PortArgsContainer>
+            </PortSettingsContainer>
+          )}
+          {androidDevices.map((device) => (
+            <div key={device.id}>
+              <DeviceID>{device.id}</DeviceID>
+              <AndroidDeviceButtonsContainer>
+                <ItemContainer
+                  onClick={() =>
+                    ipcRenderer.send("reverse-tunnel-device", device.id, reactotronPort, metroPort)
+                  }
+                  data-tip={`This will allow reactotron to connect to your device via USB<br />by running adb reverse tcp:${reactotronPort} tcp:${reactotronPort}<br /><br />Reload your React Native app after pressing this.`}
+                >
+                  <ItemIconContainer>
+                    <ReverseTunnelIcon size={40} />
+                  </ItemIconContainer>
+                  Reverse Tunnel
+                  <ReactTooltip multiline place="bottom" />
+                </ItemContainer>
+                <ItemContainer
+                  onClick={() => ipcRenderer.send("reload-app", device.id)}
+                  data-tip="This will reload the React Native app currently running on this device.<br />If you get the React Native red screen, relaunch the app from the build process."
+                >
+                  <ItemIconContainer>
+                    <ReloadAppIcon size={40} />
+                  </ItemIconContainer>
+                  Reload App
+                  <ReactTooltip multiline place="bottom" />
+                </ItemContainer>
+                <ItemContainer
+                  onClick={() => ipcRenderer.send("shake-device", device.id)}
+                  data-tip="This will shake the device to bring up<br /> the React Native developer menu."
+                >
+                  <ItemIconContainer>
+                    <ShakeDeviceIcon size={40} />
+                  </ItemIconContainer>
+                  Shake
+                  <ReactTooltip multiline place="bottom" />
+                </ItemContainer>
+              </AndroidDeviceButtonsContainer>
+            </div>
+          ))}
+        </AndroidDeviceListContainer>
         <Title>Keystrokes</Title>
         {Keybinds()}
       </HelpContainer>

--- a/apps/reactotron-app/src/renderer/pages/help/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/help/index.tsx
@@ -1,20 +1,17 @@
 import React from "react"
-import { ipcRenderer, shell } from "electron"
+import { shell } from "electron"
 import { Header } from "reactotron-core-ui"
 import styled from "styled-components"
 import {
   GoRepo as RepoIcon,
   GoComment as FeedbackIcon,
   GoSquirrel as ReleaseIcon,
-  GoGear as SettingsIcon,
 } from "react-icons/go"
 import { FaTwitter as TwitterIcon } from "react-icons/fa"
-import { MdCompareArrows as ReverseTunnelIcon } from "react-icons/md"
-import { CgSmartphoneShake as ShakeDeviceIcon } from "react-icons/cg"
-import { IoReloadOutline as ReloadAppIcon } from "react-icons/io5"
 import { getApplicationKeyMap } from "react-hotkeys"
-import ReactTooltip from "react-tooltip"
+import { ItemContainer, ItemIconContainer } from "./SharedStyles"
 import KeybindGroup from "./components/KeybindGroup"
+import AndroidDeviceHelp from "./components/AndroidDeviceHelp"
 import { reactotronLogo } from "../../images"
 
 const projectJson = require("../../../../package.json")
@@ -24,23 +21,19 @@ const Container = styled.div`
   flex-direction: column;
   width: 100%;
 `
-
 const HelpContainer = styled.div`
   padding: 20px;
   overflow-y: auto;
   overflow-x: hidden;
 `
-
 const LogoContainer = styled.div`
   display: flex;
   justify-content: center;
 `
-
 const LogoImage = styled.img`
   height: 128px;
   margin: 20px 0;
 `
-
 const Title = styled.div`
   font-size: 18px;
   margin: 10px 0;
@@ -48,103 +41,11 @@ const Title = styled.div`
   color: ${(props) => props.theme.foregroundLight};
   border-bottom: 1px solid ${(props) => props.theme.highlight};
 `
-
 const ConnectContainer = styled.div`
   display: flex;
   align-items: flex-start;
   color: ${(props) => props.theme.foreground};
   margin-bottom: 50px;
-`
-const ItemContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  padding: 10px;
-  margin: 5px;
-  flex: 1;
-  background-color: ${(props) => props.theme.chrome};
-  border-radius: 5px;
-  border: 1px solid ${(props) => props.theme.chromeLine};
-`
-const ItemIconContainer = styled.div`
-  color: ${(props) => props.theme.foregroundLight};
-  margin-bottom: 8px;
-`
-const AndroidDeviceListContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  margin-top: 10px;
-  color: ${(props) => props.theme.foreground};
-`
-
-const AndroidDeviceButtonsContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  margin-top: 0px;
-`
-const Text = styled.div`
-  margin-right: 4px;
-  color: ${(props) => props.theme.foregroundDark};
-`
-const DeviceID = styled.div`
-  font-size: 16px;
-  margin-top: 15px;
-  margin-bottom: 0px;
-  color: ${(props) => props.theme.tag};
-`
-const HighlightedText = styled.div`
-  display: inline-block;
-  border-radius: 5px;
-  border: 1px solid ${(props) => props.theme.highlight};
-  padding: 2px;
-  color: ${(props) => props.theme.tag};
-  background-color: ${(props) => props.theme.line};
-`
-const PortSettingsTitle = styled.div`
-  font-size: 18px;
-  margin: 10px 0;
-  padding-bottom: 2px;
-  color: ${(props) => props.theme.foregroundLight};
-  border-bottom: 1px solid ${(props) => props.theme.highlight};
-`
-const PortSettingsContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 10px;
-  padding: 10px;
-  border-radius: 5px;
-  border: 1px solid ${(props) => props.theme.chromeLine};
-  background-color: ${(props) => props.theme.chrome};
-`
-const PortArgsContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  margin-top: 10px;
-`
-const ArgContainer = styled.div`
-  &:not(:last-child) {
-    margin-right: 12px;
-  }
-`
-const ArgName = styled.div`
-  margin-bottom: 8px;
-`
-const ArgInput = styled.input`
-  padding: 10px 12px;
-  outline: none;
-  border-radius: 4px;
-  width: 100px;
-  border: none;
-  font-size: 16px;
-`
-const PortSettingsIconContainer = styled.div`
-  float: right;
-  color: ${(props) => props.theme.foregroundLight};
-  margin-left: 10px;
 `
 
 function openRepo() {
@@ -185,44 +86,6 @@ function Keybinds() {
 }
 
 function Help() {
-  const [androidDevices, setAndroidDevices] = React.useState([])
-  const [portsVisible, setPortsVisible] = React.useState(false)
-  const [reactotronPort, setReactotronPort] = React.useState(9090)
-  const [metroPort, setMetroPort] = React.useState(8081)
-
-  // When the page loads, get the list of devices from ADB to help users debug android issues.
-  React.useEffect(() => {
-    ipcRenderer.on("device-list", (_event, arg) => {
-      arg = arg.replace(/(\r\n|\n|\r)/gm, "\n").trim() // Fix newlines
-      const rawDevices = arg.split("\n")
-      rawDevices.shift() // Remove the first line
-      const devices = rawDevices.map((device) => {
-        const [id, state] = device.split("\t")
-        return { id, state }
-      })
-      setAndroidDevices(devices)
-    })
-
-    ipcRenderer.send("get-device-list")
-
-    var msg = {
-      title: "Awesome!",
-      message:
-        "Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>Check this out!<br>",
-      detail:
-        "PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>PI is equal to 3! - 0.0<br>",
-      width: 440,
-      // height : 160, window will be autosized
-      timeout: 6000,
-      focus: true, // set focus back to main window
-    }
-    ipcRenderer.send("electron-toaster-message", msg)
-
-    return () => {
-      ipcRenderer.removeAllListeners("device-list")
-    }
-  }, [])
-
   return (
     <Container>
       <Header title={`Using Reactotron ${projectJson.version}`} isDraggable />
@@ -258,92 +121,8 @@ function Help() {
           </ItemContainer>
         </ConnectContainer>
 
-        <Title>{androidDevices.length} Android Devices Connected via USB:</Title>
-        <PortSettingsIconContainer
-          data-tip="Advanced Port Settings"
-          onClick={() => setPortsVisible(!portsVisible)}
-        >
-          <SettingsIcon size={20} />
-          <ReactTooltip multiline place="bottom" />
-        </PortSettingsIconContainer>
-        <Text>
-          This shows all android devices connected to your machine via the{" "}
-          <HighlightedText>adb devices</HighlightedText> command.
-        </Text>
-        <Text>
-          Android devices can sometimes be tricky to connect to reactotron. Many issues can be
-          resolved by clicking "Reverse Tunnel" and then "Reload App".
-        </Text>
-        <AndroidDeviceListContainer>
-          {portsVisible && (
-            <PortSettingsContainer>
-              <PortSettingsTitle>Advanced Reverse Tunneling Settings:</PortSettingsTitle>
-              <Text>
-                Adjust these values to the ports you are using for Reactotron and Metro. Most users
-                will not need to change these values.
-              </Text>
-              <PortArgsContainer>
-                <ArgContainer key="reactotron-port">
-                  <ArgName>Reactotron Port:</ArgName>
-                  <ArgInput
-                    type="text"
-                    placeholder={reactotronPort}
-                    value={reactotronPort}
-                    onChange={(e) => setReactotronPort(e.target.value)}
-                  />
-                </ArgContainer>
-                <ArgContainer key="metro-port">
-                  <ArgName>Metro Port:</ArgName>
-                  <ArgInput
-                    type="text"
-                    placeholder={metroPort}
-                    value={metroPort}
-                    onChange={(e) => setMetroPort(e.target.value)}
-                  />
-                </ArgContainer>
-              </PortArgsContainer>
-            </PortSettingsContainer>
-          )}
-          {androidDevices.map((device) => (
-            <div key={device.id}>
-              <DeviceID>{device.id}</DeviceID>
-              <AndroidDeviceButtonsContainer>
-                <ItemContainer
-                  onClick={() =>
-                    ipcRenderer.send("reverse-tunnel-device", device.id, reactotronPort, metroPort)
-                  }
-                  data-tip={`This will allow reactotron to connect to your device via USB<br />by running adb reverse tcp:${reactotronPort} tcp:${reactotronPort}<br /><br />Reload your React Native app after pressing this.`}
-                >
-                  <ItemIconContainer>
-                    <ReverseTunnelIcon size={40} />
-                  </ItemIconContainer>
-                  Reverse Tunnel
-                  <ReactTooltip multiline place="bottom" />
-                </ItemContainer>
-                <ItemContainer
-                  onClick={() => ipcRenderer.send("reload-app", device.id)}
-                  data-tip="This will reload the React Native app currently running on this device.<br />If you get the React Native red screen, relaunch the app from the build process."
-                >
-                  <ItemIconContainer>
-                    <ReloadAppIcon size={40} />
-                  </ItemIconContainer>
-                  Reload App
-                  <ReactTooltip multiline place="bottom" />
-                </ItemContainer>
-                <ItemContainer
-                  onClick={() => ipcRenderer.send("shake-device", device.id)}
-                  data-tip="This will shake the device to bring up<br /> the React Native developer menu."
-                >
-                  <ItemIconContainer>
-                    <ShakeDeviceIcon size={40} />
-                  </ItemIconContainer>
-                  Shake
-                  <ReactTooltip multiline place="bottom" />
-                </ItemContainer>
-              </AndroidDeviceButtonsContainer>
-            </div>
-          ))}
-        </AndroidDeviceListContainer>
+        <AndroidDeviceHelp />
+
         <Title>Keystrokes</Title>
         {Keybinds()}
       </HelpContainer>

--- a/lib/reactotron-core-ui/src/components/ActionButton/index.tsx
+++ b/lib/reactotron-core-ui/src/components/ActionButton/index.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import ReactTooltip from "react-tooltip"
 import styled from "styled-components"
+import Tooltip from "../Tooltip"
+import { type TooltipProps } from "react-tooltip"
 
 const Container = styled.div`
   cursor: pointer;
@@ -10,15 +11,16 @@ const Container = styled.div`
 
 interface Props {
   tip: string
+  tipProps?: TooltipProps
   icon: any
   onClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 }
 
-function ActionButton({ icon: Icon, tip, onClick }: Props) {
+function ActionButton({ icon: Icon, tip, tipProps = {}, onClick }: Props) {
   return (
     <Container data-tip={tip} onClick={onClick}>
       <Icon size={24} />
-      <ReactTooltip place="bottom" />
+      <Tooltip {...tipProps} />
     </Container>
   )
 }

--- a/lib/reactotron-core-ui/src/components/EmptyState/index.tsx
+++ b/lib/reactotron-core-ui/src/components/EmptyState/index.tsx
@@ -33,7 +33,7 @@ const Image = styled.img`
 interface Props {
   icon?: any // TODO: Type Better?
   image?: any
-  title: string
+  title?: string
 }
 
 const EmptyState: FunctionComponent<React.PropsWithChildren<Props>> = ({
@@ -46,7 +46,7 @@ const EmptyState: FunctionComponent<React.PropsWithChildren<Props>> = ({
     <Container>
       {Icon && <Icon size={100} />}
       {image && <Image src={image} />}
-      <Title>{title}</Title>
+      {title && <Title>{title}</Title>}
       <Message>{children}</Message>
     </Container>
   )

--- a/lib/reactotron-core-ui/src/components/Header/index.tsx
+++ b/lib/reactotron-core-ui/src/components/Header/index.tsx
@@ -95,7 +95,15 @@ const Header: FunctionComponent<React.PropsWithChildren<HeaderComponentProps>> =
         <RightContainer>
           {actions &&
             actions.map((a, idx) => (
-              <ActionButton tip={a.tip} icon={a.icon} onClick={a.onClick} key={idx} />
+              <ActionButton
+                tip={a.tip}
+                tipProps={{
+                  effect: "float",
+                }}
+                icon={a.icon}
+                onClick={a.onClick}
+                key={idx}
+              />
             ))}
         </RightContainer>
       </ContentContainer>

--- a/lib/reactotron-core-ui/src/components/Tooltip/index.tsx
+++ b/lib/reactotron-core-ui/src/components/Tooltip/index.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import ReactTooltip, { type TooltipProps } from "react-tooltip"
+import { useTheme } from "styled-components"
+
+// This component provides some sane defaults for react-tooltip.
+// Use this component instead of react-tooltip directly.
+// By default, the tooltip will be placed at the bottom of the target element
+// and will have a solid border with the theme's highlight color.
+// You can override any of these props by passing them to this component.
+function ToolTip(props: TooltipProps) {
+  const theme = useTheme()
+  return (
+    <ReactTooltip
+      place="bottom"
+      effect="solid"
+      border
+      borderColor={theme.highlight}
+      textColor={theme.foreground}
+      {...props}
+    />
+  )
+}
+
+export default ToolTip

--- a/lib/reactotron-core-ui/src/index.ts
+++ b/lib/reactotron-core-ui/src/index.ts
@@ -8,6 +8,7 @@ import Header from "./components/Header"
 import Modal from "./components/Modal"
 import ReactotronAppProvider from "./components/ReactotronAppProvider"
 import ActionButton from "./components/ActionButton"
+import Tooltip from "./components/Tooltip"
 import TimelineCommand from "./components/TimelineCommand"
 import TimelineCommandTabButton from "./components/TimelineCommandTabButton"
 import Timestamp from "./components/Timestamp"
@@ -41,6 +42,7 @@ export {
   Modal,
   ReactotronAppProvider,
   ActionButton,
+  Tooltip,
   TimelineCommand,
   timelineCommandResolver,
   TimelineCommandTabButton,


### PR DESCRIPTION
Sometimes connecting to physical android devices can trip up people new to reactotron or react native development.

This PR adds a section to the Help page where users can see which android devices that are connected to their computer via USB and automatically run common functions on each device including:

1. `adb reverse tcp:9090 tcp:9090` for reactotron connections on android devices
2. `adb reverse tcp:8081 tcp:8081` for metro connections on android devices
3. `adb shell input text '"RR"` to reload an active react native application
4. `adb shell input keyevent 82` to shake the device and display the react native developer menu. This is particularly useful for simulator instances

...all with a simple to use interface on the Help page. This works with multiple connected devices and will only run on the selected device. 

There's also a hidden "port settings" for the tcp reverse command that you can access via the "gear" settings icon where power users can change the port that reactotron and metro are running on.

### To Do:

- [x] Test that this works on Windows instances
- [ ] Fail gracefully if `adb` isn't set up correctly
- [ ] Possible: feedback to the user that something actually happened when they click "Reverse Tunnel"
- [ ] Determine a better place for this, maybe? Should this go on the Help page?

### How It works:

When the app boots up, it defines the actions that can be taken with `adb` as well as spawns a process for `adb track-devices` so that we can be notified whenever an android device is connected or disconnected from USB.

When the Help screen loads, it fires off a command to get the list of connected devices and parses the result from the command's `stdout`. If the `adb track-devices` process determines that a device has been connected or disconnected, it requests the list of devices again.

Overall, this works REALLY well!

### Here's the functionality in action:

> I am physically plugging and unplugging my android device:

![667EE0DF-9FE5-41F4-BA0A-21C23C4F2091-9010-000064220203A491](https://github.com/infinitered/reactotron/assets/139261/76d0eedb-97b6-4a90-b783-3fd1340cfe30)

Here's what the interface looks like with multiple android devices connected:

![Screenshot 2023-11-01 at 5 41 10 PM](https://github.com/infinitered/reactotron/assets/139261/618abd58-cadc-4ea3-ba75-127a44bc8d4b)

Here's the input fields where power users can change the reactotron and metro ports:

![Screenshot 2023-11-01 at 5 46 20 PM](https://github.com/infinitered/reactotron/assets/139261/41fbb707-e5ae-47cb-a017-36c7f880fa11)

