### PR TITLE
fix: Display error if port is already in use

### DIFF
--- a/apps/reactotron-app/src/renderer/components/Footer/Footer.story.tsx
+++ b/apps/reactotron-app/src/renderer/components/Footer/Footer.story.tsx
@@ -7,16 +7,57 @@ import { Connection } from "../../contexts/Standalone/useStandalone"
 import Footer from "./Stateless"
 
 const testConnections: Connection[] = [
-  { id: 0, clientId: "1", name: "Test 1", commands: [], platform: "ios", platformVersion: "12", connected: true },
-  { id: 0, clientId: "1", name: "Test 2", commands: [], platform: "ios", platformVersion: "12", connected: true },
-  { id: 0, clientId: "1", name: "Test 3", commands: [], platform: "ios", platformVersion: "12", connected: true },
-  { id: 0, clientId: "1", name: "Test 4", commands: [], platform: "ios", platformVersion: "12", connected: true },
-  { id: 0, clientId: "1", name: "Test 5", commands: [], platform: "ios", platformVersion: "12", connected: true },
+  {
+    id: 0,
+    clientId: "1",
+    name: "Test 1",
+    commands: [],
+    platform: "ios",
+    platformVersion: "12",
+    connected: true,
+  },
+  {
+    id: 0,
+    clientId: "1",
+    name: "Test 2",
+    commands: [],
+    platform: "ios",
+    platformVersion: "12",
+    connected: true,
+  },
+  {
+    id: 0,
+    clientId: "1",
+    name: "Test 3",
+    commands: [],
+    platform: "ios",
+    platformVersion: "12",
+    connected: true,
+  },
+  {
+    id: 0,
+    clientId: "1",
+    name: "Test 4",
+    commands: [],
+    platform: "ios",
+    platformVersion: "12",
+    connected: true,
+  },
+  {
+    id: 0,
+    clientId: "1",
+    name: "Test 5",
+    commands: [],
+    platform: "ios",
+    platformVersion: "12",
+    connected: true,
+  },
 ]
 
 storiesOf("components/Footer", module)
   .add("Collpased", () => (
     <Footer
+      serverStatus="started"
       connections={[]}
       selectedConnection={null}
       isOpen={false}
@@ -26,6 +67,7 @@ storiesOf("components/Footer", module)
   ))
   .add("Collpased w/ connections", () => (
     <Footer
+      serverStatus="started"
       connections={testConnections}
       selectedConnection={null}
       isOpen={false}
@@ -35,6 +77,7 @@ storiesOf("components/Footer", module)
   ))
   .add("Expanded", () => (
     <Footer
+      serverStatus="started"
       connections={[]}
       selectedConnection={null}
       isOpen
@@ -44,6 +87,7 @@ storiesOf("components/Footer", module)
   ))
   .add("Expanded w/ connections", () => (
     <Footer
+      serverStatus="started"
       connections={testConnections}
       selectedConnection={null}
       isOpen
@@ -53,6 +97,7 @@ storiesOf("components/Footer", module)
   ))
   .add("Expanded w/ lots connections", () => (
     <Footer
+      serverStatus="started"
       connections={[...testConnections, ...testConnections, ...testConnections]}
       selectedConnection={null}
       isOpen

--- a/apps/reactotron-app/src/renderer/components/Footer/Stateless.tsx
+++ b/apps/reactotron-app/src/renderer/components/Footer/Stateless.tsx
@@ -82,7 +82,9 @@ function renderCollapsed(
       <ConnectionInfo>
         port {config.get("serverPort") as string} | {connections.length} connections
       </ConnectionInfo>
-      {serverStatus === "portInUse" && <ConnectionInfo>Port 9090 unavailable.</ConnectionInfo>}
+      {serverStatus === "portUnavailable" && (
+        <ConnectionInfo>Port 9090 unavailable.</ConnectionInfo>
+      )}
       {serverStatus === "started" && (
         <ConnectionInfo>
           device:{" "}

--- a/apps/reactotron-app/src/renderer/components/Footer/Stateless.tsx
+++ b/apps/reactotron-app/src/renderer/components/Footer/Stateless.tsx
@@ -4,7 +4,7 @@ import { MdSwapVert as ExpandIcon } from "react-icons/md"
 
 import config from "../../config"
 import { getPlatformName, getPlatformDetails } from "../../util/connectionHelpers"
-import { Connection } from "../../contexts/Standalone/useStandalone"
+import { Connection, ServerStatus } from "../../contexts/Standalone/useStandalone"
 import ConnectionSelector from "../ConnectionSelector"
 
 const Container = styled.div`
@@ -50,6 +50,7 @@ function renderDeviceName(connection: Connection) {
 }
 
 function renderExpanded(
+  serverStatus: ServerStatus,
   connections: Connection[],
   selectedConnection: Connection | null,
   onChangeConnection: (clientId: string | null) => void
@@ -71,21 +72,30 @@ function renderExpanded(
   )
 }
 
-function renderCollapsed(connections: Connection[], selectedConnection: Connection | null) {
+function renderCollapsed(
+  serverStatus: ServerStatus,
+  connections: Connection[],
+  selectedConnection: Connection | null
+) {
   return (
     <>
       <ConnectionInfo>
         port {config.get("serverPort") as string} | {connections.length} connections
       </ConnectionInfo>
-      <ConnectionInfo>
-        device:{" "}
-        {selectedConnection ? renderDeviceName(selectedConnection) : "Waiting for connection"}
-      </ConnectionInfo>
+      {serverStatus === "portInUse" && <ConnectionInfo>Port 9090 unavailable.</ConnectionInfo>}
+      {serverStatus === "started" && (
+        <ConnectionInfo>
+          device:{" "}
+          {selectedConnection ? renderDeviceName(selectedConnection) : "Waiting for connection"}
+        </ConnectionInfo>
+      )}
+      {serverStatus === "stopped" && <ConnectionInfo>Waiting for server to start</ConnectionInfo>}
     </>
   )
 }
 
 interface Props {
+  serverStatus: ServerStatus
   connections: Connection[]
   selectedConnection: Connection | null
   isOpen: boolean
@@ -93,13 +103,20 @@ interface Props {
   onChangeConnection: (clientId: string | null) => void
 }
 
-function Header({ connections, selectedConnection, isOpen, setIsOpen, onChangeConnection }: Props) {
+function Header({
+  serverStatus,
+  connections,
+  selectedConnection,
+  isOpen,
+  setIsOpen,
+  onChangeConnection,
+}: Props) {
   const renderMethod = isOpen ? renderExpanded : renderCollapsed
 
   return (
     <Container>
       <ContentContainer onClick={() => !isOpen && setIsOpen(true)} $isOpen={isOpen}>
-        {renderMethod(connections, selectedConnection, onChangeConnection)}
+        {renderMethod(serverStatus, connections, selectedConnection, onChangeConnection)}
         <ExpandContainer onClick={() => setIsOpen(!isOpen)}>
           <ExpandIcon size={18} />
         </ExpandContainer>

--- a/apps/reactotron-app/src/renderer/components/Footer/index.tsx
+++ b/apps/reactotron-app/src/renderer/components/Footer/index.tsx
@@ -5,11 +5,13 @@ import StandaloneContext from "../../contexts/Standalone"
 import Footer from "./Stateless"
 
 export default function ConnectedFooter() {
-  const { connections, selectedConnection, selectConnection } = useContext(StandaloneContext)
+  const { serverStatus, connections, selectedConnection, selectConnection } =
+    useContext(StandaloneContext)
   const [isOpen, setIsOpen] = useState(false)
 
   return (
     <Footer
+      serverStatus={serverStatus}
       connections={connections}
       selectedConnection={selectedConnection}
       onChangeConnection={selectConnection}

--- a/apps/reactotron-app/src/renderer/components/SideBar/SideBar.story.tsx
+++ b/apps/reactotron-app/src/renderer/components/SideBar/SideBar.story.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { BrowserRouter as Router } from "react-router-dom"
 
-import SideBar from "./Stateless"
+import SideBar from "./Sidebar"
 
 export default {
   title: "SideBar",
@@ -9,6 +9,6 @@ export default {
 
 export const Default = () => (
   <Router>
-    <SideBar isOpen />
+    <SideBar isOpen serverStatus="started" />
   </Router>
 )

--- a/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
+++ b/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
@@ -42,14 +42,14 @@ function SideBar({ isOpen, serverStatus }: { isOpen: boolean; serverStatus: Serv
     serverIcon = MdOutlineMobileFriendly
     serverText = "Running"
   }
-  if (serverStatus === "portInUse") {
+  if (serverStatus === "portUnavailable") {
     serverIcon = MdWarning
     iconColor = "yellow"
     serverText = "Port 9090 unavailable"
   }
 
   const retryConnection = () => {
-    if (serverStatus === "portInUse") {
+    if (serverStatus === "portUnavailable") {
       // TODO: Reconnect more elegantly than forcing a reload
       window.location.reload()
     }

--- a/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
+++ b/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
@@ -14,7 +14,6 @@ import styled from "styled-components"
 import SideBarButton from "../SideBarButton"
 import { reactotronLogo } from "../../images"
 import { ServerStatus } from "../../contexts/Standalone/useStandalone"
-import { SideBarButtonContainer } from "../SideBarButton/Stateless"
 
 interface SideBarContainerProps {
   $isOpen: boolean
@@ -36,7 +35,7 @@ const Spacer = styled.div`
 
 function SideBar({ isOpen, serverStatus }: { isOpen: boolean; serverStatus: ServerStatus }) {
   let serverIcon = MdMobiledataOff
-  let iconColor = undefined
+  let iconColor
   let serverText = "Stopped"
   if (serverStatus === "started") {
     serverIcon = MdOutlineMobileFriendly

--- a/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
+++ b/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
@@ -1,11 +1,20 @@
 import React from "react"
-import { MdReorder, MdAssignment, MdPhoneIphone, MdLiveHelp } from "react-icons/md"
+import {
+  MdReorder,
+  MdAssignment,
+  MdPhoneIphone,
+  MdLiveHelp,
+  MdWarning,
+  MdOutlineMobileFriendly,
+  MdMobiledataOff,
+} from "react-icons/md"
 import { FaMagic } from "react-icons/fa"
 import styled from "styled-components"
 
 import SideBarButton from "../SideBarButton"
 import { reactotronLogo } from "../../images"
 import { ServerStatus } from "../../contexts/Standalone/useStandalone"
+import { SideBarButtonContainer } from "../SideBarButton/Stateless"
 
 interface SideBarContainerProps {
   $isOpen: boolean
@@ -26,6 +35,26 @@ const Spacer = styled.div`
 `
 
 function SideBar({ isOpen, serverStatus }: { isOpen: boolean; serverStatus: ServerStatus }) {
+  let serverIcon = MdMobiledataOff
+  let iconColor = undefined
+  let serverText = "Stopped"
+  if (serverStatus === "started") {
+    serverIcon = MdOutlineMobileFriendly
+    serverText = "Running"
+  }
+  if (serverStatus === "portInUse") {
+    serverIcon = MdWarning
+    iconColor = "yellow"
+    serverText = "Port 9090 unavailable"
+  }
+
+  const retryConnection = () => {
+    if (serverStatus === "portInUse") {
+      // TODO: Reconnect more elegantly than forcing a reload
+      window.location.reload()
+    }
+  }
+
   return (
     <SideBarContainer $isOpen={isOpen}>
       <SideBarButton image={reactotronLogo} path="/home" text="Home" hideTopBar />
@@ -43,8 +72,16 @@ function SideBar({ isOpen, serverStatus }: { isOpen: boolean; serverStatus: Serv
         text="React Native"
       />
       <SideBarButton icon={FaMagic} path="/customCommands" text="Custom Commands" iconSize={25} />
+
       <Spacer />
-      <SideBarButton icon={MdLiveHelp} path="/help/portInUse" text={serverStatus} hideTopBar />
+
+      <SideBarButton
+        icon={serverIcon}
+        path="#"
+        onPress={retryConnection}
+        text={serverText}
+        iconColor={iconColor}
+      />
 
       <SideBarButton icon={MdLiveHelp} path="/help" text="Help" hideTopBar />
     </SideBarContainer>

--- a/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
+++ b/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components"
 
 import SideBarButton from "../SideBarButton"
 import { reactotronLogo } from "../../images"
+import { ServerStatus } from "../../contexts/Standalone/useStandalone"
 
 interface SideBarContainerProps {
   $isOpen: boolean
@@ -24,7 +25,7 @@ const Spacer = styled.div`
   flex: 1;
 `
 
-function SideBar({ isOpen }: { isOpen: boolean }) {
+function SideBar({ isOpen, serverStatus }: { isOpen: boolean; serverStatus: ServerStatus }) {
   return (
     <SideBarContainer $isOpen={isOpen}>
       <SideBarButton image={reactotronLogo} path="/home" text="Home" hideTopBar />
@@ -43,6 +44,8 @@ function SideBar({ isOpen }: { isOpen: boolean }) {
       />
       <SideBarButton icon={FaMagic} path="/customCommands" text="Custom Commands" iconSize={25} />
       <Spacer />
+      <SideBarButton icon={MdLiveHelp} path="/help/portInUse" text={serverStatus} hideTopBar />
+
       <SideBarButton icon={MdLiveHelp} path="/help" text="Help" hideTopBar />
     </SideBarContainer>
   )

--- a/apps/reactotron-app/src/renderer/components/SideBar/index.tsx
+++ b/apps/reactotron-app/src/renderer/components/SideBar/index.tsx
@@ -1,12 +1,14 @@
 import React, { useContext } from "react"
 import LayoutContext from "../../contexts/Layout"
+import StandaloneContext from "../../contexts/Standalone"
 
-import SidebarStateless from "./Stateless"
+import SidebarStateless from "./Sidebar"
 
 function SideBar() {
   const { isSideBarOpen } = useContext(LayoutContext)
+  const { serverStatus } = useContext(StandaloneContext)
 
-  return <SidebarStateless isOpen={isSideBarOpen} />
+  return <SidebarStateless isOpen={isSideBarOpen} serverStatus={serverStatus} />
 }
 
 export default SideBar

--- a/apps/reactotron-app/src/renderer/components/SideBarButton/Stateless.tsx
+++ b/apps/reactotron-app/src/renderer/components/SideBarButton/Stateless.tsx
@@ -8,12 +8,14 @@ const Theme = { highlight: "hsl(290, 3.2%, 47.4%)", foregroundLight: "#c3c3c3" }
 
 interface SideBarButtonComponentProps {
   icon?: any
+  iconColor?: string
   image?: any
   path: string
   text: string
   isActive: boolean
   hideTopBar?: boolean
   iconSize?: number
+  onPress?: () => void
 }
 
 interface SideBarButtonProps {
@@ -23,7 +25,7 @@ interface SideBarButtonProps {
 
 const colorInterpolator = colorInterpolate([Theme.highlight, Theme.foregroundLight])
 
-const SideBarButtonContainer = styled.div.attrs(() => ({}))<SideBarButtonProps>`
+export const SideBarButtonContainer = styled.div.attrs(() => ({}))<SideBarButtonProps>`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -50,19 +52,21 @@ const Title = styled.div`
 
 function SideBarButton({
   icon: Icon,
+  iconColor,
   image,
   path,
   text,
   isActive,
   hideTopBar,
   iconSize,
+  onPress,
 }: SideBarButtonComponentProps) {
   return (
     <Motion style={{ color: spring(isActive ? 1 : 0) }}>
       {({ color }) => (
-        <Link to={path} style={{ textDecoration: "none" }}>
+        <Link to={path} style={{ textDecoration: "none" }} onClick={onPress}>
           <SideBarButtonContainer $hideTopBar={hideTopBar || false} $colorAnimation={color}>
-            {Icon && <Icon size={iconSize || 32} />}
+            {Icon && <Icon size={iconSize || 32} color={iconColor} />}
             {image && (
               <Image src={image} $hideTopBar={hideTopBar || false} $colorAnimation={color} />
             )}

--- a/apps/reactotron-app/src/renderer/components/SideBarButton/index.tsx
+++ b/apps/reactotron-app/src/renderer/components/SideBarButton/index.tsx
@@ -5,12 +5,14 @@ import StatelessSideBarButton from "./Stateless"
 
 type Props = {
   icon?: any
+  iconColor?: string
   image?: any
   path: string
   matchPath?: string
   text: string
   hideTopBar?: boolean
   iconSize?: number
+  onPress?: () => void
 }
 
 function SideBarButton({ path, matchPath, ...rest }: Props) {

--- a/apps/reactotron-app/src/renderer/contexts/Standalone/index.tsx
+++ b/apps/reactotron-app/src/renderer/contexts/Standalone/index.tsx
@@ -4,16 +4,18 @@ import Server, { createServer } from "reactotron-core-server"
 import ReactotronBrain from "../../ReactotronBrain"
 import config from "../../config"
 
-import useStandalone, { Connection } from "./useStandalone"
+import useStandalone, { Connection, ServerStatus } from "./useStandalone"
 
 // TODO: Move up to better places like core somewhere!
 interface Context {
+  serverStatus: ServerStatus
   connections: Connection[]
   selectedConnection: Connection
   selectConnection: (clientId: string) => void
 }
 
 const StandaloneContext = React.createContext<Context>({
+  serverStatus: "stopped",
   connections: [],
   selectedConnection: null,
   selectConnection: null,
@@ -23,27 +25,32 @@ const Provider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const reactotronServer = useRef<Server>(null)
 
   const {
+    serverStatus,
     connections,
     selectedClientId,
     selectedConnection,
     selectConnection,
     clearSelectedConnectionCommands,
+    serverStarted,
+    serverStopped,
     connectionEstablished,
     commandReceived,
     connectionDisconnected,
     addCommandListener,
+    portInUse,
   } = useStandalone()
 
   useEffect(() => {
     reactotronServer.current = createServer({ port: config.get("serverPort") as number })
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore need to sync these types between reactotron-core-server and reactotron-app
+    reactotronServer.current.on("start", serverStarted)
+    reactotronServer.current.on("stop", serverStopped)
+    // @ts-expect-error need to sync these types between reactotron-core-server and reactotron-app
     reactotronServer.current.on("connectionEstablished", connectionEstablished)
     reactotronServer.current.on("command", commandReceived)
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore need to sync these types between reactotron-core-server and reactotron-app
+    // @ts-expect-error need to sync these types between reactotron-core-server and reactotron-app
     reactotronServer.current.on("disconnect", connectionDisconnected)
+    reactotronServer.current.on("portInUse", portInUse)
 
     reactotronServer.current.start()
 
@@ -65,6 +72,7 @@ const Provider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <StandaloneContext.Provider
       value={{
+        serverStatus,
         connections,
         selectedConnection,
         selectConnection,

--- a/apps/reactotron-app/src/renderer/contexts/Standalone/index.tsx
+++ b/apps/reactotron-app/src/renderer/contexts/Standalone/index.tsx
@@ -57,7 +57,14 @@ const Provider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     return () => {
       reactotronServer.current.stop()
     }
-  }, [connectionEstablished, commandReceived, connectionDisconnected])
+  }, [
+    serverStarted,
+    serverStopped,
+    connectionEstablished,
+    commandReceived,
+    connectionDisconnected,
+    portUnavailable,
+  ])
 
   const sendCommand = useCallback(
     (type: string, payload: any, clientId?: string) => {

--- a/apps/reactotron-app/src/renderer/contexts/Standalone/index.tsx
+++ b/apps/reactotron-app/src/renderer/contexts/Standalone/index.tsx
@@ -37,7 +37,7 @@ const Provider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     commandReceived,
     connectionDisconnected,
     addCommandListener,
-    portInUse,
+    portUnavailable,
   } = useStandalone()
 
   useEffect(() => {
@@ -50,7 +50,7 @@ const Provider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     reactotronServer.current.on("command", commandReceived)
     // @ts-expect-error need to sync these types between reactotron-core-server and reactotron-app
     reactotronServer.current.on("disconnect", connectionDisconnected)
-    reactotronServer.current.on("portInUse", portInUse)
+    reactotronServer.current.on("portUnavailable", portUnavailable)
 
     reactotronServer.current.start()
 

--- a/apps/reactotron-app/src/renderer/contexts/Standalone/useStandalone.ts
+++ b/apps/reactotron-app/src/renderer/contexts/Standalone/useStandalone.ts
@@ -2,13 +2,18 @@ import { useCallback, useReducer } from "react"
 import { produce } from "immer"
 
 export enum ActionTypes {
+  ServerStarted = "SERVER_STARTED",
+  ServerStopped = "SERVER_STOPPED",
   AddConnection = "ADD_CONNECTION",
   RemoveConnection = "REMOVE_CONNECTION",
   ClearConnectionCommands = "CLEAR_CONNECTION_COMMANDS",
   CommandReceived = "COMMAND_RECEIVED",
   ChangeSelectedClientId = "CHANGE_SELECTED_CLIENT_ID",
   AddCommandHandler = "ADD_COMMAND_HANDLER",
+  PortInUse = "PORT_IN_USE",
 }
+
+export type ServerStatus = "stopped" | "portInUse" | "started"
 
 export interface ReactotronConnection {
   // Stuff shipped from core-server
@@ -30,6 +35,7 @@ export interface Connection extends ReactotronConnection {
 }
 
 interface State {
+  serverStatus: ServerStatus
   connections: Connection[]
   selectedClientId: string
   orphanedCommands: any[] // Command[]
@@ -37,6 +43,8 @@ interface State {
 }
 
 type Action =
+  | { type: ActionTypes.ServerStarted; payload: undefined }
+  | { type: ActionTypes.ServerStopped; payload: undefined }
   | {
       type: ActionTypes.AddConnection | ActionTypes.RemoveConnection
       payload: ReactotronConnection
@@ -45,13 +53,22 @@ type Action =
   | { type: ActionTypes.CommandReceived; payload: any } // TODO: Type this better!
   | { type: ActionTypes.ClearConnectionCommands }
   | { type: ActionTypes.AddCommandHandler; payload: (command: any) => void }
+  | { type: ActionTypes.PortInUse; payload: undefined }
 
 export function reducer(state: State, action: Action) {
   switch (action.type) {
+    case ActionTypes.ServerStarted:
+      return produce(state, (draftState) => {
+        draftState.serverStatus = "started"
+      })
+    case ActionTypes.ServerStopped:
+      return produce(state, (draftState) => {
+        draftState.serverStatus = "stopped"
+      })
     case ActionTypes.AddConnection:
-      return produce(state, draftState => {
+      return produce(state, (draftState) => {
         let existingConnection = draftState.connections.find(
-          c => c.clientId === action.payload.clientId
+          (c) => c.clientId === action.payload.clientId
         )
 
         if (existingConnection) {
@@ -69,29 +86,32 @@ export function reducer(state: State, action: Action) {
         if (draftState.orphanedCommands.length > 0) {
           // TODO: Make this better... filtering this list twice probably is a terrible idea.
           const orphanedCommands = draftState.orphanedCommands.filter(
-            oc => oc.connectionId === action.payload.id
+            (oc) => oc.connectionId === action.payload.id
           )
 
           // TODO: Consider if we need to do a one time sort of these... just in case.
           existingConnection.commands.push(...orphanedCommands)
 
           draftState.orphanedCommands = draftState.orphanedCommands.filter(
-            oc => oc.connectionId !== action.payload.id
+            (oc) => oc.connectionId !== action.payload.id
           )
         }
 
         // TODO: Figure out if we can stop having these dumb commands so early. Make core client only send once we actually have a client ID! (maybe won't work for flipper if it doesn't assign client id? Maybe that is how this broke?!?)
 
-        const filteredConnections = draftState.connections.filter(c => c.connected)
+        const filteredConnections = draftState.connections.filter((c) => c.connected)
 
         if (filteredConnections.length === 1) {
           draftState.selectedClientId = filteredConnections[0].clientId
         }
+
+        // Change the server status to started if it wasn't already
+        draftState.serverStatus = "started"
       })
     case ActionTypes.RemoveConnection:
-      return produce(state, draftState => {
+      return produce(state, (draftState) => {
         const existingConnection = draftState.connections.find(
-          c => c.clientId === action.payload.clientId
+          (c) => c.clientId === action.payload.clientId
         )
 
         if (!existingConnection) return
@@ -99,7 +119,7 @@ export function reducer(state: State, action: Action) {
         existingConnection.connected = false
 
         if (draftState.selectedClientId === action.payload.clientId) {
-          const filteredConnections = draftState.connections.filter(c => c.connected)
+          const filteredConnections = draftState.connections.filter((c) => c.connected)
 
           if (filteredConnections.length > 0) {
             draftState.selectedClientId = filteredConnections[0].clientId
@@ -109,24 +129,26 @@ export function reducer(state: State, action: Action) {
         }
       })
     case ActionTypes.CommandReceived:
-      return produce(state, draftState => {
+      return produce(state, (draftState) => {
         if (!action.payload.clientId) {
           draftState.orphanedCommands.push(action.payload)
           return
         }
 
-        draftState.commandListeners.forEach(cl => cl(action.payload))
+        draftState.commandListeners.forEach((cl) => cl(action.payload))
 
-        const connection = draftState.connections.find(c => c.clientId === action.payload.clientId)
+        const connection = draftState.connections.find(
+          (c) => c.clientId === action.payload.clientId
+        )
 
         connection.commands = [action.payload, ...connection.commands]
       })
     case ActionTypes.ClearConnectionCommands:
-      return produce(state, draftState => {
+      return produce(state, (draftState) => {
         if (!draftState.selectedClientId) return
 
         const selectedConnection = draftState.connections.find(
-          c => c.clientId === draftState.selectedClientId
+          (c) => c.clientId === draftState.selectedClientId
         )
 
         if (!selectedConnection) return
@@ -134,16 +156,21 @@ export function reducer(state: State, action: Action) {
         selectedConnection.commands = []
       })
     case ActionTypes.ChangeSelectedClientId:
-      return produce(state, draftState => {
-        const selectedConnection = draftState.connections.find(c => c.clientId === action.payload)
+      return produce(state, (draftState) => {
+        const selectedConnection = draftState.connections.find((c) => c.clientId === action.payload)
 
         if (!selectedConnection) return
 
         draftState.selectedClientId = action.payload
       })
     case ActionTypes.AddCommandHandler:
-      return produce(state, draftState => {
+      return produce(state, (draftState) => {
         draftState.commandListeners.push(action.payload)
+      })
+    case ActionTypes.PortInUse:
+      return produce(state, (draftState) => {
+        console.error("Port in use!")
+        draftState.serverStatus = "portInUse"
       })
     default:
       return state
@@ -152,11 +179,22 @@ export function reducer(state: State, action: Action) {
 
 function useStandalone() {
   const [state, dispatch] = useReducer(reducer, {
+    serverStatus: "stopped",
     connections: [],
     selectedClientId: null,
     orphanedCommands: [],
     commandListeners: [],
   })
+
+  // Called when the server successfully starts
+  const serverStarted = useCallback(() => {
+    dispatch({ type: ActionTypes.ServerStarted, payload: undefined })
+  }, [])
+
+  // Called when the server stops
+  const serverStopped = useCallback(() => {
+    dispatch({ type: ActionTypes.ServerStopped, payload: undefined })
+  }, [])
 
   // Called when we have client details. NOTE: Commands can start flying in before this gets called!
   const connectionEstablished = useCallback((connection: ReactotronConnection) => {
@@ -188,15 +226,22 @@ function useStandalone() {
     dispatch({ type: ActionTypes.AddCommandHandler, payload: callback })
   }, [])
 
+  const portInUse = useCallback(() => {
+    dispatch({ type: ActionTypes.PortInUse, payload: undefined })
+  }, [])
+
   return {
     ...state,
-    selectedConnection: state.connections.find(c => c.clientId === state.selectedClientId),
+    selectedConnection: state.connections.find((c) => c.clientId === state.selectedClientId),
     selectConnection,
+    serverStarted,
+    serverStopped,
     connectionEstablished,
     connectionDisconnected,
     commandReceived,
     clearSelectedConnectionCommands,
     addCommandListener,
+    portInUse,
   }
 }
 

--- a/apps/reactotron-app/src/renderer/contexts/Standalone/useStandalone.ts
+++ b/apps/reactotron-app/src/renderer/contexts/Standalone/useStandalone.ts
@@ -10,10 +10,10 @@ export enum ActionTypes {
   CommandReceived = "COMMAND_RECEIVED",
   ChangeSelectedClientId = "CHANGE_SELECTED_CLIENT_ID",
   AddCommandHandler = "ADD_COMMAND_HANDLER",
-  PortInUse = "PORT_IN_USE",
+  PortUnavailable = "PORT_UNAVAILABLE",
 }
 
-export type ServerStatus = "stopped" | "portInUse" | "started"
+export type ServerStatus = "stopped" | "portUnavailable" | "started"
 
 export interface ReactotronConnection {
   // Stuff shipped from core-server
@@ -53,7 +53,7 @@ type Action =
   | { type: ActionTypes.CommandReceived; payload: any } // TODO: Type this better!
   | { type: ActionTypes.ClearConnectionCommands }
   | { type: ActionTypes.AddCommandHandler; payload: (command: any) => void }
-  | { type: ActionTypes.PortInUse; payload: undefined }
+  | { type: ActionTypes.PortUnavailable; payload: undefined }
 
 export function reducer(state: State, action: Action) {
   switch (action.type) {
@@ -167,10 +167,10 @@ export function reducer(state: State, action: Action) {
       return produce(state, (draftState) => {
         draftState.commandListeners.push(action.payload)
       })
-    case ActionTypes.PortInUse:
+    case ActionTypes.PortUnavailable:
       return produce(state, (draftState) => {
-        console.error("Port in use!")
-        draftState.serverStatus = "portInUse"
+        console.error("Port unavailable!")
+        draftState.serverStatus = "portUnavailable"
       })
     default:
       return state
@@ -226,8 +226,8 @@ function useStandalone() {
     dispatch({ type: ActionTypes.AddCommandHandler, payload: callback })
   }, [])
 
-  const portInUse = useCallback(() => {
-    dispatch({ type: ActionTypes.PortInUse, payload: undefined })
+  const portUnavailable = useCallback(() => {
+    dispatch({ type: ActionTypes.PortUnavailable, payload: undefined })
   }, [])
 
   return {
@@ -241,7 +241,7 @@ function useStandalone() {
     commandReceived,
     clearSelectedConnectionCommands,
     addCommandListener,
-    portInUse,
+    portUnavailable,
   }
 }
 

--- a/lib/reactotron-core-contract/src/server-events.ts
+++ b/lib/reactotron-core-contract/src/server-events.ts
@@ -95,7 +95,7 @@ export const ServerEvent = {
   /**
    * Port is already in use
    */
-  portInUse: "portInUse",
+  portUnavailable: "portUnavailable",
 } as const
 
 export type ServerEventKey = keyof typeof ServerEvent
@@ -105,7 +105,7 @@ type StopPayload = any
 type ConnectPayload = PartialConnection
 type ConnectionEstablishedPayload = any
 type DisconnectPayload = any
-type PortInUsePayload = any
+type PortUnavailablePayload = any
 
 export type ServerEventMap = {
   [ServerEvent.command]: Command
@@ -114,7 +114,7 @@ export type ServerEventMap = {
   [ServerEvent.connect]: ConnectPayload
   [ServerEvent.connectionEstablished]: ConnectionEstablishedPayload
   [ServerEvent.disconnect]: DisconnectPayload
-  [ServerEvent.portInUse]: PortInUsePayload
+  [ServerEvent.portUnavailable]: PortUnavailablePayload
 }
 
 export type WebSocketEvent = (socket: WebSocket) => void

--- a/lib/reactotron-core-contract/src/server-events.ts
+++ b/lib/reactotron-core-contract/src/server-events.ts
@@ -92,6 +92,10 @@ export const ServerEvent = {
    * A client has disconnected.
    */
   disconnect: "disconnect",
+  /**
+   * Port is already in use
+   */
+  portInUse: "portInUse",
 } as const
 
 export type ServerEventKey = keyof typeof ServerEvent
@@ -101,6 +105,7 @@ type StopPayload = any
 type ConnectPayload = PartialConnection
 type ConnectionEstablishedPayload = any
 type DisconnectPayload = any
+type PortInUsePayload = any
 
 export type ServerEventMap = {
   [ServerEvent.command]: Command
@@ -109,6 +114,7 @@ export type ServerEventMap = {
   [ServerEvent.connect]: ConnectPayload
   [ServerEvent.connectionEstablished]: ConnectionEstablishedPayload
   [ServerEvent.disconnect]: DisconnectPayload
+  [ServerEvent.portInUse]: PortInUsePayload
 }
 
 export type WebSocketEvent = (socket: WebSocket) => void

--- a/lib/reactotron-core-server/README.md
+++ b/lib/reactotron-core-server/README.md
@@ -27,7 +27,7 @@ server.on("disconnect", (conn) => console.log("Disconnected", conn))
 // The server has stopped.
 server.on("stop", () => console.log("Reactotron stopped"))
 // Port is already in use
-server.on("portInUse", () => console.log("Port 9090 already in use"))
+server.on("portUnavailable", () => console.log("Port 9090 unavailable"))
 
 // start the server
 server.start()

--- a/lib/reactotron-core-server/README.md
+++ b/lib/reactotron-core-server/README.md
@@ -12,37 +12,31 @@ import { createServer } from "reactotron-core-server"
 // configure a server
 const server = createServer({
   port: 9090, // default
-
-  onStart: () => null, // fires when we start the server
-  onStop: () => null, // fires when we stop the server
-  onConnect: ({ id, address }) => null, // fires when a client connects
-  onDisconnect: ({ id, address }) => null, // fires when a client disconnects
-
-  // a handler that fires whenever a message is received
-  onCommand: ({ type, payload, messageId, date }) => {
-    switch (type) {
-      case "hello.client":
-        break
-      case "log":
-        break
-      case "state.action.complete":
-        break
-      case "state.values.response":
-        break
-      case "state.keys.response":
-        break
-      case "state.values.change":
-        break
-      case "api.response":
-        break
-      case "bench.report":
-        break
-    }
-  },
 })
+
+// The server has started.
+server.on("start", () => console.log("Reactotron started"))
+// A client has connected, but we don't know who it is yet.
+server.on("connect", () => console.log("Connected"))
+// A client has connected and provided us the initial detail we want.
+server.on("connectionEstablished", (conn) => console.log("Connection", conn))
+// A command has arrived from the client.
+server.on("command", (cmd) => console.log("Command: ", cmd))
+// A client has disconnected.
+server.on("disconnect", (conn) => console.log("Disconnected", conn))
+// The server has stopped.
+server.on("stop", () => console.log("Reactotron stopped"))
+// Port is already in use
+server.on("portInUse", () => console.log("Port 9090 already in use"))
 
 // start the server
 server.start()
+
+// check to see if it started
+if (!server.started) {
+  console.log("Server failed to start")
+  return
+}
 
 // say hello when we connect (this is automatic, you don't send this)
 server.send("hello.server", {})

--- a/lib/reactotron-core-server/src/reactotron-core-server.ts
+++ b/lib/reactotron-core-server/src/reactotron-core-server.ts
@@ -149,7 +149,7 @@ export default class Server {
       this.wss = new WebSocketServer({ port })
       this.wss.on("error", (error) => {
         if (error.message.includes("EADDRINUSE")) {
-          this.emitter.emit("portInUse", port)
+          this.emitter.emit("portUnavailable", port)
         } else {
           console.error(error)
         }

--- a/lib/reactotron-core-server/src/reactotron-core-server.ts
+++ b/lib/reactotron-core-server/src/reactotron-core-server.ts
@@ -144,8 +144,16 @@ export default class Server {
   start = () => {
     const { port } = this.options
     const httpsServerOptions = buildHttpsServerOptions(this.options.wss)
+
     if (!httpsServerOptions) {
       this.wss = new WebSocketServer({ port })
+      this.wss.on("error", (error) => {
+        if (error.message.includes("EADDRINUSE")) {
+          this.emitter.emit("portInUse", port)
+        } else {
+          console.error(error)
+        }
+      })
     } else {
       const server = createHttpsServer(httpsServerOptions)
       this.wss = new WebSocketServer({ server })


### PR DESCRIPTION
Fixes #1334.

This adds an icon to the left sidebar that indicates the server status: Stopped, Started, or Port Unavailable.

<table>
<tr><th>Server Started</th><th>Port 9090 Unavailable</th></tr>
<tr><td>
<img src="https://github.com/infinitered/reactotron/assets/1479215/273abeb1-1f0b-43e4-88c9-63bd46c25651" width="500" />
</td>
<td>
<img src="https://github.com/infinitered/reactotron/assets/1479215/60e0bb00-f7c2-4fa6-b8db-20f2d2dba18a" width="500" />
</td>
</tr>
</table>

Clicking the icon reloads Reactotron, which is a quick & dirty way to attempt reconnection. In the future, we can handle it more elegantly.
