### PR TITLE
ci(ir-docs): Force publish docs only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,11 +339,6 @@ workflows:
           filters:
             branches:
               ignore: *release_branch_names
-      - publish-docs/build_docs:
-          <<: *ir_docs_config
-          filters:
-            branches:
-              ignore: *release_branch_names
 
 
   # Allows for manual publishing of docs independent of deployment
@@ -373,11 +368,6 @@ workflows:
               only: *release_branch_names
           requires:
             - build_and_test
-      - publish-docs/publish_docs:
-          <<: *ir_docs_config
-          filters:
-            branches:
-              only: *release_branch_names
       - release_package:
           context:
             - infinitered-npm-package


### PR DESCRIPTION
Removes automated build/deploy of docs and leaves the force-publish-docs option, allowing it to be manually run from the circleCI console.