### PR TITLE
docs(quick-start/react-native.md): remove host snippet for expo

### DIFF
--- a/docs/quick-start/react-native.md
+++ b/docs/quick-start/react-native.md
@@ -82,24 +82,6 @@ Reactotron.setAsyncStorageHandler(AsyncStorage)
   .connect();
 ```
 
-If you're using Expo, you will also need to configure the host:
-
-```js
-import Reactotron from "reactotron-react-native";
-import { NativeModules } from "react-native";
-import { AsyncStorage } from "@react-native-async-storage/async-storage";
-
-const hostname = NativeModules.SourceCode.scriptURL
-  .split("://")[1] // Remove the scheme
-  .split("/")[0] // Remove the path
-  .split(":")[0]; // Remove the port
-
-Reactotron.setAsyncStorageHandler(AsyncStorage)
-  .configure({ host: hostname }) // configure the hostname for Expo
-  .useReactNative() // add all built-in react native plugins
-  .connect(); // let's connect!
-```
-
 #### **Step 3 - Add Reactotron to your app**
 
 Finally, we import this on in one of:


### PR DESCRIPTION
This snippet is no longer necessary as of https://github.com/infinitered/reactotron/pull/1311