### PR TITLE
feat(reactotron-app): Move android devices from Help to Home

### DIFF
--- a/apps/reactotron-app/src/renderer/pages/help/components/AndroidDeviceHelp.tsx
+++ b/apps/reactotron-app/src/renderer/pages/help/components/AndroidDeviceHelp.tsx
@@ -9,12 +9,23 @@ import { EmptyState, Tooltip } from "reactotron-core-ui"
 import { FaAndroid } from "react-icons/fa"
 import { ItemContainer, ItemIconContainer } from "../SharedStyles"
 
+const Container = styled.div`
+  margin: 50px 0px;
+`
+
+const TitleContainer = styled.div`
+  display: flex;
+  margin: 10px 0;
+  padding-bottom: 10px;
+  border-bottom: 1px solid ${(props) => props.theme.highlight};
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 20px;
+`
+
 const Title = styled.div`
   font-size: 18px;
-  margin: 10px 0;
-  padding-bottom: 2px;
   color: ${(props) => props.theme.foregroundLight};
-  border-bottom: 1px solid ${(props) => props.theme.highlight};
 `
 const AndroidDeviceListContainer = styled.div`
   display: flex;
@@ -86,9 +97,7 @@ const ArgInput = styled.input`
   font-size: 16px;
 `
 const PortSettingsIconContainer = styled.div`
-  float: right;
   color: ${(props) => props.theme.foregroundLight};
-  margin-left: 10px;
 `
 
 function AndroidDeviceHelp() {
@@ -127,16 +136,18 @@ function AndroidDeviceHelp() {
   }, [androidDevices.length])
 
   return (
-    <>
-      <TitleComponent />
-      <PortSettingsIconContainer
-        data-tip="Advanced Port Settings"
-        data-for="port-settings"
-        onClick={() => setPortsVisible(!portsVisible)}
-      >
-        <SettingsIcon size={20} />
-        <Tooltip id="port-settings" />
-      </PortSettingsIconContainer>
+    <Container>
+      <TitleContainer>
+        <TitleComponent />
+        <PortSettingsIconContainer
+          data-tip="Advanced Port Settings"
+          data-for="port-settings"
+          onClick={() => setPortsVisible(!portsVisible)}
+        >
+          <SettingsIcon size={20} />
+          <Tooltip id="port-settings" />
+        </PortSettingsIconContainer>
+      </TitleContainer>
       <Text>
         This shows all android devices connected to your machine via the{" "}
         <HighlightedText>adb devices</HighlightedText> command.
@@ -186,7 +197,7 @@ function AndroidDeviceHelp() {
           />
         )}
       </AndroidDeviceListContainer>
-    </>
+    </Container>
   )
 }
 

--- a/apps/reactotron-app/src/renderer/pages/help/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/help/index.tsx
@@ -11,7 +11,6 @@ import { FaTwitter as TwitterIcon } from "react-icons/fa"
 import { getApplicationKeyMap } from "react-hotkeys"
 import { ItemContainer, ItemIconContainer } from "./SharedStyles"
 import KeybindGroup from "./components/KeybindGroup"
-import AndroidDeviceHelp from "./components/AndroidDeviceHelp"
 import { reactotronLogo } from "../../images"
 
 const projectJson = require("../../../../package.json")
@@ -120,8 +119,6 @@ function Help() {
             @reactotron
           </ItemContainer>
         </ConnectContainer>
-
-        <AndroidDeviceHelp />
 
         <Title>Keystrokes</Title>
         {Keybinds()}

--- a/apps/reactotron-app/src/renderer/pages/home/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/home/index.tsx
@@ -12,18 +12,25 @@ import {
 } from "../../util/connectionHelpers"
 import { Connection } from "../../contexts/Standalone/useStandalone"
 import Welcome from "./welcome"
+import AndroidDeviceHelp from "../help/components/AndroidDeviceHelp"
 
 const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
 `
+const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  overflow-y: scroll;
+`
 
 const ConnectionContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 10px 0;
+  padding: 10px 20px;
   border-bottom: 1px solid ${(props) => props.theme.line};
 `
 const IconContainer = styled.div`
@@ -78,13 +85,16 @@ function Connections() {
   return (
     <Container>
       <Header title="Connections" isDraggable />
-      {connections.length > 0 ? (
-        connections.map((connection) => (
-          <ConnectionCell key={connection.clientId} connection={connection} />
-        ))
-      ) : (
-        <Welcome />
-      )}
+      <ContentContainer>
+        {connections.length > 0 ? (
+          connections.map((connection) => (
+            <ConnectionCell key={connection.clientId} connection={connection} />
+          ))
+        ) : (
+          <Welcome />
+        )}
+        <AndroidDeviceHelp />
+      </ContentContainer>
     </Container>
   )
 }

--- a/apps/reactotron-app/src/renderer/pages/home/welcome.tsx
+++ b/apps/reactotron-app/src/renderer/pages/home/welcome.tsx
@@ -6,13 +6,12 @@ import { EmptyState } from "reactotron-core-ui"
 
 const WelcomeText = styled.div`
   font-size: 1.25em;
-  margin-bottom: 5px;
 `
 
 const Container = styled.div`
   display: flex;
   padding: 4px 8px;
-  margin-top: 20px;
+  margin: 20px 0px 50px;
   border-radius: 4px;
   cursor: pointer;
   background-color: ${(props) => props.theme.backgroundLighter};


### PR DESCRIPTION
This moves Android devices list from the Help screen to the Home screen. This way it is more discoverable and can help the user get started with their Android devices when they first get started with Reactotron.

We also addressed some styling issues to give it a bit more spacing around text and sections.

## Screenshots
<img width="915" alt="image" src="https://github.com/infinitered/reactotron/assets/151139/4d3a57ce-2643-4340-a03c-e524f7862428">
<img width="915" alt="image" src="https://github.com/infinitered/reactotron/assets/151139/bcf4e4ab-caf6-4652-9063-6ca353f5fdd7">
<img width="871" alt="Screenshot 2024-01-05 at 3 14 13 PM" src="https://github.com/infinitered/reactotron/assets/151139/7302c430-765a-4383-beb2-33141526ef85">
<img width="915" alt="Screenshot 2024-01-05 at 3 11 18 PM" src="https://github.com/infinitered/reactotron/assets/151139/c7d4b176-37e4-4b53-aeac-5229d2cb54f7">



Co-authored-by: @markrickert @joshuayoes
