### PR TITLE
Add app name more places

### DIFF
--- a/apps/reactotron-app/src/renderer/components/ConnectionSelector/ConnectionSelector.story.tsx
+++ b/apps/reactotron-app/src/renderer/components/ConnectionSelector/ConnectionSelector.story.tsx
@@ -17,7 +17,6 @@ storiesOf("components/ConnectionSelector", module)
         commands: [],
         connected: true,
       }}
-      showName={false}
       onClick={() => {}}
     />
   ))
@@ -33,7 +32,6 @@ storiesOf("components/ConnectionSelector", module)
         commands: [],
         connected: true,
       }}
-      showName={false}
       onClick={() => {}}
     />
   ))
@@ -57,7 +55,6 @@ storiesOf("components/ConnectionSelector", module)
         commands: [],
         connected: true,
       }}
-      showName={false}
       onClick={() => {}}
     />
   ))
@@ -83,7 +80,6 @@ storiesOf("components/ConnectionSelector", module)
         commands: [],
         connected: true,
       }}
-      showName
       onClick={() => {}}
     />
   ))

--- a/apps/reactotron-app/src/renderer/components/ConnectionSelector/index.tsx
+++ b/apps/reactotron-app/src/renderer/components/ConnectionSelector/index.tsx
@@ -2,7 +2,12 @@ import React, { useMemo } from "react"
 import styled from "styled-components"
 import { MdCheckCircle as Checkmark } from "react-icons/md"
 
