### PR TITLE
feat: validate workspace package.json, add export condition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,9 @@ jobs:
           name: Build
           command: yarn build
       - run:
+          name: Package Validation
+          command: yarn package:validate
+      - run:
           name: Lint
           command: yarn lint
       - run:

--- a/apps/reactotron-app/src/renderer/ReactotronBrain.tsx
+++ b/apps/reactotron-app/src/renderer/ReactotronBrain.tsx
@@ -1,6 +1,6 @@
 // TODO: Name this better...
 import React, { FunctionComponent, PropsWithChildren } from "react"
-import { Command } from "reactotron-core-contract"
+import type { Command } from "reactotron-core-contract"
 import {
   ReactotronProvider,
   CustomCommandsProvider,

--- a/apps/reactotron-app/src/renderer/pages/customCommands/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/customCommands/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext, useReducer } from "react"
-import { Header, EmptyState, CustomCommandsContext, CustomCommand } from "reactotron-core-ui"
+import { Header, EmptyState, CustomCommandsContext } from "reactotron-core-ui"
+import type { CustomCommand } from "reactotron-core-ui"
 import styled from "styled-components"
 import { MdSearch } from "react-icons/md"
 import { FaMagic } from "react-icons/fa"

--- a/apps/reactotron-app/src/renderer/pages/state/Snapshots.tsx
+++ b/apps/reactotron-app/src/renderer/pages/state/Snapshots.tsx
@@ -3,10 +3,10 @@ import {
   ContentView,
   SnapshotRenameModal,
   StateContext,
-  Snapshot,
   Header,
   EmptyState,
 } from "reactotron-core-ui"
