### PR TITLE
ci: require manual approval before building docs from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,6 @@ jobs:
             bundle exec fastlane setup
       - release-reactotron-app:
           os: MacOS
-
   release_app:
     <<: *defaults
     executor: *node_executor
@@ -339,8 +338,13 @@ workflows:
           filters:
             branches:
               ignore: *release_branch_names
-      - publish-docs/build_docs:
+      - hold:
+          type: approval
+          requires:
+            - build_and_test
+      - publish-docs/build_docs_with_approval:
           <<: *ir_docs_config
+          manual_approval_granted: "yes"
           filters:
             branches:
               ignore: *release_branch_names

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,15 +338,15 @@ workflows:
           filters:
             branches:
               ignore: *release_branch_names
-      - hold:
+      - approve_building_code_from_fork:
           type: approval
           requires:
             - build_and_test
-      - publish-docs/build_docs_with_approval:
+      - publish-docs/build_docs_include_forks:
           <<: *ir_docs_config
           manual_approval_granted: "yes"
           requires:
-            - hold
+            - approve_building_code_from_fork
           filters:
             branches:
               ignore: *release_branch_names

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,7 @@ workflows:
             - build_and_test
       - publish-docs/build_docs_include_forks:
           <<: *ir_docs_config
-          manual_approval_granted: "yes"
+          confirm_manual_approval_in_place: "yes"
           requires:
             - approve_building_code_from_fork
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,6 +345,8 @@ workflows:
       - publish-docs/build_docs_with_approval:
           <<: *ir_docs_config
           manual_approval_granted: "yes"
+          requires:
+            - hold
           filters:
             branches:
               ignore: *release_branch_names

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,21 +349,6 @@ workflows:
           filters:
             branches:
               ignore: *fork_prs_and_releases_filter
-      - approve_building_code_from_fork:
-          type: approval
-          requires:
-            - build_and_test
-          filters:
-            branches:
-              only: *pull_request_branch_filter
-      - publish-docs/build_docs_include_forks:
-          <<: *ir_docs_config
-          confirm_manual_approval_in_place: "yes"
-          requires:
-            - approve_building_code_from_fork
-          filters:
-            branches:
-              only: *pull_request_branch_filter
 
   #  pull_request_from_fork:
   #    # prevents the workflow from running when `force-publish-docs` is true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ anchors:
     - master
     - beta
     - alpha
+  fork_prs_and_releases_filter: &fork_prs_and_releases_filter
+    - /^(master|beta|alpha|pull\/\d+)$/
+  pull_requests: &pull_request_branch_filter
+    - /^pull\/\d+/
   # All branches
   release_branch_filter: &release_branch_filter
     ignore: /.*/
@@ -338,10 +342,20 @@ workflows:
           filters:
             branches:
               ignore: *release_branch_names
+      - publish-docs/build_docs:
+          <<: *ir_docs_config
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              ignore: *fork_prs_and_releases_filter
       - approve_building_code_from_fork:
           type: approval
           requires:
             - build_and_test
+          filters:
+            branches:
+              only: *pull_request_branch_filter
       - publish-docs/build_docs_include_forks:
           <<: *ir_docs_config
           confirm_manual_approval_in_place: "yes"
@@ -349,7 +363,34 @@ workflows:
             - approve_building_code_from_fork
           filters:
             branches:
-              ignore: *release_branch_names
+              only: *pull_request_branch_filter
+
+  #  pull_request_from_fork:
+  #    # prevents the workflow from running when `force-publish-docs` is true
+  #    when:
+  #      and:
+  #        - not: << pipeline.parameters.force-publish-docs >>
+  #        - true  # Placeholder for correct YAML structure
+  #    jobs:
+  #      - build_and_test:
+  #          filters:
+  #            branches:
+  #              only: *pull_request_branch_filter
+  #      - approve_building_code_from_fork:
+  #          type: approval
+  #          requires:
+  #            - build_and_test
+  #          filters:
+  #            branches:
+  #              only: *pull_request_branch_filter
+  #      - publish-docs/build_docs_include_forks:
+  #          <<: *ir_docs_config
+  #          confirm_manual_approval_in_place: "yes"
+  #          requires:
+  #            - approve_building_code_from_fork
+  #          filters:
+  #            branches:
+  #              only: *pull_request_branch_filter
 
 
   # Allows for manual publishing of docs independent of deployment

--- a/scripts/git-push-fork-to-upstream-repo.sh
+++ b/scripts/git-push-fork-to-upstream-repo.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eo pipefail
+
+: "${GPF_REACTOTRON_BRANCH:=build-trusted-commits}"
+
+REACTOTRON_REPO="git@github.com:infinitered/reactotron.git"
+BRANCH_SPEC=$1
+NUM_COLONS=$(echo "$BRANCH_SPEC" | awk -F: '{print NF-1}')
+
+if [ "$#" -ne 1 ] || [ "$NUM_COLONS" -ne 1 ] ; then
+    echo "Usage: <fork_username>:<fork_branchname>"
+    exit 1
+fi
+
+SOURCE_GH_USER=$(echo "$BRANCH_SPEC" | awk -F: '{print $1}')
+SOURCE_BRANCH=$(echo "$BRANCH_SPEC" | awk -F: '{print $2}')
+REPO_NAME=$(git remote get-url --push origin | awk -F/ '{print $NF}' | sed 's/\.git$//')
+
+# Check if 'fork-to-test' remote exists and then remove it
+if git config --get "remote.fork-to-test.url" > /dev/null; then
+    git remote remove fork-to-test
+    echo "Removed remote fork-to-test"
+else
+    echo "Remote fork-to-test does not exist, no need to remove it"
+fi
+
+git remote add fork-to-test "git@github.com:$SOURCE_GH_USER/$REPO_NAME.git"
+
+git fetch --all
+git push --force "$REACTOTRON_REPO" "refs/remotes/fork-to-test/$SOURCE_BRANCH:refs/heads/$GPF_REACTOTRON_BRANCH"
+git remote remove fork-to-test || echo "Removed new remote fork-to-test"
+
+cat <<EOF
+Forked branch '$BRANCH_SPEC' has been pushed to branch '$GPF_REACTOTRON_BRANCH'
+EOF


### PR DESCRIPTION
Separates out build step, so there is one for builds from forks that requires approval before building the docs.

This is prevent unreviewed code from being run in the CI environment.