### PR TITLE
chore(dx): add generate:plugin script

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+scripts/template

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,7 +21,7 @@ You should see the reactotron electron app open on your machine with the develop
 
 ### Step 3: Making changes to `reactotron-app`
 
-Any changes you make to the main reactotron electron app that lives in `./apps/reactotron-app` will be reflected in the reactotron app that you started in step 1. You may need to kill the app and restart it to see your changes. 
+Any changes you make to the main reactotron electron app that lives in `./apps/reactotron-app` will be reflected in the reactotron app that you started in step 1. You may need to kill the app and restart it to see your changes.
 
 Remember to reload your Ignited react-native PizzaApp created in step 2 to reconnect the app to reactotron.
 
@@ -45,7 +45,17 @@ npx nx watch --all -- "npx zx scripts/install-workspace-packages-in-target.mjs ~
 
 Make sure that the path to your `PizzaApp` is an absolute path and not a relative one (i.e. `~/Code/PizzaApp` instead of `../PizzaApp`)
 
-> *Note: you must have already run `yarn` in your `PizzaApp` folder before running this script because is copies over the built js files from each reactotron library into the app's `node_modules` folder.*
+> _Note: you must have already run `yarn` in your `PizzaApp` folder before running this script because is copies over the built js files from each reactotron library into the app's `node_modules` folder._
+
+### Adding a new Reactotron plugin to `./lib`
+
+If you have a new plugin to contribute to the Reactotron ecosystem, you can start a new workspace by running the generate plugin script:
+
+```sh
+yarn generate:plugin my-plugin
+```
+
+This will create the necessary directory in `./lib` and get you started with a template. You'll want to implement your configuration and plugin in `./lib/reactotron-my-plugin/reactotron-my-plugin.ts`.
 
 ### Prepare for a pull request
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -57,6 +57,8 @@ yarn generate:plugin my-plugin
 
 This will create the necessary directory in `./lib` and get you started with a template. You'll want to implement your configuration and plugin in `./lib/reactotron-my-plugin/reactotron-my-plugin.ts`.
 
+Keep in mind this won't add the workspace to `.circleci/config.yml`, that must still be done manually when ready.
+
 ### Prepare for a pull request
 
 Before you open a pull request, please ensure that the following command runs without errors:

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "postinstall": "sh ./scripts/postinstall.sh",
     "clean": "sh ./scripts/clean.sh",
     "reset": "sh ./scripts/reset.sh",
+    "generate:plugin": "zx scripts/generate-plugin.mjs",
     "start": "yarn workspace reactotron-app start",
     "build": "npx nx run-many --target build",
     "build:watch": "npx nx watch --all -- npx nx run \\$NX_PROJECT_NAME:build",

--- a/scripts/generate-plugin.mjs
+++ b/scripts/generate-plugin.mjs
@@ -12,7 +12,7 @@ const pluginName = _pluginName.includes("reactotron")
   : `reactotron-${_pluginName}`;
 const targetDir = path.join(libDir, pluginName);
 