+import type { Snapshot } from "reactotron-core-ui"
 import { clipboard } from "electron"
 import styled from "styled-components"
 import {

--- a/lib/reactotron-apisauce/package.json
+++ b/lib/reactotron-apisauce/package.json
@@ -7,15 +7,22 @@
   "bugs": {
     "url": "https://github.com/infinitered/reactotron/issues"
   },
-  "homepage": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-apisauce",
-  "repository": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-apisauce",
+  "homepage": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-apisauce",
+  "repository": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-apisauce",
   "files": [
     "dist",
-    "LICENSE",
-    "README.md"
+    "src"
   ],
   "main": "dist/index.js",
-  "typings": "dist/types/src/index.d.ts",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "default": "./dist/index.js",
+    "import": "./dist/index.esm.js",
+    "types": "./dist/types/src/index.d.ts",
+    "react-native": "./src/index.ts"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-apisauce/rollup.config.js
+++ b/lib/reactotron-apisauce/rollup.config.js
@@ -6,12 +6,19 @@ import minify from "rollup-plugin-babel-minify"
 
 const coreClientVersion = require("./package.json").version
 
+/** @type {import('rollup').RollupOptions} */
 export default {
   input: "src/index.ts",
-  output: {
-    file: "dist/index.js",
-    format: "cjs",
-  },
+  output: [
+    {
+      file: "dist/index.js",
+      format: "cjs",
+    },
+    {
+      file: "dist/index.esm.js",
+      format: "esm",
+    },
+  ],
   plugins: [
     resolve({ extensions: [".ts"] }),
     replace({

--- a/lib/reactotron-core-client/package.json
+++ b/lib/reactotron-core-client/package.json
@@ -7,15 +7,22 @@
   "bugs": {
     "url": "https://github.com/infinitered/reactotron/issues"
   },
-  "homepage": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-core-client",
-  "repository": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-core-client",
+  "homepage": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-core-client",
+  "repository": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-core-client",
   "files": [
     "dist",
-    "LICENSE",
-    "README.md"
+    "src"
   ],
   "main": "dist/index.js",
-  "typings": "dist/types/src/reactotron-core-client.d.ts",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "default": "./dist/index.js",
+    "import": "./dist/index.esm.js",
+    "react-native": "./src/index.ts",
+    "types": "./dist/types/src/index.d.ts"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-core-client/rollup.config.js
+++ b/lib/reactotron-core-client/rollup.config.js
@@ -6,12 +6,19 @@ import minify from "rollup-plugin-babel-minify"
 
 const coreClientVersion = require("./package.json").version
 
+/** @type {import('rollup').RollupOptions} */
 export default {
   input: "src/reactotron-core-client.ts",
-  output: {
-    file: "dist/index.js",
-    format: "cjs",
-  },
+  output: [
+    {
+      file: "dist/index.js",
+      format: "cjs",
+    },
+    {
+      file: "dist/index.esm.js",
+      format: "esm",
+    },
+  ],
   plugins: [
     resolve({ extensions: [".ts"] }),
     replace({

--- a/lib/reactotron-core-client/src/index.ts
+++ b/lib/reactotron-core-client/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./reactotron-core-client"

--- a/lib/reactotron-core-client/src/reactotron-core-client.ts
+++ b/lib/reactotron-core-client/src/reactotron-core-client.ts
@@ -1,5 +1,5 @@
 import WebSocket from "ws"
-import { Command, CommandTypeKey } from "reactotron-core-contract"
+import type { Command, CommandTypeKey } from "reactotron-core-contract"
 import validate from "./validate"
 import logger from "./plugins/logger"
 import image from "./plugins/image"

--- a/lib/reactotron-core-contract/package.json
+++ b/lib/reactotron-core-contract/package.json
@@ -11,11 +11,18 @@
   "repository": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-core-contract",
   "files": [
     "dist",
-    "LICENSE",
-    "README.md"
+    "src"
   ],
   "main": "dist/index.js",
-  "typings": "dist/types/src/reactotron-core-contract.d.ts",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "default": "./dist/index.js",
+    "import": "./dist/index.esm.js",
+    "types": "./dist/types/src/index.d.ts",
+    "react-native": "./src/index.ts"
+  },
   "scripts": {
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-core-contract/rollup.config.js
+++ b/lib/reactotron-core-contract/rollup.config.js
@@ -8,10 +8,16 @@ const coreClientVersion = require("./package.json").version
 
 export default {
   input: "src/reactotron-core-contract.ts",
-  output: {
-    file: "dist/index.js",
-    format: "cjs",
-  },
+  output: [
+    {
+      file: "dist/index.js",
+      format: "cjs",
+    },
+    {
+      file: "dist/index.esm.js",
+      format: "esm",
+    },
+  ],
   plugins: [
     resolve({ extensions: [".ts"] }),
     replace({

--- a/lib/reactotron-core-contract/src/index.ts
+++ b/lib/reactotron-core-contract/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./reactotron-core-contract"

--- a/lib/reactotron-core-server/package.json
+++ b/lib/reactotron-core-server/package.json
@@ -7,15 +7,22 @@
   "bugs": {
     "url": "https://github.com/infinitered/reactotron/issues"
   },
-  "homepage": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-core-server",
-  "repository": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-core-server",
+  "homepage": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-core-server",
+  "repository": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-core-server",
   "files": [
     "dist",
-    "LICENSE",
-    "README.md"
+    "src"
   ],
   "main": "dist/index.js",
-  "typings": "dist/types/src/reactotron-core-server.d.ts",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "default": "./dist/index.js",
+    "import": "./dist/index.esm.js",
+    "types": "./dist/types/src/index.d.ts",
+    "react-native": "./src/index.ts"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-core-server/rollup.config.js
+++ b/lib/reactotron-core-server/rollup.config.js
@@ -5,10 +5,16 @@ import minify from "rollup-plugin-babel-minify"
 
 export default {
   input: "src/reactotron-core-server.ts",
-  output: {
-    file: "dist/index.js",
-    format: "cjs",
-  },
+  output: [
+    {
+      file: "dist/index.js",
+      format: "cjs",
+    },
+    {
+      file: "dist/index.esm.js",
+      format: "esm",
+    },
+  ],
   plugins: [
     resolve({ extensions: [".ts", ".tsx"] }),
     babel({ extensions: [".ts", ".tsx"], runtimeHelpers: true }),

--- a/lib/reactotron-core-server/src/index.ts
+++ b/lib/reactotron-core-server/src/index.ts
@@ -1,0 +1,3 @@
+import Server from "./reactotron-core-server"
+export { createServer } from "./reactotron-core-server"
+export default Server

--- a/lib/reactotron-core-server/src/reactotron-core-server.ts
+++ b/lib/reactotron-core-server/src/reactotron-core-server.ts
@@ -1,6 +1,6 @@
 import { merge, find, propEq, without, contains, forEach, pluck, reject, equals } from "ramda"
 import { createServer as createHttpsServer, ServerOptions as HttpsServerOptions } from "https"
-import {
+import type {
   ServerEventMap,
   ServerOptions,
   PartialConnection,

--- a/lib/reactotron-core-server/src/validation.ts
+++ b/lib/reactotron-core-server/src/validation.ts
@@ -1,5 +1,5 @@
 import { allPass, complement, isNil, is } from "ramda"
-import { ServerOptions } from "reactotron-core-contract"
+import type { ServerOptions } from "reactotron-core-contract"
 
 /**
  * Is this a valid port?

--- a/lib/reactotron-core-ui/package.json
+++ b/lib/reactotron-core-ui/package.json
@@ -7,10 +7,18 @@
   "bugs": {
     "url": "https://github.com/infinitered/reactotron/issues"
   },
-  "homepage": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-core-ui",
-  "repository": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-core-ui",
+  "homepage": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-core-ui",
+  "repository": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-core-ui",
   "main": "dist/index.js",
-  "typings": "dist/types/index.d.ts",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "default": "./dist/index.js",
+    "import": "./dist/index.esm.js",
+    "types": "./dist/types/src/index.d.ts",
+    "react-native": "./src/index.ts"
+  },
   "scripts": {
     "start": "start-storybook -p 6006",
     "prebuild": "yarn clean",
@@ -32,7 +40,8 @@
     "format:write": "yarn format --write"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/lib/reactotron-core-ui/rollup.config.js
+++ b/lib/reactotron-core-ui/rollup.config.js
@@ -6,10 +6,16 @@ import external from "rollup-plugin-peer-deps-external"
 
 export default {
   input: "src/index.ts",
-  output: {
-    file: "dist/index.js",
-    format: "cjs",
-  },
+  output: [
+    {
+      file: "dist/index.js",
+      format: "cjs",
+    },
+    {
+      file: "dist/index.esm.js",
+      format: "esm",
+    },
+  ],
   plugins: [
     resolve({ extensions: [".ts", ".tsx"] }),
     external({ includeDependencies: true }),

--- a/lib/reactotron-core-ui/src/contexts/CustomCommands/useCustomCommands.ts
+++ b/lib/reactotron-core-ui/src/contexts/CustomCommands/useCustomCommands.ts
@@ -1,7 +1,8 @@
 import { useReducer, useContext, useEffect } from "react"
 import { produce } from "immer"
 
-import { Command, CommandType } from "reactotron-core-contract"
+import type { Command } from "reactotron-core-contract"
+import { CommandType } from "reactotron-core-contract"
 import ReactotronContext from "../Reactotron"
 
 export interface CustomCommand {

--- a/lib/reactotron-core-ui/src/contexts/Reactotron/index.tsx
+++ b/lib/reactotron-core-ui/src/contexts/Reactotron/index.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react"
 
-import { Command } from "reactotron-core-contract"
+import type { Command } from "reactotron-core-contract"
 
 import useReactotron from "./useReactotron"
 

--- a/lib/reactotron-core-ui/src/contexts/State/useSnapshots.ts
+++ b/lib/reactotron-core-ui/src/contexts/State/useSnapshots.ts
@@ -2,7 +2,8 @@ import { useContext, useEffect, useReducer, useCallback } from "react"
 import { format } from "date-fns"
 import { produce } from "immer"
 
-import { Command, CommandType } from "reactotron-core-contract"
+import { CommandType } from "reactotron-core-contract"
+import type { Command } from "reactotron-core-contract"
 import ReactotronContext from "../Reactotron"
 
 export interface Snapshot {

--- a/lib/reactotron-core-ui/src/contexts/Timeline/index.tsx
+++ b/lib/reactotron-core-ui/src/contexts/Timeline/index.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react"
 
-import { CommandTypeKey } from "reactotron-core-contract"
+import type { CommandTypeKey } from "reactotron-core-contract"
 
 import useTimeline from "./useTimeline"
 

--- a/lib/reactotron-core-ui/src/contexts/Timeline/useTimeline.ts
+++ b/lib/reactotron-core-ui/src/contexts/Timeline/useTimeline.ts
@@ -1,6 +1,6 @@
 import { useReducer, useEffect } from "react"
 
-import { CommandTypeKey } from "reactotron-core-contract"
+import type { CommandTypeKey } from "reactotron-core-contract"
 
 export enum StorageKey {
   ReversedOrder = "ReactotronTimelineReversedOrder",

--- a/lib/reactotron-core-ui/src/modals/TimelineFilterModal/index.tsx
+++ b/lib/reactotron-core-ui/src/modals/TimelineFilterModal/index.tsx
@@ -3,7 +3,8 @@ import styled from "styled-components"
 
 import Modal from "../../components/Modal"
 import Checkbox from "../../components/Checkbox"
-import { CommandType, CommandTypeKey } from "reactotron-core-contract"
+import type { CommandTypeKey } from "reactotron-core-contract"
+import { CommandType } from "reactotron-core-contract"
 
 const GROUPS = [
   {

--- a/lib/reactotron-core-ui/src/timelineCommands/LogCommand/index.tsx
+++ b/lib/reactotron-core-ui/src/timelineCommands/LogCommand/index.tsx
@@ -6,7 +6,8 @@ import stringifyObject from "stringify-object"
 import TimelineCommand from "../../components/TimelineCommand"
 import ContentView from "../../components/ContentView"
 import { TimelineCommandProps, buildTimelineCommand } from "../BaseCommand"
-import { ErrorStackFrame, LogPayload, isErrorStackFrameArray } from "reactotron-core-contract"
+import { isErrorStackFrameArray } from "reactotron-core-contract"
+import type { ErrorStackFrame, LogPayload } from "reactotron-core-contract"
 
 const SOURCE_LINES_UP = 3
 const SOURCE_LINES_DOWN = 3

--- a/lib/reactotron-core-ui/src/timelineCommands/index.ts
+++ b/lib/reactotron-core-ui/src/timelineCommands/index.ts
@@ -1,6 +1,7 @@
 import { FunctionComponent } from "react"
 
-import { CommandType, CommandTypeKey } from "reactotron-core-contract"
+import { CommandType } from "reactotron-core-contract"
+import type { CommandTypeKey } from "reactotron-core-contract"
 
 import ApiResponseCommand from "./ApiResponseCommand"
 import AsyncStorageMutationCommand from "./AsyncStorageMutationCommand"

--- a/lib/reactotron-core-ui/src/utils/filterCommands/index.ts
+++ b/lib/reactotron-core-ui/src/utils/filterCommands/index.ts
@@ -1,4 +1,5 @@
-import { CommandType, CommandTypeKey } from "reactotron-core-contract"
+import { CommandType } from "reactotron-core-contract"
+import type { CommandTypeKey } from "reactotron-core-contract"
 
 function path(...searchPath) {
   return (obj) => {

--- a/lib/reactotron-core-ui/tsconfig.json
+++ b/lib/reactotron-core-ui/tsconfig.json
@@ -4,6 +4,7 @@
     "jsx": "react",
     "declaration": true,
     "declarationDir": "dist/types",
+    "rootDir": ".",
     "emitDeclarationOnly": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,

--- a/lib/reactotron-mst/package.json
+++ b/lib/reactotron-mst/package.json
@@ -7,15 +7,22 @@
   "bugs": {
     "url": "https://github.com/infinitered/reactotron/issues"
   },
-  "homepage": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-mst",
-  "repository": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-mst",
+  "homepage": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-mst",
+  "repository": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-mst",
   "files": [
     "dist",
-    "LICENSE"
+    "src"
   ],
-  "main": "dist/reactotron-mst.umd.js",
-  "module": "dist/reactotron-mst.es5.js",
-  "typings": "dist/types/reactotron-mst.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "import": "./dist/index.esm.js",
+    "default": "./dist/index.js",
+    "react-native": "./src/index.ts",
+    "types": "./dist/types/src/index.d.ts"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-mst/rollup.config.ts
+++ b/lib/reactotron-mst/rollup.config.ts
@@ -2,29 +2,19 @@ import resolve from "rollup-plugin-node-resolve"
 import babel from "rollup-plugin-babel"
 import filesize from "rollup-plugin-filesize"
 import minify from "rollup-plugin-babel-minify"
-import camelCase from "lodash.camelcase"
 
-// @ts-ignore
 const pkg = require("./package.json")
-
-const LIBRARY_NAME = "reactotron-mst"
-const GLOBALS = ["ramda", "mobx-state-tree", "mobx"]
 
 export default {
   input: "src/reactotron-mst.ts",
   output: [
     {
       file: pkg.main,
-      name: camelCase(LIBRARY_NAME),
-      format: "umd",
-      sourcemap: true,
-      globals: GLOBALS,
+      format: "cjs",
     },
     {
       file: pkg.module,
-      format: "es",
-      sourcemap: true,
-      globals: GLOBALS,
+      format: "esm",
     },
   ],
   plugins: [

--- a/lib/reactotron-mst/src/index.ts
+++ b/lib/reactotron-mst/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./reactotron-mst"

--- a/lib/reactotron-mst/test/backup.test.ts
+++ b/lib/reactotron-mst/test/backup.test.ts
@@ -1,6 +1,6 @@
 import td from "testdouble"
 import { TestUserModel, commandMetadataFixture, createMstPlugin } from "./fixtures"
-import { Command } from "reactotron-core-contract"
+import type { Command } from "reactotron-core-contract"
 
 const INBOUND = {
   ...commandMetadataFixture,

--- a/lib/reactotron-mst/test/fixtures/command.ts
+++ b/lib/reactotron-mst/test/fixtures/command.ts
@@ -1,4 +1,4 @@
-import { Command } from "reactotron-core-contract"
+import type { Command } from "reactotron-core-contract"
 
 export const commandMetadataFixture: Omit<Command, "payload" | "type" | "payload"> = {
   connectionId: 1,

--- a/lib/reactotron-mst/test/request-values.test.ts
+++ b/lib/reactotron-mst/test/request-values.test.ts
@@ -1,6 +1,6 @@
 import td from "testdouble"
 import { TestUserModel, commandMetadataFixture, createMstPlugin } from "./fixtures"
-import { Command } from "reactotron-core-contract"
+import type { Command } from "reactotron-core-contract"
 
 function createAction(path: string) {
   return {

--- a/lib/reactotron-mst/test/restore.test.ts
+++ b/lib/reactotron-mst/test/restore.test.ts
@@ -1,6 +1,6 @@
 import { getSnapshot } from "mobx-state-tree"
 import { TestUserModel, commandMetadataFixture, createMstPlugin } from "./fixtures"
-import { Command } from "reactotron-core-contract"
+import type { Command } from "reactotron-core-contract"
 
 const STATE = { age: 1, name: "i" }
 const INBOUND = {

--- a/lib/reactotron-mst/test/subscribe.test.ts
+++ b/lib/reactotron-mst/test/subscribe.test.ts
@@ -5,7 +5,7 @@ import {
   createMstPlugin,
   createTestCompany,
 } from "./fixtures"
-import { Command } from "reactotron-core-contract"
+import type { Command } from "reactotron-core-contract"
 
 function createAction(paths: string[]) {
   return {

--- a/lib/reactotron-mst/tsconfig.json
+++ b/lib/reactotron-mst/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": false,
     "declaration": true,
     "declarationDir": "dist/types",
-    "rootDir": "src",
+    "rootDir": ".",
     "emitDeclarationOnly": true,
     "emitDecoratorMetadata": true,
     "allowSyntheticDefaultImports": true,

--- a/lib/reactotron-react-js/package.json
+++ b/lib/reactotron-react-js/package.json
@@ -7,15 +7,22 @@
   "bugs": {
     "url": "https://github.com/infinitered/reactotron/issues"
   },
-  "homepage": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-react-js",
-  "repository": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-react-js",
+  "homepage": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-react-js",
+  "repository": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-react-js",
   "files": [
     "dist",
-    "LICENSE",
-    "README.md"
+    "src"
   ],
   "main": "dist/index.js",
-  "types": "./dist/types/index.d.ts",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "default": "./dist/index.js",
+    "import": "./dist/index.esm.js",
+    "types": "./dist/types/src/index.d.ts",
+    "react-native": "./src/index.ts"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-react-js/rollup.config.js
+++ b/lib/reactotron-react-js/rollup.config.js
@@ -8,11 +8,17 @@ const reactotronReactJsVersion = require("./package.json").version
 
 export default {
   input: "src/index.ts",
-  output: {
-    file: "dist/index.js",
-    format: "cjs",
-    exports: "named",
-  },
+  output: [
+    {
+      file: "dist/index.js",
+      format: "cjs",
+      exports: "named",
+    },
+    {
+      file: "dist/index.esm.js",
+      format: "esm",
+    },
+  ],
   plugins: [
     resolve({ extensions: [".ts"] }),
     replace({

--- a/lib/reactotron-react-js/tsconfig.json
+++ b/lib/reactotron-react-js/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": ".",
     "allowJs": false,
     "declaration": true,
     "declarationDir": "dist/types",

--- a/lib/reactotron-react-native-mmkv/package.json
+++ b/lib/reactotron-react-native-mmkv/package.json
@@ -11,11 +11,18 @@
   "repository": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-react-native-mmkv",
   "files": [
     "dist",
-    "LICENSE"
+    "src"
   ],
-  "main": "dist/reactotron-react-native-mmkv.umd.js",
-  "module": "dist/reactotron-react-native-mmkv.es5.js",
-  "typings": "dist/types/reactotron-react-native-mmkv.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "default": "./dist/index.js",
+    "import": "./dist/index.esm.js",
+    "types": "./dist/types/src/index.d.ts",
+    "react-native": "./src/index.ts"
+  },
   "scripts": {
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-react-native-mmkv/rollup.config.ts
+++ b/lib/reactotron-react-native-mmkv/rollup.config.ts
@@ -3,27 +3,18 @@ import babel from "rollup-plugin-babel"
 import filesize from "rollup-plugin-filesize"
 import minify from "rollup-plugin-babel-minify"
 
-// @ts-ignore
 const pkg = require("./package.json")
-
-const LIBRARY_NAME = "reactotron-react-native-mmkv"
-const GLOBALS = ["react-native-mmkv"]
 
 export default {
   input: "src/reactotron-react-native-mmkv.ts",
   output: [
     {
       file: pkg.main,
-      name: LIBRARY_NAME,
-      format: "umd",
-      sourcemap: true,
-      globals: GLOBALS,
+      format: "commonjs",
     },
     {
       file: pkg.module,
-      format: "es",
-      sourcemap: true,
-      globals: GLOBALS,
+      format: "esm",
     },
   ],
   plugins: [

--- a/lib/reactotron-react-native-mmkv/src/index.ts
+++ b/lib/reactotron-react-native-mmkv/src/index.ts
@@ -1,0 +1,1 @@
+export default "./reactotron-react-native-mmkv"

--- a/lib/reactotron-react-native-mmkv/src/index.ts
+++ b/lib/reactotron-react-native-mmkv/src/index.ts
@@ -1,1 +1,3 @@
-export default "./reactotron-react-native-mmkv"
+import mmkvPlugin from "./reactotron-react-native-mmkv"
+export * from "./reactotron-react-native-mmkv"
+export default mmkvPlugin

--- a/lib/reactotron-react-native-mmkv/src/reactotron-react-native-mmkv.ts
+++ b/lib/reactotron-react-native-mmkv/src/reactotron-react-native-mmkv.ts
@@ -1,7 +1,7 @@
 import { type MMKV } from "react-native-mmkv"
 import type { Reactotron } from "reactotron-core-client"
 
-interface MmkvPluginConfig {
+export interface MmkvPluginConfig {
   /**
    * MMKV storage instance
    * @example

--- a/lib/reactotron-react-native-mmkv/tsconfig.json
+++ b/lib/reactotron-react-native-mmkv/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": false,
     "declaration": true,
     "declarationDir": "dist/types",
-    "rootDir": "src",
+    "rootDir": ".",
     "emitDeclarationOnly": true,
     "emitDecoratorMetadata": true,
     "allowSyntheticDefaultImports": true,

--- a/lib/reactotron-react-native/package.json
+++ b/lib/reactotron-react-native/package.json
@@ -7,16 +7,22 @@
   "bugs": {
     "url": "https://github.com/infinitered/reactotron/issues"
   },
-  "homepage": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-react-native",
-  "repository": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-react-native",
+  "homepage": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-react-native",
+  "repository": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-react-native",
   "files": [
     "dist",
-    "LICENSE",
-    "README.md",
-    "reactotron-react-native.d.ts"
+    "src"
   ],
   "main": "dist/index.js",
-  "types": "dist/types/src/reactotron-react-native.d.ts",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "default": "./dist/index.js",
+    "import": "./dist/index.esm.js",
+    "types": "./dist/types/src/index.d.ts",
+    "react-native": "./src/index.ts"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-react-native/rollup.config.js
+++ b/lib/reactotron-react-native/rollup.config.js
@@ -28,10 +28,16 @@ const EXTERNALS = [
 export default [
   {
     input: "src/reactotron-react-native.ts",
-    output: {
-      file: "dist/index.js",
-      format: "cjs",
-    },
+    output: [
+      {
+        file: "dist/index.js",
+        format: "cjs",
+      },
+      {
+        file: "dist/index.esm.js",
+        format: "esm",
+      },
+    ],
     plugins: getPlugins(),
     external: EXTERNALS,
   },

--- a/lib/reactotron-react-native/src/index.ts
+++ b/lib/reactotron-react-native/src/index.ts
@@ -1,1 +1,3 @@
+import reactotron from "./reactotron-react-native"
 export * from "./reactotron-react-native"
+export default reactotron

--- a/lib/reactotron-react-native/src/index.ts
+++ b/lib/reactotron-react-native/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./reactotron-react-native"

--- a/lib/reactotron-redux/package.json
+++ b/lib/reactotron-redux/package.json
@@ -7,16 +7,22 @@
   "bugs": {
     "url": "https://github.com/infinitered/reactotron/issues"
   },
-  "homepage": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-redux",
-  "repository": "https://github.com/infinitered/reactotron/tree/alpha/lib/reactotron-redux",
+  "homepage": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-redux",
+  "repository": "https://github.com/infinitered/reactotron/tree/beta/lib/reactotron-redux",
   "files": [
     "dist",
-    "LICENSE",
-    "README.md",
-    "reactotron-redux.d.ts"
+    "src"
   ],
   "main": "dist/index.js",
-  "types": "dist/types/index.d.ts",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "default": "./dist/index.js",
+    "import": "./dist/index.esm.js",
+    "types": "./dist/types/src/index.d.ts",
+    "react-native": "./src/index.ts"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch --notify",

--- a/lib/reactotron-redux/rollup.config.js
+++ b/lib/reactotron-redux/rollup.config.js
@@ -5,10 +5,16 @@ import minify from "rollup-plugin-babel-minify"
 
 export default {
   input: "src/index.ts",
-  output: {
-    file: "dist/index.js",
-    format: "cjs",
-  },
+  output: [
+    {
+      file: "dist/index.js",
+      format: "cjs",
+    },
+    {
+      file: "dist/index.esm.js",
+      format: "esm",
+    },
+  ],
   plugins: [
     resolve({ extensions: [".ts"] }),
     babel({ extensions: [".ts"], runtimeHelpers: true }),

--- a/lib/reactotron-redux/tsconfig.json
+++ b/lib/reactotron-redux/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": false,
-    "rootDir": "src",
+    "rootDir": ".",
     "declaration": true,
     "declarationDir": "dist/types",
     "emitDeclarationOnly": true,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "release:tags:push": "zx scripts/release.tags.push.mjs",
     "copy-prettier-ignore": "zx scripts/copy-prettier-ignore.mjs",
     "remove-local-tags": "git tag -l | xargs git tag -d && git fetch -t",
-    "build-and-test:local": "yarn build && yarn lint && yarn format:check && yarn test && yarn typecheck"
+    "build-and-test:local": "yarn build && yarn package:validate && yarn lint && yarn format:check && yarn test && yarn typecheck",
+    "package:validate": "zx scripts/package.validate.mjs"
   },
   "packageManager": "yarn@3.6.3"
 }

--- a/scripts/package.validate.mjs
+++ b/scripts/package.validate.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env zx
+// @ts-check
+import "zx/globals";
+import { getWorkspaceList } from "./tools/workspace.mjs";
+$.verbose = false;
+
+console.log(
+  [
+    "Validating each workspace has the correct package.json fields for publishing.",
+  ].join("\n")
+);
+
+// #region Find lib workspaces
+const ROOT_DIR = path.join(__dirname, "..");
+
+const workspaceList = await getWorkspaceList();
+
+const workspacePaths = workspaceList
+  // create absolute paths
+  .map((workspace) => path.join(ROOT_DIR, workspace.location))
+  // filter out workspaces without /lib/ in the path
+  .filter((workspacePath) => workspacePath.includes("/lib/"));
+
+console.log(`Found ${workspacePaths.length} library workspaces`);
+// #endregion
+
+for (const workspacePath of workspacePaths) {
+  console.log(`Validating "${workspacePath}"`);
+
+  // #region Parse package.json
+  const packageJsonPath = path.join(workspacePath, "package.json");
+  const packageJsonFile = fs.readFileSync(packageJsonPath, "utf-8");
+  if (!packageJsonFile || typeof packageJsonFile !== "string") {
+    console.error(`Failed to read ${packageJsonPath}`);
+    process.exit(1);
+  }
+  const packageJson = JSON.parse(packageJsonFile);
+  if (
+    !packageJson ||
+    typeof packageJson !== "object" ||
+    Array.isArray(packageJson)
+  ) {
+    console.error(`Failed to parse ${packageJsonPath}`);
+    process.exit(1);
+  }
+  // #endregion
+
+  // #region Validate package.json
+
+  // assert "author" field is Infinite Red
+  if (packageJson.author !== "Infinite Red") {
+    console.error(
+      `Invalid ${packageJsonPath} author field: ${packageJson.author}`
+    );
+    process.exit(1);
+  }
+
+  // assert "license" field is MIT
+  if (packageJson.license !== "MIT") {
+    console.error(
+      `Invalid ${packageJsonPath} license field: ${packageJson.license}`
+    );
+    process.exit(1);
+  }
+
+  // assert "bugs.url" field is "https://github.com/infinitered/reactotron/issues"
+  if (
+    packageJson.bugs.url !== "https://github.com/infinitered/reactotron/issues"
+  ) {
+    console.error(
+      `Invalid ${packageJsonPath} bugs.url field: ${packageJson.bugs.url}`
+    );
+    process.exit(1);
+  }
+
+  // assert "homepage" field is `https://github.com/infinitered/reactotron/tree/beta/lib/${workspaceName}`
+  const workspaceName = path.basename(workspacePath);
+  const expectedHomepage = `https://github.com/infinitered/reactotron/tree/beta/lib/${workspaceName}`;
+
+  if (packageJson.homepage !== expectedHomepage) {
+    console.error(
+      `Invalid ${packageJsonPath} homepage field: ${packageJson.homepage}`
+    );
+    process.exit(1);
+  }
+
+  // assert "repository" field is `https://github.com/infinitered/reactotron/tree/beta/lib/${workspaceName}`
+  if (
+    packageJson.repository !==
+    `https://github.com/infinitered/reactotron/tree/beta/lib/${workspaceName}`
+  ) {
+    console.error(
+      `Invalid ${packageJsonPath} repository field: ${packageJson.repository}`
+    );
+    process.exit(1);
+  }
+
+  // assert "files" field should be ["dist", "src"]
+  // LICENSE, README, and package.json are implicitly included https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files
+  if (
+    !Array.isArray(packageJson.files) ||
+    packageJson.files.length !== 2 ||
+    packageJson.files[0] !== "dist" ||
+    packageJson.files[1] !== "src"
+  ) {
+    console.error(
+      `Invalid ${packageJsonPath} files field: ${packageJson.files}`
+    );
+    process.exit(1);
+  }
+
+  // assert "main" field is "dist/index.js"
+  if (packageJson.main !== "dist/index.js") {
+    console.error(`Invalid ${packageJsonPath} main field: ${packageJson.main}`);
+    process.exit(1);
+  }
+
+  // assert "main" field points to a real file
+  const mainPath = path.join(workspacePath, packageJson.main);
+  if (!fs.existsSync(mainPath)) {
+    console.error(`Missing ${mainPath}`);
+    process.exit(1);
+  }
+
+  // assert "module" field is "dist/index.esm.js"
+  if (packageJson.module !== "dist/index.esm.js") {
+    console.error(
+      `Invalid ${packageJsonPath} module field: ${packageJson.module}`
+    );
+    process.exit(1);
+  }
+
+  // assert "module" field points to a real file
+  const modulePath = path.join(workspacePath, packageJson.module);
+  if (!fs.existsSync(modulePath)) {
+    console.error(`Missing ${modulePath}`);
+    process.exit(1);
+  }
+
+  // assert "types" field is "dist/types/src/index.d.ts"
+  if (packageJson.types !== "dist/types/src/index.d.ts") {
+    console.error(
+      `Invalid ${packageJsonPath} types field: ${packageJson.types}`
+    );
+    process.exit(1);
+  }
+
+  // assert "types" field points to a real file
+  const typesPath = path.join(workspacePath, packageJson.types);
+  if (!fs.existsSync(typesPath)) {
+    console.error(`Missing ${typesPath}`);
+    process.exit(1);
+  }
+
+  // assert "react-native" field is "src/index.ts"
+  if (packageJson["react-native"] !== "src/index.ts") {
+    console.error(
+      `Invalid ${packageJsonPath} react-native field: ${packageJson["react-native"]}`
+    );
+    process.exit(1);
+  }
+
+  // assert "react-native" field points to a real file
+  const reactNativePath = path.join(workspacePath, packageJson["react-native"]);
+  if (!fs.existsSync(reactNativePath)) {
+    console.error(`Missing ${reactNativePath}`);
+    process.exit(1);
+  }
+
+  // assert "exports" field is an object with "default", "import", "react-native", and "types" fields
+  if (
+    !packageJson.exports ||
+    typeof packageJson.exports !== "object" ||
+    Array.isArray(packageJson.exports) ||
+    !packageJson.exports.default ||
+    !packageJson.exports.import ||
+    !packageJson.exports["react-native"] ||
+    !packageJson.exports.types
+  ) {
+    console.error(
+      `Invalid ${packageJsonPath} exports field: ${JSON.stringify(
+        packageJson.exports,
+        null,
+        2
+      )}`
+    );
+    process.exit(1);
+  }
+
+  // assert "exports.default" field is "./dist/index.js"
+  if (packageJson.exports.default !== "./dist/index.js") {
+    console.error(
+      `Invalid ${packageJsonPath} exports.default field: ${packageJson.exports.default}`
+    );
+    process.exit(1);
+  }
+
+  // assert "exports.default" field points to a real file
+  const exportsDefaultPath = path.join(
+    workspacePath,
+    packageJson.exports.default
+  );
+  if (!fs.existsSync(exportsDefaultPath)) {
+    console.error(`Missing ${exportsDefaultPath}`);
+    process.exit(1);
+  }
+
+  // assert "exports.import" field is "./dist/index.esm.js"
+  if (packageJson.exports.import !== "./dist/index.esm.js") {
+    console.error(
+      `Invalid ${packageJsonPath} exports.import field: ${packageJson.exports.import}`
+    );
+    process.exit(1);
+  }
+
+  // assert "exports.import" field points to a real file
+  const exportsImportPath = path.join(
+    workspacePath,
+    packageJson.exports.import
+  );
+  if (!fs.existsSync(exportsImportPath)) {
+    console.error(`Missing ${exportsImportPath}`);
+    process.exit(1);
+  }
+
+  // assert "exports.react-native" field is "./src/index.ts"
+  if (packageJson.exports["react-native"] !== "./src/index.ts") {
+    console.error(
+      `Invalid ${packageJsonPath} exports.react-native field: ${packageJson.exports["react-native"]}`
+    );
+    process.exit(1);
+  }
+
+  // assert "exports.react-native" field points to a real file
+  const exportsReactNativePath = path.join(
+    workspacePath,
+    packageJson.exports["react-native"]
+  );
+  if (!fs.existsSync(exportsReactNativePath)) {
+    console.error(`Missing ${exportsReactNativePath}`);
+    process.exit(1);
+  }
+
+  // assert "exports.types" field is "./dist/types/src/index.d.ts"
+  if (packageJson.exports.types !== "./dist/types/src/index.d.ts") {
+    console.error(
+      `Invalid ${packageJsonPath} exports.types field: ${packageJson.exports.types}`
+    );
+    process.exit(1);
+  }
+
+  // assert "exports.types" field is a real file
+  const exportsTypesPath = path.join(workspacePath, packageJson.exports.types);
+  if (!fs.existsSync(exportsTypesPath)) {
+    console.error(`Missing ${exportsTypesPath}`);
+    process.exit(1);
+  }
+
+  // #endregion
+}
+
+console.log("All workspaces are valid!");


### PR DESCRIPTION
This PR standardizes the configuration in each library workspace `package.json` to ensure that our commonjs, esm, and typescript builds are consistent and correct across all of our library workspaces.

It ensures this by adding `scripts/package.validate.mjs`, which goes through each workspace and asserts that all the necessary conditions are working. Essentially this brings unit tests to our package.json configuration. This has also been added the CI to ensure that future workspaces have the correct configuration or the CI fails. 

It also adds the new package exports react-native condition for future releases.
https://reactnative.dev/blog/2023/06/21/package-exports-support#the-new-react-native-condition

It also adds the previously used "react-native" root field for existing apps that may still use (motivated by this PR https://github.com/infinitered/reactotron/pull/1288).