-import { getIcon, getPlatformName, getPlatformDetails } from "../../util/connectionHelpers"
+import {
+  getIcon,
+  getPlatformName,
+  getPlatformDetails,
+  getConnectionName,
+} from "../../util/connectionHelpers"
 import { Connection } from "../../contexts/Standalone/useStandalone"
 
 const Container = styled.div`
@@ -32,20 +37,23 @@ const InfoContainer = styled.div`
 interface ConnectionSelectorProps {
   selectedConnection: Connection | null
   connection: Connection
-  showName: boolean
   onClick: () => void
 }
 
 export default function ConnectionSelector({
   selectedConnection,
   connection,
-  showName,
   onClick,
 }: ConnectionSelectorProps) {
   const isSelected = selectedConnection && selectedConnection.clientId === connection.clientId
 
-  const [ConnectionIcon, platformName, platformDetails] = useMemo(() => {
-    return [getIcon(connection), getPlatformName(connection), getPlatformDetails(connection)]
+  const [ConnectionIcon, platformName, platformDetails, connectionName] = useMemo(() => {
+    return [
+      getIcon(connection),
+      getPlatformName(connection),
+      getPlatformDetails(connection),
+      getConnectionName(connection),
+    ]
   }, [connection])
 
   return (
@@ -59,11 +67,10 @@ export default function ConnectionSelector({
         )}
       </IconContainer>
       <InfoContainer>
+        <div>{connectionName}</div>
         <div>
-          {platformName}
-          {showName ? ` - ${connection.name}` : ""}
+          {platformName} {platformDetails}
         </div>
-        <div>{platformDetails}</div>
       </InfoContainer>
     </Container>
   )

--- a/apps/reactotron-app/src/renderer/components/Footer/Stateless.tsx
+++ b/apps/reactotron-app/src/renderer/components/Footer/Stateless.tsx
@@ -3,7 +3,11 @@ import styled from "styled-components"
 import { MdSwapVert as ExpandIcon } from "react-icons/md"
 
 import config from "../../config"
-import { getPlatformName, getPlatformDetails } from "../../util/connectionHelpers"
+import {
+  getPlatformName,
+  getPlatformDetails,
+  getConnectionName,
+} from "../../util/connectionHelpers"
 import { Connection, ServerStatus } from "../../contexts/Standalone/useStandalone"
 import ConnectionSelector from "../ConnectionSelector"
 
@@ -45,18 +49,12 @@ const ExpandContainer = styled.div`
   cursor: pointer;
 `
 
-function renderDeviceName(connection: Connection) {
-  return `${getPlatformName(connection)} ${getPlatformDetails(connection)}`
-}
-
 function renderExpanded(
   serverStatus: ServerStatus,
   connections: Connection[],
   selectedConnection: Connection | null,
   onChangeConnection: (clientId: string | null) => void
 ) {
-  const showName = connections && connections.some((c) => c.name !== connections[0].name)
-
   return (
     <ConnectionContainer>
       {connections.map((c) => (
@@ -64,12 +62,19 @@ function renderExpanded(
           key={c.id}
           selectedConnection={selectedConnection}
           connection={c}
-          showName={showName}
           onClick={() => onChangeConnection(c.clientId)}
         />
       ))}
     </ConnectionContainer>
   )
+}
+
+function renderConnectionInfo(selectedConnection) {
+  return selectedConnection
+    ? `${getConnectionName(selectedConnection)} | ${getPlatformName(
+        selectedConnection
+      )} ${getPlatformDetails(selectedConnection)}`
+    : "Waiting for connection"
 }
 
 function renderCollapsed(
@@ -86,10 +91,7 @@ function renderCollapsed(
         <ConnectionInfo>Port 9090 unavailable.</ConnectionInfo>
       )}
       {serverStatus === "started" && (
-        <ConnectionInfo>
-          device:{" "}
-          {selectedConnection ? renderDeviceName(selectedConnection) : "Waiting for connection"}
-        </ConnectionInfo>
+        <ConnectionInfo>{renderConnectionInfo(selectedConnection)}</ConnectionInfo>
       )}
       {serverStatus === "stopped" && <ConnectionInfo>Waiting for server to start</ConnectionInfo>}
     </>

--- a/apps/reactotron-app/src/renderer/pages/home/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/home/index.tsx
@@ -8,6 +8,7 @@ import {
   getPlatformDetails,
   getScreen,
   getIcon,
+  getConnectionName,
 } from "../../util/connectionHelpers"
 import { Connection } from "../../contexts/Standalone/useStandalone"
 import Welcome from "./welcome"
@@ -28,7 +29,7 @@ const ConnectionContainer = styled.div`
 const IconContainer = styled.div`
   color: ${(props) => props.theme.foregroundLight};
 `
-const PlatformName = styled.div`
+const AppName = styled.div`
   padding-left: 10px;
   color: ${(props) => props.theme.tag};
   width: 25%;
@@ -47,11 +48,12 @@ const Screen = styled.div`
 `
 
 function ConnectionCell({ connection }: { connection: Connection }) {
-  const [ConnectionIcon, platformName, platformDetails, screen] = useMemo(() => {
+  const [ConnectionIcon, platformName, platformDetails, connectionName, screen] = useMemo(() => {
     return [
       getIcon(connection),
       getPlatformName(connection),
       getPlatformDetails(connection),
+      getConnectionName(connection),
       getScreen(connection),
     ]
   }, [connection])
@@ -61,8 +63,10 @@ function ConnectionCell({ connection }: { connection: Connection }) {
       <IconContainer>
         <ConnectionIcon size={32} />
       </IconContainer>
-      <PlatformName>{platformName}</PlatformName>
-      <PlatformDetails>{platformDetails}</PlatformDetails>
+      <AppName>{connectionName}</AppName>
+      <PlatformDetails>
+        {platformName} {platformDetails}
+      </PlatformDetails>
       <Screen>{screen}</Screen>
     </ConnectionContainer>
   )

--- a/apps/reactotron-app/src/renderer/util/connectionHelpers.ts
+++ b/apps/reactotron-app/src/renderer/util/connectionHelpers.ts
@@ -67,6 +67,13 @@ export function getPlatformDetails(connection: Connection) {
   }
 }
 
+export function getConnectionName(connection: Connection) {
+  if (!connection.name) {
+    return "Name unknown"
+  }
+  return connection.name
+}
+
 export function getScreen(connection) {
   const { windowWidth, windowHeight, screenScale } = connection
 


### PR DESCRIPTION
Add the app name on Home and bottom connection bar. Always show the app name passed in by the app establishing the Reactotron connection. If it's not set, let the user know it's unknown so they know it's possible to add. Fixes https://github.com/infinitered/reactotron/issues/1351.

Worked on by @carlinisaacson @darinwilson and @lindboe !

**Home screen with connections**
<img width="736" alt="Screenshot 2023-12-15 at 10 19 37 AM" src="https://github.com/infinitered/reactotron/assets/5252268/830ee0d4-a604-4e6a-ae7d-8f8b89a95d5b">

**Bottom bar, collapsed**
<img width="812" alt="Screenshot 2023-12-15 at 10 20 05 AM" src="https://github.com/infinitered/reactotron/assets/5252268/b7906538-0a95-4577-baa7-37be5666b657">

**Bottom bar, expanded**
<img width="434" alt="Screenshot 2023-12-15 at 10 20 23 AM" src="https://github.com/infinitered/reactotron/assets/5252268/50c45ae6-cd4f-48a0-8993-c96e6c590e60">
