### PR TITLE
chore(eslint-plugin-reactotron): add jsdoc and Typescript types

### DIFF
--- a/lib/eslint-plugin-reactotron/src/index.ts
+++ b/lib/eslint-plugin-reactotron/src/index.ts
@@ -1,7 +1,25 @@
+import type { Linter } from "@typescript-eslint/utils/ts-eslint"
 import { noTronInProduction } from "./rules/no-tron-in-production"
 
-export default {
+/**
+ * Modify your plugins and rules inside `./eslintrc` or `eslintConfig` inside `package.json`
+ * 
+ * @example 
+ * ```json
+    "eslintConfig": {
+      "plugins": [
+        "reactotron"
+      ],
+      "rules": {
+        "reactotron/no-tron-in-production": "error"
+      }
+    }
+  ```
+ */
+const eslintPluginReactotron = {
   rules: {
     "no-tron-in-production": noTronInProduction,
   },
-}
+} satisfies Linter.Plugin
+
+export default eslintPluginReactotron

--- a/lib/eslint-plugin-reactotron/src/rules/no-tron-in-production.ts
+++ b/lib/eslint-plugin-reactotron/src/rules/no-tron-in-production.ts
@@ -2,6 +2,9 @@ import { ESLintUtils } from "@typescript-eslint/utils"
 
 const createRule = ESLintUtils.RuleCreator(() => `reactotron/no-tron-in-production`)
 
+/**
+ * Enforces `if (__DEV__)` around `console.tron` calls so they are not included in production.
+ */
 export const noTronInProduction = createRule({
   name: "no-tron-in-production",
   meta: {


### PR DESCRIPTION
This PR add some JS doc comments and Typescript types to trigger a `0.1.1` release