-console.log(`Module name: ${pluginName}`);
+console.log(`Plugin name: ${pluginName}`);
 // validate that the target directory exists
 if (fs.existsSync(targetDir)) {
   console.error(`Plugin already exists "${targetDir}" does not exist`);
@@ -21,19 +21,25 @@ if (fs.existsSync(targetDir)) {
 
 fs.mkdirSync(targetDir, { recursive: true });
 
+// static files that need to string replacements
+const filesToCopy = [
+  "tsconfig.json",
+  "LICENSE",
+  ".babelrc",
+  ".prettierignore",
+  ".prettierrc",
+  ".gitignore",
+];
+
+for (const file of filesToCopy) {
+  fs.copyFileSync(path.join(templateDir, file), path.join(targetDir, file));
+}
+
+// dynamic files where we need to update the plugin name
+// or camel case version of it, etc
 fs.writeFileSync(
   path.join(targetDir, "package.json"),
   JSON.stringify(getPackageJson({ pluginName }), null, 2)
-);
-
-fs.copyFileSync(
-  path.join(templateDir, "tsconfig.json"),
-  path.join(targetDir, "tsconfig.json")
-);
-
-fs.copyFileSync(
-  path.join(templateDir, "LICENSE"),
-  path.join(targetDir, "LICENSE")
 );
 
 fs.writeFileSync(

--- a/scripts/generate-plugin.mjs
+++ b/scripts/generate-plugin.mjs
@@ -32,18 +32,23 @@ fs.copyFileSync(
 );
 
 fs.copyFileSync(
-  path.join(templateDir, "project.json"),
-  path.join(targetDir, "project.json")
-);
-
-fs.copyFileSync(
   path.join(templateDir, "LICENSE"),
   path.join(targetDir, "LICENSE")
 );
 
 fs.writeFileSync(
+  path.join(targetDir, "project.json"),
+  createProjectJson({ pluginName })
+);
+
+fs.writeFileSync(
   path.join(targetDir, `README.md`),
   createTemplateREADME({ pluginName })
+);
+
+fs.writeFileSync(
+  path.join(targetDir, `rollup.config.ts`),
+  createTemplateRollupConfig({ pluginName })
 );
 
 const srcFolder = path.join(targetDir, "src");
@@ -103,6 +108,23 @@ function createTemplateIndex({ pluginName }) {
     /templatePlugin/g,
     `${camelize(pluginName.replace("reactotron-", ""))}Plugin`
   );
+  template = template.replace(/reactotron-template/g, pluginName);
+
+  return template;
+}
+
+/**
+ * Creates a project.json index for a plugin.
+ * @param {Object} options - The options for creating the template index.
+ * @param {string} options.pluginName - The name of the plugin.
+ * @returns {string}
+ */
+function createProjectJson({ pluginName }) {
+  let template = fs.readFileSync(
+    path.join(templateDir, "project.json"),
+    "utf8"
+  );
+
   template = template.replace(/reactotron-template/g, pluginName);
 
   return template;

--- a/scripts/generate-plugin.mjs
+++ b/scripts/generate-plugin.mjs
@@ -70,6 +70,11 @@ fs.writeFileSync(
   createTemplatePlugin({ pluginName })
 );
 
+console.log(`Voila! Start building: cd ${targetDir} && yarn`);
+console.log(
+  "FYI you may have to update .circleci/config.yml to include your new plugin when ready."
+);
+
 /**
  * Converts a string to camel case.
  * @param {string} str - The string to be converted.

--- a/scripts/generate-plugin.mjs
+++ b/scripts/generate-plugin.mjs
@@ -1,17 +1,16 @@
 #!/usr/bin/env zx
 // @ts-check
 import "zx/globals";
-import { ROOT_DIR } from "./tools/path.mjs";
 
 const libDir = path.join(__dirname, "../lib");
 const templateDir = path.join(__dirname, "./template");
 
-const [_pluginName] = process.argv;
+const [_nodePath, _zxPath, _fileName, _pluginName] = process.argv;
 
 const pluginName = _pluginName.includes("reactotron")
   ? _pluginName
   : `reactotron-${_pluginName}`;
-const targetDir = path(libDir, pluginName);
+const targetDir = path.join(libDir, pluginName);
 
 console.log(`Module name: ${pluginName}`);
 // validate that the target directory exists
@@ -23,44 +22,49 @@ if (fs.existsSync(targetDir)) {
 fs.mkdirSync(targetDir, { recursive: true });
 
 fs.writeFileSync(
-  path.join(outputDir, "package.json"),
-  JSON.stringify(getPackageJson(pluginName), null, 2)
+  path.join(targetDir, "package.json"),
+  JSON.stringify(getPackageJson({ pluginName }), null, 2)
 );
 
 fs.copyFileSync(
   path.join(templateDir, "tsconfig.json"),
-  path.join(outputDir, "tsconfig.json")
+  path.join(targetDir, "tsconfig.json")
 );
 
 fs.copyFileSync(
   path.join(templateDir, "project.json"),
-  path.join(outputDir, "project.json")
+  path.join(targetDir, "project.json")
 );
 
 fs.copyFileSync(
   path.join(templateDir, "LICENSE"),
-  path.join(outputDir, "LICENSE")
+  path.join(targetDir, "LICENSE")
 );
 
-const srcFolder = path.join(outputDir, "src");
+fs.writeFileSync(
+  path.join(targetDir, `README.md`),
+  createTemplateREADME({ pluginName })
+);
+
+const srcFolder = path.join(targetDir, "src");
 fs.mkdirSync(srcFolder, { recursive: true });
 
 fs.writeFileSync(
   path.join(srcFolder, `index.ts`),
-  createTemplatePlugin(pluginName)
+  createTemplateIndex({ pluginName })
 );
 
 fs.writeFileSync(
   path.join(srcFolder, `${pluginName}.ts`),
-  createTemplatePlugin(pluginName)
+  createTemplatePlugin({ pluginName })
 );
 
-fs.writeFileSync(
-  path.join(outputDir, `README.md`),
-  createTemplateREADME(pluginName)
-);
-
-function camelize(str: string) {
+/**
+ * Converts a string to camel case.
+ * @param {string} str - The string to be converted.
+ * @returns {string} - The camel case version of the string.
+ */
+function camelize(str) {
   const arr = str.split("-");
   const capital = arr.map((item, index) =>
     index
@@ -70,30 +74,72 @@ function camelize(str: string) {
   return capital.join("");
 }
 
-function createTemplateIndex({
-  pluginName
-}) {
-  let template = fs.readFileSync(path.join(templateDir, "index.ts"), "utf8");
+/**
+ * Converts a string to proper case.
+ * @param {string} str - The string to be converted.
+ * @returns {string} - The proper case version of the string.
+ */
+function properCase(str) {
+  const arr = str.split("-");
+  const capital = arr.map(
+    (item) => item.charAt(0).toUpperCase() + item.slice(1).toLowerCase()
+  );
+  return capital.join("");
+}
 
-  template = template.replace(/templatePlugin/g, camelize(pluginName));
+/**
+ * Creates a template index for a plugin.
+ * @param {Object} options - The options for creating the template index.
+ * @param {string} options.pluginName - The name of the plugin.
+ * @returns {string}
+ */
+function createTemplateIndex({ pluginName }) {
+  let template = fs.readFileSync(
+    path.join(templateDir, "src", "index.ts"),
+    "utf8"
+  );
+
+  template = template.replace(
+    /templatePlugin/g,
+    `${camelize(pluginName.replace("reactotron-", ""))}Plugin`
+  );
   template = template.replace(/reactotron-template/g, pluginName);
 
   return template;
 }
 
-function createTemplatePlugin({
-  pluginName
-}) {
-  let template = fs.readFileSync(path.join(templateDir, `reactotron-template.ts`), "utf8");
+/**
+ * Creates a template plugin
+ * @param {Object} options - The options for creating the template index.
+ * @param {string} options.pluginName - The name of the plugin.
+ * @returns {string}
+ */
+function createTemplatePlugin({ pluginName }) {
+  let template = fs.readFileSync(
+    path.join(templateDir, `src/reactotron-template.ts`),
+    "utf8"
+  );
 
-  template = template.replace(/templatePlugin/g, camelize(pluginName));
+  template = template.replace(
+    /Template/g,
+    `${properCase(pluginName.replace("reactotron-", ""))}`
+  );
+
+  template = template.replace(
+    /templatePlugin/g,
+    `${camelize(pluginName.replace("reactotron-", ""))}Plugin`
+  );
 
   return template;
 }
 
-function createTemplateREADME({
-  pluginName,
-}) {
+/**
+ * Creates a template index for a readme.
+ * @param {Object} options - The options for creating the template index.
+ * @param {string} options.pluginName - The name of the plugin.
+ * @returns {string}
+ */
+function createTemplateREADME({ pluginName }) {
   let template = fs.readFileSync(path.join(templateDir, "README.md"), "utf8");
 
   template = template.replace(/reactotron-template/g, pluginName);
@@ -101,24 +147,37 @@ function createTemplateREADME({
   return template;
 }
 
-function createTemplateRollupConfig({pluginName}) {
-  let template = fs.readFileSync(path.join(templateDir, "rollup.config.ts"), "utf8");
+/**
+ * Creates a rollup config for a plugin.
+ * @param {Object} options - The options for creating the template index.
+ * @param {string} options.pluginName - The name of the plugin.
+ * @returns {string} .
+ */
+function createTemplateRollupConfig({ pluginName }) {
+  let template = fs.readFileSync(
+    path.join(templateDir, "rollup.config.ts"),
+    "utf8"
+  );
 
   template = template.replace(/reactotron-template/g, pluginName);
 
   return template;
 }
 
-function getPackageJson({
-  pluginName
-}) {
+/**
+ * Get package.json for a plugin
+ * @param {Object} options - The options for creating the template index.
+ * @param {string} options.pluginName - The name of the plugin.
+ * @returns {string}
+ */
+function getPackageJson({ pluginName }) {
   const templatePackageJson = JSON.parse(
     fs.readFileSync(path.join(templateDir, "package.json"), "utf8")
   );
 
   templatePackageJson.name = pluginName;
-  templatePackageJson.homepage = `https://github.com/infinitered/reactotron/tree/master/lib/${pluginName}`,
-  templatePackageJson.repository = `https://github.com/infinitered/reactotron/tree/master/lib/${pluginName}`",
+  (templatePackageJson.homepage = `https://github.com/infinitered/reactotron/tree/master/lib/${pluginName}`),
+    (templatePackageJson.repository = `https://github.com/infinitered/reactotron/tree/master/lib/${pluginName}`);
 
   return templatePackageJson;
 }

--- a/scripts/generate-plugin.mjs
+++ b/scripts/generate-plugin.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env zx
+// @ts-check
+import "zx/globals";
+import { ROOT_DIR } from "./tools/path.mjs";
+
+const libDir = path.join(__dirname, "../lib");
+const templateDir = path.join(__dirname, "./template");
+
+const [_pluginName] = process.argv;
+
+const pluginName = _pluginName.includes("reactotron")
+  ? _pluginName
+  : `reactotron-${_pluginName}`;
+const targetDir = path(libDir, pluginName);
+
+console.log(`Module name: ${pluginName}`);
+// validate that the target directory exists
+if (fs.existsSync(targetDir)) {
+  console.error(`Plugin already exists "${targetDir}" does not exist`);
+  process.exit(1);
+}
+
+fs.mkdirSync(targetDir, { recursive: true });
+
+fs.writeFileSync(
+  path.join(outputDir, "package.json"),
+  JSON.stringify(getPackageJson(pluginName), null, 2)
+);
+
+fs.copyFileSync(
+  path.join(templateDir, "tsconfig.json"),
+  path.join(outputDir, "tsconfig.json")
+);
+
+fs.copyFileSync(
+  path.join(templateDir, "project.json"),
+  path.join(outputDir, "project.json")
+);
+
+fs.copyFileSync(
+  path.join(templateDir, "LICENSE"),
+  path.join(outputDir, "LICENSE")
+);
+
+const srcFolder = path.join(outputDir, "src");
+fs.mkdirSync(srcFolder, { recursive: true });
+
+fs.writeFileSync(
+  path.join(srcFolder, `index.ts`),
+  createTemplatePlugin(pluginName)
+);
+
+fs.writeFileSync(
+  path.join(srcFolder, `${pluginName}.ts`),
+  createTemplatePlugin(pluginName)
+);
+
+fs.writeFileSync(
+  path.join(outputDir, `README.md`),
+  createTemplateREADME(pluginName)
+);
+
+function camelize(str: string) {
+  const arr = str.split("-");
+  const capital = arr.map((item, index) =>
+    index
+      ? item.charAt(0).toUpperCase() + item.slice(1).toLowerCase()
+      : item.toLowerCase()
+  );
+  return capital.join("");
+}
+
+function createTemplateIndex({
+  pluginName
+}) {
+  let template = fs.readFileSync(path.join(templateDir, "index.ts"), "utf8");
+
+  template = template.replace(/templatePlugin/g, camelize(pluginName));
+  template = template.replace(/reactotron-template/g, pluginName);
+
+  return template;
+}
+
+function createTemplatePlugin({
+  pluginName
+}) {
+  let template = fs.readFileSync(path.join(templateDir, `reactotron-template.ts`), "utf8");
+
+  template = template.replace(/templatePlugin/g, camelize(pluginName));
+
+  return template;
+}
+
+function createTemplateREADME({
+  pluginName,
+}) {
+  let template = fs.readFileSync(path.join(templateDir, "README.md"), "utf8");
+
+  template = template.replace(/reactotron-template/g, pluginName);
+
+  return template;
+}
+
+function createTemplateRollupConfig({pluginName}) {
+  let template = fs.readFileSync(path.join(templateDir, "rollup.config.ts"), "utf8");
+
+  template = template.replace(/reactotron-template/g, pluginName);
+
+  return template;
+}
+
+function getPackageJson({
+  pluginName
+}) {
+  const templatePackageJson = JSON.parse(
+    fs.readFileSync(path.join(templateDir, "package.json"), "utf8")
+  );
+
+  templatePackageJson.name = pluginName;
+  templatePackageJson.homepage = `https://github.com/infinitered/reactotron/tree/master/lib/${pluginName}`,
+  templatePackageJson.repository = `https://github.com/infinitered/reactotron/tree/master/lib/${pluginName}`",
+
+  return templatePackageJson;
+}

--- a/scripts/template/.babelrc
+++ b/scripts/template/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+}

--- a/scripts/template/.gitignore
+++ b/scripts/template/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+coverage
+.nyc_output
+dist
+yarn-error.log
+.idea

--- a/scripts/template/.prettierignore
+++ b/scripts/template/.prettierignore
@@ -1,0 +1,9 @@
+**/.vscode
+**/android
+**/build
+**/compiled
+**/dist
+**/ios
+**/package.json
+**/release
+CHANGELOG.md

--- a/scripts/template/.prettierrc
+++ b/scripts/template/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "semi": false,
+  "trailingComma": "es5"
+}

--- a/scripts/template/LICENSE
+++ b/scripts/template/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 - 3016 Infinite Red LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/template/LICENSE
+++ b/scripts/template/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 - 3016 Infinite Red LLC.
+Copyright (c) 2016 - 2024 Infinite Red LLC.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/scripts/template/README.md
+++ b/scripts/template/README.md
@@ -1,0 +1,15 @@
+# reactotron-template
+
+TODO Description
+
+# Installing
+
+```bash
+npm i --save-dev reactotron-template
+# or
+yarn add -D reactotron-template
+```
+
+## Usage
+
+TODO Usage

--- a/scripts/template/package.json
+++ b/scripts/template/package.json
@@ -73,7 +73,6 @@
     "rollup-plugin-filesize": "^6.0.1",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-resolve": "^0.0.1-predev.1",
-    "testdouble": "^3.20.0",
     "ts-jest": "^29.1.1",
     "typescript": "^4.9.5"
   },

--- a/scripts/template/package.json
+++ b/scripts/template/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "reactotron-template",
+  "version": "0.0.1",
+  "description": "A Reactotron plugin",
+  "author": "Infinite Red",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/infinitered/reactotron/issues"
+  },
+  "homepage": "https://github.com/infinitered/reactotron/tree/master/lib/reactotron-template",
+  "repository": "https://github.com/infinitered/reactotron/tree/master/lib/reactotron-template",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/types/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "exports": {
+    "default": "./dist/index.js",
+    "import": "./dist/index.esm.js",
+    "types": "./dist/types/src/index.d.ts",
+    "react-native": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch --notify",
+    "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}'",
+    "format:check": "yarn format --check",
+    "format:write": "yarn format --write",
+    "prebuild": "yarn clean",
+    "build": "yarn tsc && yarn compile",
+    "prebuild:dev": "yarn clean",
+    "build:dev": "yarn tsc && yarn compile:dev",
+    "clean": "rimraf ./dist",
+    "lint": "eslint 'src/**/**.{ts,tsx}'",
+    "compile": "NODE_ENV=production rollup -c rollup.config.ts",
+    "compile:dev": "NODE_ENV=development rollup -c rollup.config.ts",
+    "tsc": "tsc",
+    "typecheck": "tsc",
+    "ci:test": "yarn test --runInBand"
+  },
+  "peerDependencies": {
+    "reactotron-core-client": "*"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.2",
+    "@babel/preset-env": "^7.23.2",
+    "@babel/preset-typescript": "^7.23.2",
+    "@types/jest": "^29.5.7",
+    "@types/node": "^18.18.8",
+    "@typescript-eslint/eslint-plugin": "^6.7.5",
+    "@typescript-eslint/parser": "^6.7.5",
+    "babel-eslint": "^10.1.0",
+    "babel-jest": "^29.7.0",
+    "eslint": "^8.53.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-n": "^16.2.0",
+    "eslint-plugin-promise": "^6.1.1",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-standard": "^5.0.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.0.3",
+    "react-native-mmkv": "^2.10.2",
+    "reactotron-core-client": "workspace:*",
+    "rollup": "^1.1.2",
+    "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-babel-minify": "^7.0.0",
+    "rollup-plugin-filesize": "^6.0.1",
+    "rollup-plugin-node-resolve": "^4.0.0",
+    "rollup-plugin-resolve": "^0.0.1-predev.1",
+    "testdouble": "^3.20.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^4.9.5"
+  },
+  "eslintConfig": {
+    "root": false
+  }
+}

--- a/scripts/template/project.json
+++ b/scripts/template/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "reactotron-template",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "version": {
+      "executor": "@jscutlery/semver:version"
+    }
+  }
+}

--- a/scripts/template/rollup.config.ts
+++ b/scripts/template/rollup.config.ts
@@ -1,0 +1,32 @@
+import resolve from "rollup-plugin-node-resolve";
+import babel from "rollup-plugin-babel";
+import filesize from "rollup-plugin-filesize";
+import minify from "rollup-plugin-babel-minify";
+
+const pkg = require("./package.json");
+
+export default {
+  input: "src/reactotron-template.ts",
+  output: [
+    {
+      file: pkg.main,
+      format: "commonjs",
+    },
+    {
+      file: pkg.module,
+      format: "esm",
+    },
+  ],
+  plugins: [
+    resolve({ extensions: [".ts"] }),
+    babel({ extensions: [".ts"], runtimeHelpers: true }),
+    process.env.NODE_ENV === "production"
+      ? minify({
+          comments: false,
+        })
+      : null,
+    filesize(),
+  ],
+  // put any external react-native- deps here
+  external: ["reactotron-core-client"],
+};

--- a/scripts/template/src/index.ts
+++ b/scripts/template/src/index.ts
@@ -1,0 +1,3 @@
+import templatePlugin from "./reactotron-template";
+export * from "./reactotron-template";
+export default templatePlugin;

--- a/scripts/template/src/reactotron-template.ts
+++ b/scripts/template/src/reactotron-template.ts
@@ -1,1 +1,7 @@
-export default function templatePlugin() {}
+export interface TemplateConfigPlugin {
+  // type your plugin config here
+}
+
+export default function templatePlugin() {
+  // implement your plugin here
+}

--- a/scripts/template/src/reactotron-template.ts
+++ b/scripts/template/src/reactotron-template.ts
@@ -1,0 +1,1 @@
+export default function templatePlugin() {}

--- a/scripts/template/tsconfig.json
+++ b/scripts/template/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "rootDir": ".",
+    "emitDeclarationOnly": true,
+    "emitDecoratorMetadata": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "module": "es2015",
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "sourceMap": true,
+    "target": "es5",
+    "skipLibCheck": true, // Temp?
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["src"]
+}


### PR DESCRIPTION
## Describe your PR
- Adds a plugin generator script to more easily set up a new workspace in `./lib`
- Usage: `yarn generate:plugin my-plugin`
- Adds a .nxignore file to skip the template directory from getting looked at by nx
- Adds blurb in `contributing.md` on how to use the script for a new plugin

## Questions
- [x] Do we want to modify CircleCI config with this?
  - Will stay manual for now, added a console.log for the notice and in documentation
- [x] Closes #1340 or is there more to it?
  - It will

## Screenshots

Example: `yarn generate:plugin apollo-client`

### Dir Structure

![image](https://github.com/infinitered/reactotron/assets/374022/f3c5d173-a54b-48b9-9d4f-ff6a284a4899)

### src Files

<img width="710" alt="image" src="https://github.com/infinitered/reactotron/assets/374022/04b79654-5960-4081-8631-cb3425b268f3">
