### PR TITLE
feat: make home screen default route when app starts up

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ On the [Releases](https://github.com/infinitered/reactotron/releases?q=reactotro
 
 ## Want to contribute? Here are some helpful reading materials:
 
-- [**Contributing**](./docs/contributing.md)
-- [**Architecture**](./docs/architecture.md)
-- [**Monorepo**](./docs/monorepo.md)
-- [**Release**](./docs/release.md)
+- [**Contributing**](./docs/contributing/index.md)
+- [**Architecture**](./docs/contributing/architecture.md)
+- [**Monorepo**](./docs/contributing/monorepo.md)
+- [**Release**](./docs/contributing/releasing.md)
 
 ## Troubleshooting
 

--- a/apps/reactotron-app/src/renderer/App.tsx
+++ b/apps/reactotron-app/src/renderer/App.tsx
@@ -52,10 +52,10 @@ function App() {
             <MainContainer>
               <Routes>
                 {/* Home */}
-                <Route path="/home" element={<Home />} />
+                <Route path="/" element={<Home />} />
 
                 {/* Timeline */}
-                <Route path="/" element={<Timeline />} />
+                <Route path="/timeline" element={<Timeline />} />
 
                 {/* State */}
                 <Route path="/state/subscriptions" element={<Subscriptions />} />

--- a/apps/reactotron-app/src/renderer/KeybindHandler.tsx
+++ b/apps/reactotron-app/src/renderer/KeybindHandler.tsx
@@ -91,10 +91,10 @@ function KeybindHandler({ children }) {
   const handlers = {
     // Tab Navigation
     OpenHomeTab: () => {
-      window.location.hash = "/home"
+      window.location.hash = "/"
     },
     OpenTimelineTab: () => {
-      window.location.hash = "/"
+      window.location.hash = "/timeline"
     },
     OpenStateTab: () => {
       window.location.hash = "/state/subscriptions"

--- a/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
+++ b/apps/reactotron-app/src/renderer/components/SideBar/Sidebar.tsx
@@ -56,8 +56,8 @@ function SideBar({ isOpen, serverStatus }: { isOpen: boolean; serverStatus: Serv
 
   return (
     <SideBarContainer $isOpen={isOpen}>
-      <SideBarButton image={reactotronLogo} path="/home" text="Home" hideTopBar />
-      <SideBarButton icon={MdReorder} path="/" text="Timeline" />
+      <SideBarButton image={reactotronLogo} path="/" text="Home" hideTopBar />
+      <SideBarButton icon={MdReorder} path="/timeline" text="Timeline" />
       <SideBarButton
         icon={MdAssignment}
         path="/state/subscriptions"

--- a/apps/reactotron-app/src/renderer/pages/help/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/help/index.tsx
@@ -99,7 +99,7 @@ function Help() {
             <ItemIconContainer>
               <RepoIcon size={40} />
             </ItemIconContainer>
-            Repo
+            GitHub Docs
           </ItemContainer>
           <ItemContainer onClick={openFeedback}>
             <ItemIconContainer>


### PR DESCRIPTION
# Overview

- Make Home screen the default route (set it to `/` instead of timeline)
- Update Sidebar components and keybindings accordingly
- Also updated the "Repo" item on the settings screen to be called "GitHub Docs" as a more clear place to find docs, in addition to the home screen

# Visual

https://github.com/infinitered/reactotron/assets/6894653/a8b58d73-2834-4790-b070-d17f624626f0

![CleanShot 2024-01-05 at 09 48 34@2x](https://github.com/infinitered/reactotron/assets/6894653/5d8d84f0-4328-4d7c-afc3-aa3d1a2c143b)


