### PR TITLE
feat(reactotron-react-native): enable trackGlobalLogs in useReactNative by default

### DIFF
--- a/lib/reactotron-react-native/src/reactotron-react-native.ts
+++ b/lib/reactotron-react-native/src/reactotron-react-native.ts
@@ -18,6 +18,7 @@ import trackGlobalErrors, { TrackGlobalErrorsOptions } from "./plugins/trackGlob
 import networking, { NetworkingOptions } from "./plugins/networking"
 import storybook from "./plugins/storybook"
 import devTools from "./plugins/devTools"
+import trackGlobalLogs from "./plugins/trackGlobalLogs"
 
 const constants = NativeModules.PlatformConstants || {}
 
@@ -83,6 +84,7 @@ const DEFAULTS: ClientOptions<ReactotronReactNative> = {
 
 export interface UseReactNativeOptions {
   errors?: TrackGlobalErrorsOptions | boolean
+  log?: boolean
   editor?: OpenInEditorOptions | boolean
   overlay?: boolean
   asyncStorage?: AsyncStorageOptions | boolean
@@ -94,6 +96,7 @@ export interface UseReactNativeOptions {
 export const reactNativeCorePlugins = [
   asyncStorage(),
   trackGlobalErrors(),
+  trackGlobalLogs(),
   openInEditor(),
   overlay(),
   networking(),
@@ -121,6 +124,10 @@ function getPluginOptions<T>(options?: T | boolean): T {
 reactotron.useReactNative = (options: UseReactNativeOptions = {}) => {
   if (options.errors !== false) {
     reactotron.use(trackGlobalErrors(getPluginOptions(options.errors)))
+  }
+
+  if (options.log !== false) {
+    reactotron.use(trackGlobalLogs())
   }
 
   if (options.editor !== false) {
@@ -156,8 +163,16 @@ reactotron.setAsyncStorageHandler = (asyncStorage: AsyncStorageStatic) => {
   return reactotron
 }
 
-export { asyncStorage, trackGlobalErrors, openInEditor, overlay, networking, storybook, devTools }
-export { default as trackGlobalLogs } from "./plugins/trackGlobalLogs"
+export {
+  asyncStorage,
+  trackGlobalErrors,
+  trackGlobalLogs,
+  openInEditor,
+  overlay,
+  networking,
+  storybook,
+  devTools,
+}
 
 export type { ClientOptions }
 


### PR DESCRIPTION
This PR adds a new core plugin called `trackGlobalLogs` to the `useReactNative` default plugins, which will automatically track `console.log`, `console.warn`, and `console.debug` without needing to do calls to `Reactotron.log` or `console.tron.log`.

This has been enabled in Ignite for [several releases now](https://github.com/infinitered/ignite/blob/v9.0.4/boilerplate/app/devtools/ReactotronConfig.ts#L149-L178), so we will be able to remove this snippet. 

Monkey patching globals like console log is not ideal but we determined that we would expect a debugging tool to collect logs. We also already do similar strategies for inspecting network traffic, so we think this is a tradeoff worth making.