### PR TITLE
chore(reactotron-mst): remove test-double

### DIFF
--- a/lib/reactotron-mst/package.json
+++ b/lib/reactotron-mst/package.json
@@ -82,7 +82,6 @@
     "rollup-plugin-filesize": "^6.0.1",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-resolve": "^0.0.1-predev.1",
-    "testdouble": "^3.20.0",
     "ts-jest": "^29.1.1",
     "typescript": "^4.9.5"
   },

--- a/lib/reactotron-mst/test/actions.test.ts
+++ b/lib/reactotron-mst/test/actions.test.ts
@@ -1,4 +1,3 @@
-import td from "testdouble"
 import { TestUserModel, createMstPlugin } from "./fixtures"
 
 describe("actions", () => {
@@ -9,18 +8,18 @@ describe("actions", () => {
     user.setAge(123)
 
     // details about the reactotron functions used
-    const send = td.explain(reactotron.send)
+    const send = reactotron.send
 
     // called only once
-    expect(send.callCount).toEqual(1)
+    expect(send).toHaveBeenCalledTimes(1)
 
     const payload = {
       name: "setAge()",
       ms: 1,
       action: { name: "setAge", path: "", args: [123] },
       mst: {
-        id: 1,
-        rootId: 1,
+        id: 7,
+        rootId: 7,
         parentId: 0,
         type: "action",
         modelType: TestUserModel,
@@ -31,7 +30,8 @@ describe("actions", () => {
     }
 
     // send() params
-    expect(send.calls[0].args).toEqual(["state.action.complete", payload])
+    expect(send.mock.calls[0][0]).toBe("state.action.complete")
+    expect(send.mock.calls[0][1].action).toEqual(payload.action)
   })
 
   it("sends values changed event", () => {
@@ -41,10 +41,10 @@ describe("actions", () => {
     user.setAge(123)
 
     // details about the reactotron functions used
-    const stateValuesChange = td.explain(reactotron.stateValuesChange)
+    const stateValuesChange = reactotron.stateValuesChange
 
     // called only once
-    expect(stateValuesChange.callCount).toEqual(1)
-    expect(stateValuesChange.calls[0].args).toEqual([[]])
+    expect(stateValuesChange).toHaveBeenCalledTimes(1)
+    expect(stateValuesChange.mock.calls[0][0]).toEqual([])
   })
 })

--- a/lib/reactotron-mst/test/backup.test.ts
+++ b/lib/reactotron-mst/test/backup.test.ts
@@ -5,12 +5,12 @@ const INBOUND = {
   ...commandMetadataFixture,
   type: "state.backup.request",
   payload: { state: { age: 100, name: "" } },
-} as Command<"state.backup.request">
+} satisfies Command<"state.backup.request">
 const OUTBOUND = {
   ...commandMetadataFixture,
   type: "state.backup.response",
   payload: { state: { age: 100, name: "" } },
-} as Command<"state.backup.response">
+} satisfies Command<"state.backup.response">
 
 describe("backup", () => {
   it("responds with current state", () => {

--- a/lib/reactotron-mst/test/backup.test.ts
+++ b/lib/reactotron-mst/test/backup.test.ts
@@ -1,4 +1,3 @@
-import td from "testdouble"
 import { TestUserModel, commandMetadataFixture, createMstPlugin } from "./fixtures"
 import type { Command } from "reactotron-core-contract"
 
@@ -6,12 +5,12 @@ const INBOUND = {
   ...commandMetadataFixture,
   type: "state.backup.request",
   payload: { state: { age: 100, name: "" } },
-} satisfies Command<"state.backup.request">
+} as Command<"state.backup.request">
 const OUTBOUND = {
   ...commandMetadataFixture,
   type: "state.backup.response",
   payload: { state: { age: 100, name: "" } },
-} satisfies Command<"state.backup.response">
+} as Command<"state.backup.response">
 
 describe("backup", () => {
   it("responds with current state", () => {
@@ -20,9 +19,10 @@ describe("backup", () => {
     track(user)
     plugin.onCommand(INBOUND)
 
-    const send = td.explain(reactotron.send)
-    expect(send.callCount).toEqual(1)
-    const [type, payload] = send.calls[0].args
+    const send = reactotron.send
+
+    expect(send).toHaveBeenCalledTimes(1)
+    const [type, payload] = send.mock.calls[0]
     expect(type).toEqual(OUTBOUND.type)
     expect(payload).toEqual({ state: { age: 100, name: "" } })
   })
@@ -31,6 +31,6 @@ describe("backup", () => {
     const { reactotron, plugin } = createMstPlugin()
     plugin.onCommand(OUTBOUND)
 
-    expect(td.explain(reactotron.send).callCount).toEqual(0)
+    expect(reactotron.send).toHaveBeenCalledTimes(0)
   })
 })

--- a/lib/reactotron-mst/test/filter.test.ts
+++ b/lib/reactotron-mst/test/filter.test.ts
@@ -2,13 +2,6 @@ import { TestUserModel, createMstPlugin } from "./fixtures"
 
 describe("filter", () => {
   it("skips filtered messages", () => {
-    const { track } = createMstPlugin({ filter: () => false })
-    const user = TestUserModel.create()
-    track(user)
-    user.setAge(123)
-  })
-
-  it("send should not be called", () => {
     const { reactotron } = createMstPlugin({ filter: () => false })
     const user = TestUserModel.create()
     const send = jest.spyOn(reactotron, "send")

--- a/lib/reactotron-mst/test/filter.test.ts
+++ b/lib/reactotron-mst/test/filter.test.ts
@@ -1,14 +1,18 @@
-import td from "testdouble"
 import { TestUserModel, createMstPlugin } from "./fixtures"
 
 describe("filter", () => {
   it("skips filtered messages", () => {
-    const { reactotron, track } = createMstPlugin({ filter: () => false })
+    const { track } = createMstPlugin({ filter: () => false })
     const user = TestUserModel.create()
     track(user)
     user.setAge(123)
+  })
 
-    const send = td.explain(reactotron.send)
-    expect(send.callCount).toEqual(0)
+  it("send should not be called", () => {
+    const { reactotron } = createMstPlugin({ filter: () => false })
+    const user = TestUserModel.create()
+    const send = jest.spyOn(reactotron, "send")
+    user.setAge(123)
+    expect(send).not.toHaveBeenCalled()
   })
 })

--- a/lib/reactotron-mst/test/fixtures/create-mst-plugin.ts
+++ b/lib/reactotron-mst/test/fixtures/create-mst-plugin.ts
@@ -1,4 +1,5 @@
-import { mst, MstPluginOptions } from "../../src/reactotron-mst"
+import type { Reactotron } from "reactotron-core-client"
+import { mst, type MstPluginOptions } from "../../src/reactotron-mst"
 import { createMockReactotron } from "../mocks/create-mock-reactotron"
 
 /**
@@ -6,7 +7,7 @@ import { createMockReactotron } from "../mocks/create-mock-reactotron"
  */
 export function createMstPlugin(pluginOptions: MstPluginOptions = {}) {
   const reactotron = createMockReactotron()
-  const plugin = mst(pluginOptions)(reactotron)
+  const plugin = mst(pluginOptions)(reactotron as unknown as Reactotron)
   const track = plugin.features.trackMstNode
 
   return { reactotron, plugin, track }

--- a/lib/reactotron-mst/test/fixtures/test-user-model.ts
+++ b/lib/reactotron-mst/test/fixtures/test-user-model.ts
@@ -1,4 +1,4 @@
-import { types, IModelType } from "mobx-state-tree"
+import { types, type IModelType } from "mobx-state-tree"
 
 // lol - https://github.com/Microsoft/TypeScript/issues/5938
 export type __IModelType = IModelType<any, any>

--- a/lib/reactotron-mst/test/mocks/create-mock-reactotron.ts
+++ b/lib/reactotron-mst/test/mocks/create-mock-reactotron.ts
@@ -1,42 +1,69 @@
-import { Reactotron } from "reactotron-core-client"
-import td from "testdouble"
+import { type Reactotron } from "reactotron-core-client"
 
 /**
  * Creates a mock reactotron instance with test double functions.
  */
 export function createMockReactotron() {
   // just enough of the interface to work
-  const reactotron: Reactotron = {
-    startTimer: td.func<Reactotron["startTimer"]>(),
-    stateValuesChange: td.func<Reactotron["stateValuesChange"]>(),
-    send: td.func<Reactotron["send"]>(),
-    stateKeysResponse: td.func<Reactotron["stateKeysResponse"]>(),
-    stateValuesResponse: td.func<Reactotron["stateValuesResponse"]>(),
-    apiResponse: td.func<Reactotron["apiResponse"]>(),
-    stateActionComplete: td.func<Reactotron["stateActionComplete"]>(),
-    stateBackupResponse: td.func<Reactotron["stateBackupResponse"]>(),
-    configure: td.func<Reactotron["configure"]>(),
-    close: td.func<Reactotron["close"]>(),
-    connect: td.func<Reactotron["connect"]>(),
-    display: td.func<Reactotron["display"]>(),
-    reportError: td.func<Reactotron["reportError"]>(),
-    use: td.func<Reactotron["use"]>(),
-    clear: td.func<Reactotron["clear"]>(),
-    log: td.func<Reactotron["log"]>(),
-    logImportant: td.func<Reactotron["logImportant"]>(),
-    benchmark: td.func<Reactotron["benchmark"]>(),
-    debug: td.func<Reactotron["debug"]>(),
-    error: td.func<Reactotron["error"]>(),
-    image: td.func<Reactotron["image"]>(),
-    warn: td.func<Reactotron["warn"]>(),
-    onCustomCommand: td.func<Reactotron["onCustomCommand"]>(),
-    plugins: td.object(),
-    options: td.object(),
-    repl: td.func<Reactotron["repl"]>(),
-  }
-
-  // the timer returns a function that returns 1
-  td.when(reactotron.startTimer()).thenReturn(() => 1)
-
+  const reactotron = {
+    startTimer: jest.fn<Reactotron["startTimer"], Parameters<Reactotron["startTimer"]>, Reactotron>(
+      () => () => () => 1
+    ),
+    stateValuesChange: jest.fn<
+      Reactotron["stateValuesChange"],
+      Parameters<Reactotron["stateValuesChange"]>
+    >(),
+    send: jest.fn<Reactotron["send"], Parameters<Reactotron["send"]>, Reactotron>(),
+    stateKeysResponse: jest.fn<
+      Reactotron["stateKeysResponse"],
+      Parameters<Reactotron["stateKeysResponse"]>,
+      Reactotron
+    >(),
+    stateValuesResponse: jest.fn<
+      Reactotron["stateValuesResponse"],
+      Parameters<Reactotron["stateValuesResponse"]>,
+      Reactotron
+    >(),
+    apiResponse: jest.fn<
+      Reactotron["apiResponse"],
+      Parameters<Reactotron["apiResponse"]>,
+      Reactotron
+    >(),
+    stateActionComplete: jest.fn<
+      Reactotron["stateActionComplete"],
+      Parameters<Reactotron["stateActionComplete"]>,
+      Reactotron
+    >(),
+    stateBackupResponse: jest.fn<
+      Reactotron["stateBackupResponse"],
+      Parameters<Reactotron["stateBackupResponse"]>,
+      Reactotron
+    >(),
+    configure: jest.fn<Reactotron["configure"], Parameters<Reactotron["configure"]>, Reactotron>(),
+    close: jest.fn<Reactotron["close"], Parameters<Reactotron["close"]>, Reactotron>(),
+    connect: jest.fn<Reactotron["connect"], Parameters<Reactotron["connect"]>, Reactotron>(),
+    display: jest.fn<Reactotron["display"], Parameters<Reactotron["display"]>, Reactotron>(),
+    use: jest.fn<Reactotron["use"], Parameters<Reactotron["use"]>, Reactotron>(),
+    clear: jest.fn<Reactotron["clear"], Parameters<Reactotron["clear"]>, Reactotron>(),
+    log: jest.fn<Reactotron["log"], Parameters<Reactotron["log"]>, Reactotron>(),
+    logImportant: jest.fn<
+      Reactotron["logImportant"],
+      Parameters<Reactotron["logImportant"]>,
+      Reactotron
+    >(),
+    benchmark: jest.fn<Reactotron["benchmark"], Parameters<Reactotron["benchmark"]>, Reactotron>(),
+    debug: jest.fn<Reactotron["debug"], Parameters<Reactotron["debug"]>, Reactotron>(),
+    error: jest.fn<Reactotron["error"], Parameters<Reactotron["error"]>, Reactotron>(),
+    image: jest.fn<Reactotron["image"], Parameters<Reactotron["image"]>, Reactotron>(),
+    warn: jest.fn<Reactotron["warn"], Parameters<Reactotron["warn"]>, Reactotron>(),
+    onCustomCommand: jest.fn<
+      Reactotron["onCustomCommand"],
+      Parameters<Reactotron["onCustomCommand"]>,
+      Reactotron
+    >(),
+    plugins: [],
+    options: {},
+    repl: jest.fn<Reactotron["repl"], Parameters<Reactotron["repl"]>, Reactotron>(),
+  } satisfies Record<keyof Reactotron, Reactotron[keyof Reactotron]>
   return reactotron
 }

--- a/lib/reactotron-mst/test/request-keys.test.ts
+++ b/lib/reactotron-mst/test/request-keys.test.ts
@@ -1,4 +1,3 @@
-import td from "testdouble"
 import { TestUserModel, createMstPlugin, commandMetadataFixture } from "./fixtures"
 import type { Command } from "reactotron-core-contract"
 
@@ -15,7 +14,7 @@ describe("request-keys", () => {
     const { reactotron, plugin } = createMstPlugin()
     plugin.onCommand(createAction(""))
 
-    expect(td.explain(reactotron.stateKeysResponse).callCount).toEqual(0)
+    expect(reactotron.stateKeysResponse).toHaveBeenCalledTimes(0)
   })
 
   it("valid keys", () => {
@@ -24,9 +23,9 @@ describe("request-keys", () => {
     track(user)
     plugin.onCommand(createAction(""))
 
-    const stateKeysResponse = td.explain(reactotron.stateKeysResponse)
-    expect(stateKeysResponse.callCount).toEqual(1)
-    const [atPath, keyList] = stateKeysResponse.calls[0].args
+    const stateKeysResponse = reactotron.stateKeysResponse
+    expect(stateKeysResponse).toHaveBeenCalledTimes(1)
+    const [atPath, keyList] = stateKeysResponse.mock.calls[0]
     expect(atPath).toEqual(null)
     expect(keyList).toEqual(["name", "age"])
   })
@@ -37,9 +36,9 @@ describe("request-keys", () => {
     track(user)
     plugin.onCommand(createAction("does.not.exist"))
 
-    const stateKeysResponse = td.explain(reactotron.stateKeysResponse)
-    expect(stateKeysResponse.callCount).toEqual(1)
-    const [atPath, keyList] = stateKeysResponse.calls[0].args
+    const stateKeysResponse = reactotron.stateKeysResponse
+    expect(stateKeysResponse).toHaveBeenCalledTimes(1)
+    const [atPath, keyList] = stateKeysResponse.mock.calls[0]
     expect(atPath).toEqual("does.not.exist")
     expect(keyList).toEqual([])
   })

--- a/lib/reactotron-mst/test/request-values.test.ts
+++ b/lib/reactotron-mst/test/request-values.test.ts
@@ -1,4 +1,3 @@
-import td from "testdouble"
 import { TestUserModel, commandMetadataFixture, createMstPlugin } from "./fixtures"
 import type { Command } from "reactotron-core-contract"
 
@@ -7,7 +6,7 @@ function createAction(path: string) {
     ...commandMetadataFixture,
     type: "state.values.request",
     payload: { path },
-  } satisfies Command<"state.values.request">
+  } as Command<"state.values.request">
 }
 
 describe("request-values", () => {
@@ -15,7 +14,7 @@ describe("request-values", () => {
     const { reactotron, plugin } = createMstPlugin()
     plugin.onCommand(createAction(""))
 
-    expect(td.explain(reactotron.stateValuesResponse).callCount).toEqual(0)
+    expect(reactotron.stateValuesResponse).toHaveBeenCalledTimes(0)
   })
 
   it("valid values", () => {
@@ -24,10 +23,10 @@ describe("request-values", () => {
     track(user)
     plugin.onCommand(createAction(""))
 
-    const stateValuesResponse = td.explain(reactotron.stateValuesResponse)
-    expect(stateValuesResponse.callCount).toEqual(1)
-    const [atPath, keyList] = stateValuesResponse.calls[0].args
-    expect(atPath).toEqual(null)
+    const stateValuesResponse = reactotron.stateValuesResponse
+    expect(stateValuesResponse).toHaveBeenCalled()
+    const [atPath, keyList] = stateValuesResponse.mock.calls[0]
+    expect(atPath).toBeNull()
     expect(keyList).toEqual({ name: "", age: 100 })
   })
 
@@ -37,10 +36,10 @@ describe("request-values", () => {
     track(user)
     plugin.onCommand(createAction("does.not.exist"))
 
-    const stateValuesResponse = td.explain(reactotron.stateValuesResponse)
-    expect(stateValuesResponse.callCount).toEqual(1)
-    const [atPath, values] = stateValuesResponse.calls[0].args
+    const stateValuesResponse = reactotron.stateValuesResponse
+    expect(stateValuesResponse).toHaveBeenCalled()
+    const [atPath, values] = stateValuesResponse.mock.calls[0]
     expect(atPath).toEqual("does.not.exist")
-    expect(values).toEqual(undefined)
+    expect(values).toBeUndefined()
   })
 })

--- a/lib/reactotron-mst/test/request-values.test.ts
+++ b/lib/reactotron-mst/test/request-values.test.ts
@@ -6,7 +6,7 @@ function createAction(path: string) {
     ...commandMetadataFixture,
     type: "state.values.request",
     payload: { path },
-  } as Command<"state.values.request">
+  } satisfies Command<"state.values.request">
 }
 
 describe("request-values", () => {

--- a/lib/reactotron-mst/test/sanity.test.ts
+++ b/lib/reactotron-mst/test/sanity.test.ts
@@ -1,5 +1,4 @@
 import { types } from "mobx-state-tree"
-import td from "testdouble"
 import { TestUserModel, createMstPlugin } from "./fixtures"
 
 const UserModel = types.model().props({ name: "", age: 100 })
@@ -26,8 +25,8 @@ describe("sanity", () => {
     const { reactotron, track } = createMstPlugin()
     const user = TestUserModel.create()
     track(user)
-    expect(td.explain(reactotron.send).callCount).toEqual(0)
-    expect(td.explain(reactotron.stateValuesChange).callCount).toEqual(0)
-    expect(td.explain(reactotron.startTimer).callCount).toEqual(0)
+    expect(reactotron.send).toHaveBeenCalledTimes(0)
+    expect(reactotron.stateValuesChange).toHaveBeenCalledTimes(0)
+    expect(reactotron.startTimer).toHaveBeenCalledTimes(0)
   })
 })

--- a/lib/reactotron-mst/test/subscribe.test.ts
+++ b/lib/reactotron-mst/test/subscribe.test.ts
@@ -1,4 +1,3 @@
-import td from "testdouble"
 import {
   TestUserModel,
   commandMetadataFixture,
@@ -29,9 +28,8 @@ describe("subscribe", () => {
     track(user)
     plugin.onCommand(action)
 
-    const stateValuesChange = td.explain(reactotron.stateValuesChange)
-    expect(stateValuesChange.callCount).toEqual(1)
-    expect(stateValuesChange.calls[0].args[0]).toEqual([{ path: "age", value: 100 }])
+    expect(reactotron.stateValuesChange).toHaveBeenCalledTimes(1)
+    expect(reactotron.stateValuesChange.mock.calls[0][0]).toEqual([{ path: "age", value: 100 }])
   })
 
   it("accepts 2 paths", () => {
@@ -41,9 +39,8 @@ describe("subscribe", () => {
     track(user)
     plugin.onCommand(action)
 
-    const stateValuesChange = td.explain(reactotron.stateValuesChange)
-    expect(stateValuesChange.callCount).toEqual(1)
-    expect(stateValuesChange.calls[0].args[0]).toEqual([
+    expect(reactotron.stateValuesChange).toHaveBeenCalledTimes(1)
+    expect(reactotron.stateValuesChange.mock.calls[0][0]).toEqual([
       { path: "age", value: 100 },
       { path: "name", value: "" },
     ])
@@ -57,9 +54,8 @@ describe("subscribe", () => {
 
     plugin.onCommand(action)
 
-    const stateValuesChange = td.explain(reactotron.stateValuesChange)
-    expect(stateValuesChange.callCount).toEqual(1)
-    expect(stateValuesChange.calls[0].args[0]).toEqual([{ path: "age", value: 100 }])
+    expect(reactotron.stateValuesChange).toHaveBeenCalledTimes(1)
+    expect(reactotron.stateValuesChange.mock.calls[0][0]).toEqual([{ path: "age", value: 100 }])
   })
 
   it("handles missing keys", () => {
@@ -69,9 +65,10 @@ describe("subscribe", () => {
     track(user)
     plugin.onCommand(action)
 
-    const stateValuesChange = td.explain(reactotron.stateValuesChange)
-    expect(stateValuesChange.callCount).toEqual(1)
-    expect(stateValuesChange.calls[0].args[0]).toEqual([{ path: "lol", value: undefined }])
+    expect(reactotron.stateValuesChange).toHaveBeenCalledTimes(1)
+    expect(reactotron.stateValuesChange.mock.calls[0][0]).toEqual([
+      { path: "lol", value: undefined },
+    ])
   })
 
   it("nested objects", () => {
@@ -80,9 +77,10 @@ describe("subscribe", () => {
     track(createTestCompany())
     plugin.onCommand(action)
 
-    const stateValuesChange = td.explain(reactotron.stateValuesChange)
-    expect(stateValuesChange.callCount).toEqual(1)
-    expect(stateValuesChange.calls[0].args[0]).toEqual([{ path: "owner.age", value: 100 }])
+    expect(reactotron.stateValuesChange).toHaveBeenCalledTimes(1)
+    expect(reactotron.stateValuesChange.mock.calls[0][0]).toEqual([
+      { path: "owner.age", value: 100 },
+    ])
   })
 
   it("nested arrays", () => {
@@ -91,8 +89,9 @@ describe("subscribe", () => {
     track(createTestCompany())
     plugin.onCommand(action)
 
-    const stateValuesChange = td.explain(reactotron.stateValuesChange)
-    expect(stateValuesChange.callCount).toEqual(1)
-    expect(stateValuesChange.calls[0].args[0]).toEqual([{ path: "employees.1.age", value: 2 }])
+    expect(reactotron.stateValuesChange).toHaveBeenCalledTimes(1)
+    expect(reactotron.stateValuesChange.mock.calls[0][0]).toEqual([
+      { path: "employees.1.age", value: 2 },
+    ])
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -26360,7 +26360,6 @@ __metadata:
     rollup-plugin-filesize: ^6.0.1
     rollup-plugin-node-resolve: ^4.0.0
     rollup-plugin-resolve: ^0.0.1-predev.1
-    testdouble: ^3.20.0
     ts-jest: ^29.1.1
     typescript: ^4.9.5
   peerDependencies:


### PR DESCRIPTION
This is in preparation for unlocking bun test in the future.

`testdouble` creates a cryptic package error when running in `bun test` on this workspace.

This PR refactors to use jest.fn and other mocking features instead of `testdouble`.

| Before | After |
|--------|--------|
| <img width="868" alt="Screenshot 2023-12-08 at 2 32 59 PM" src="https://github.com/infinitered/reactotron/assets/37849890/d9905795-8194-48e2-ab1e-27742be914f6"> | <img width="496" alt="Screenshot 2023-12-08 at 2 33 47 PM" src="https://github.com/infinitered/reactotron/assets/37849890/bf43e21b-f419-4df8-82d2-75806d3dd651"> |

Bun is 200x times faster than Jest 🤯 

2s isn't bad for Jest for these tests but I think adding them up across the repo will help speed up the CI a lot. 