### PR TITLE
feat: Preferences screen

### DIFF
--- a/apps/reactotron-app/src/renderer/App.tsx
+++ b/apps/reactotron-app/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import Overlay from "./pages/reactNative/Overlay"
 import Storybook from "./pages/reactNative/Storybook"
 import CustomCommands from "./pages/customCommands"
 import Help from "./pages/help"
+import Preferences from "./pages/preferences"
 
 const AppContainer = styled.div`
   position: absolute;
@@ -67,6 +68,9 @@ function App() {
 
                 {/* Custom Commands */}
                 <Route path="/customCommands" element={<CustomCommands />} />
+
+                {/* Preferences */}
+                <Route path="/preferences" element={<Preferences />} />
 
                 {/* Help */}
                 <Route path="/help" element={<Help />} />

--- a/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
+++ b/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   MdMobiledataOff,
 } from "react-icons/md"
 import { FaMagic } from "react-icons/fa"
+import { FaGear } from "react-icons/fa6"
 import styled from "styled-components"
 
 import SideBarButton from "../SideBarButton"
@@ -82,6 +83,7 @@ function SideBar({ isOpen, serverStatus }: { isOpen: boolean; serverStatus: Serv
         iconColor={iconColor}
       />
 
+      <SideBarButton icon={FaGear} path="/preferences" text="Preferences" hideTopBar />
       <SideBarButton icon={MdLiveHelp} path="/help" text="Help" hideTopBar />
     </SideBarContainer>
   )

--- a/apps/reactotron-app/src/renderer/config.ts
+++ b/apps/reactotron-app/src/renderer/config.ts
@@ -1,6 +1,6 @@
 import Store from "electron-store"
 
-const schema = {
+export const schema = {
   serverPort: {
     type: "number",
     default: 9090,
@@ -9,9 +9,9 @@ const schema = {
     type: "number",
     default: 500,
   },
-}
+} as const
 
-const configStore = new Store({ schema } as any)
+const configStore = new Store({ schema })
 
 // Setup defaults
 if (!configStore.has("serverPort")) {

--- a/apps/reactotron-app/src/renderer/pages/preferences/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/preferences/index.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { Header } from "reactotron-core-ui"
+
+import configStore from "../../config"
+import { Container, Title, Text } from "../reactNative/components/Shared"
+import styled from "styled-components"
+
+export const Row = styled.div`
+  display: flex;
+  flex: 0;
+  flex-direction: row;
+  align-items: center;
+`
+
+const Preferences: React.FC = () => {
+  return (
+    <Container>
+      <Header title={"Preferences"} isDraggable />
+      <Container>
+        {Object.entries(configStore.store).map(([key, value]) => (
+          <Row key={key}>
+            <Title>{key}</Title>
+            <Text>{JSON.stringify(value)}</Text>
+          </Row>
+        ))}
+      </Container>
+    </Container>
+  )
+}
+
+export default Preferences


### PR DESCRIPTION
This PR address this issue https://github.com/infinitered/reactotron/issues/1354 by adding a new preferences screen that shows the electron store.

TODO: 
- [ ] Update "Settings" to navigate to new "Preferences" tab
<img width="341" alt="Screenshot 2023-12-15 at 10 31 05 AM" src="https://github.com/infinitered/reactotron/assets/37849890/8029e578-4a5c-4cd8-a42f-91f762ede678">

- [ ] Add keyboard shortcut `Cmd + ,` to navigate to "Preferences" tab
<img width="620" alt="Screenshot 2023-12-15 at 10 31 46 AM" src="https://github.com/infinitered/reactotron/assets/37849890/760aabfb-9b48-424a-82c9-74890a0517e1">

- [ ] Add styles to "Preferences" and allow for editing config values