### PR TITLE
fix: update client types in reactotron-react-native-mmkv and reactotron-redux

### DIFF
--- a/lib/reactotron-react-native-mmkv/src/reactotron-react-native-mmkv.ts
+++ b/lib/reactotron-react-native-mmkv/src/reactotron-react-native-mmkv.ts
@@ -1,5 +1,5 @@
 import { type MMKV } from "react-native-mmkv"
-import type { Reactotron } from "reactotron-core-client"
+import type { ReactotronCore } from "reactotron-core-client"
 
 export interface MmkvPluginConfig {
   /**
@@ -28,13 +28,15 @@ interface Listener {
  * // pass your instance to the plugin
  * Reactotron.use(mmkvPlugin({ storage }))
  */
-export default function mmkvPlugin(config: MmkvPluginConfig) {
+export default function mmkvPlugin<Client extends ReactotronCore = ReactotronCore>(
+  config: MmkvPluginConfig
+) {
   /** This gives us the ability to ignore specific writes for less noise */
   const ignore = config.ignore ?? []
 
   let listener: Listener | undefined
 
-  return (reactotron: Reactotron) => {
+  return (reactotron: Client) => {
     const log = ({
       value,
       preview,

--- a/lib/reactotron-redux/src/commandHandler.ts
+++ b/lib/reactotron-redux/src/commandHandler.ts
@@ -1,6 +1,6 @@
 import {
   InferFeatures,
-  Reactotron,
+  ReactotronCore,
   StateResponsePlugin,
   assertHasStateResponsePlugin,
 } from "reactotron-core-client"
@@ -10,19 +10,21 @@ import pathObject from "./helpers/pathObject"
 import createSubscriptionsHandler from "./subscriptionsHandler"
 import { PluginConfig } from "./pluginConfig"
 
-export default function createCommandHandler(
-  reactotron: Reactotron,
+export default function createCommandHandler<Client extends ReactotronCore = ReactotronCore>(
+  reactotron: Client,
   pluginConfig: PluginConfig,
   onReduxStoreCreation: (func: () => void) => void
 ) {
   // make sure have loaded the StateResponsePlugin
   assertHasStateResponsePlugin(reactotron)
-  const client = reactotron as Reactotron & InferFeatures<Reactotron, StateResponsePlugin>
+  const client = reactotron as Client & InferFeatures<Client, StateResponsePlugin>
 
   // create our subscriptions handler
   const subscriptionsHandler = createSubscriptionsHandler(reactotron, onReduxStoreCreation)
 
   return ({ type, payload }: { type: string; payload?: any }) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore shhhhhh -- this is a private API
     const reduxStore = client.reduxStore
 
     switch (type) {
@@ -88,6 +90,8 @@ export default function createCommandHandler(
           restoredState = pluginConfig.onRestore(payload.state, reduxStore.getState())
         }
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore shhhhhh -- this is a private API
         client.reduxStore.dispatch({
           type: pluginConfig.restoreActionType,
           state: restoredState,

--- a/lib/reactotron-redux/src/enhancer.ts
+++ b/lib/reactotron-redux/src/enhancer.ts
@@ -1,11 +1,11 @@
-import { Reactotron } from "reactotron-core-client"
+import type { ReactotronCore } from "reactotron-core-client"
 
 import reactotronReducer from "./reducer"
 import createCustomDispatch from "./customDispatch"
 import { PluginConfig } from "./pluginConfig"
 
-export default function createEnhancer(
-  reactotron: Reactotron,
+export default function createEnhancer<Client extends ReactotronCore = ReactotronCore>(
+  reactotron: Client,
   pluginConfig: PluginConfig,
   handleStoreCreation: () => void
 ) {
@@ -22,6 +22,8 @@ export default function createEnhancer(
       }
 
       if (!skipSettingStore) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore shhhhhh -- this is a private API
         reactotron.reduxStore = store
         handleStoreCreation()
       }

--- a/lib/reactotron-redux/src/sendAction.ts
+++ b/lib/reactotron-redux/src/sendAction.ts
@@ -1,6 +1,8 @@
-import { Reactotron } from "reactotron-core-client"
+import type { ReactotronCore } from "reactotron-core-client"
 
-export default function createSendAction(reactotron: Reactotron) {
+export default function createSendAction<Client extends ReactotronCore = ReactotronCore>(
+  reactotron: Client
+) {
   return (action: { type: any }, ms: number, important = false) => {
     // let's call the type, name because that's "generic" name in Reactotron
     let { type: name } = action

--- a/lib/reactotron-redux/src/testHelpers.ts
+++ b/lib/reactotron-redux/src/testHelpers.ts
@@ -1,6 +1,8 @@
-import type { Reactotron } from "reactotron-core-client"
+import type { InferFeatures, Reactotron } from "reactotron-core-client"
+import type { ReactotronReduxPlugin } from "."
 
-export const defaultReactotronMock: Reactotron = {
+export const defaultReactotronMock: Reactotron &
+  InferFeatures<Reactotron, ReactotronReduxPlugin<Reactotron>> = {
   startTimer: jest.fn(),
   configure: jest.fn(),
   close: jest.fn(),
@@ -27,6 +29,8 @@ export const defaultReactotronMock: Reactotron = {
   stateValuesResponse: jest.fn(),
   warn: jest.fn(),
   createEnhancer: jest.fn(),
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore shhhhhh -- this is a private API
   reduxStore: jest.fn(),
   setReduxStore: jest.fn(),
 }


### PR DESCRIPTION
This PR fixes #1391 by allowing for the client types to be passed a generic, since the plugins expect `Reactotron`, which is a narrower type than  `ReactotronReactNative`.

## How to verify changes:
Ignite (replace ~/Code/ignite your path)
1. `cd ~/Code/ignite/boilerplate && npm i`
2. `npm i -d reactotron-react-native-mmkv reactotron-redux reactotron-react-native-mmkv`

Reactotron
1. `yarn`
2. `yarn build`
3. `npx zx scripts/install-workspace-packages-in-target.mjs ~/Code/ignite/boilerplate` Copy local changes into Ignite app 
4. Copy and paste in the following snippet
```ts
import Reactotron, { ReactotronReactNative } from "reactotron-react-native"
import mmkvPlugin from "reactotron-react-native-mmkv"
import { reactotronRedux } from "reactotron-redux"

import { MMKV } from "react-native-mmkv"

export const reactotron = Reactotron.configure({
  name: "Notos",
})
  .use(mmkvPlugin<ReactotronReactNative>({ storage: new MMKV() }))
  .use(reactotronRedux<ReactotronReactNative>())
  .connect()
```
5. See that type checking passes