### PR TITLE
Update Redux-Toolkit Docs for Integration

### DIFF
--- a/docs/plugin-redux.md
+++ b/docs/plugin-redux.md
@@ -49,7 +49,19 @@ ReactotronConfig, you'll need to add `reactotron-redux` as plugin
   
 + export default reactotron
 ```
+## Using Redux-toolkit
+Then, add enhancer from `Reactotron.createEnhancer()` to `enhancers` in `configureStore`
 
+```diff
+import {configureStore} from '@reduxjs/toolkit';
++ import Reactotron from './ReactotronConfig'
+const store = configureStore({
+   ... (reducers, middlewares etc),
+  enhancers: __DEV__ ? [Reactotron.createEnhancer!()] : [],
+});
+```
+
+## Using Classic Redux
 Then, add enhancer from `Reactotron.createEnhancer()` to `createStore` as last parameter
 
 ```diff
@@ -63,7 +75,7 @@ import { createStore } from 'redux'
 
 Note: passing enhancer as last argument requires redux@>=3.1.0
 
-## If you have middleware
+### If you have middleware
 
 ```diff
 import { createStore } from 'redux'

--- a/docs/plugin-redux.md
+++ b/docs/plugin-redux.md
@@ -57,7 +57,7 @@ import {configureStore} from '@reduxjs/toolkit';
 + import Reactotron from './ReactotronConfig'
 const store = configureStore({
    ... (reducers, middlewares etc),
- + enhancers: __DEV__ ? [Reactotron.createEnhancer!()] : [],
++  enhancers: __DEV__ ? [Reactotron.createEnhancer!()] : [],
 });
 ```
 

--- a/docs/plugin-redux.md
+++ b/docs/plugin-redux.md
@@ -49,8 +49,9 @@ ReactotronConfig, you'll need to add `reactotron-redux` as plugin
   
 + export default reactotron
 ```
-## Using Redux-toolkit
-Then, add enhancer from `Reactotron.createEnhancer()` to `enhancers` in `configureStore`
+## Using Redux Toolkit (RTK)
+
+If you're using RTK, add the enhancer from `Reactotron.createEnhancer()` to `enhancers` in `configureStore`
 
 ```diff
 import {configureStore} from '@reduxjs/toolkit';
@@ -59,10 +60,6 @@ const store = configureStore({
    ... (reducers, middlewares etc),
 +  enhancers: __DEV__ ? [Reactotron.createEnhancer!()] : [],
 });
-```
-
-## Using Classic Redux
-Then, add enhancer from `Reactotron.createEnhancer()` to `createStore` as last parameter
 
 ```diff
 import { createStore } from 'redux'

--- a/docs/plugin-redux.md
+++ b/docs/plugin-redux.md
@@ -57,7 +57,7 @@ import {configureStore} from '@reduxjs/toolkit';
 + import Reactotron from './ReactotronConfig'
 const store = configureStore({
    ... (reducers, middlewares etc),
-  enhancers: __DEV__ ? [Reactotron.createEnhancer!()] : [],
+ + enhancers: __DEV__ ? [Reactotron.createEnhancer!()] : [],
 });
 ```
 


### PR DESCRIPTION
Update documentation to clarify integration with redux-toolkit: enhancers should now be passed to enhancers in configureStore instead of middlewares in createStore for improved compatibility.