### PR TITLE
fix(reactotron-app): added fontFamily from useTheme to Modal component

### DIFF
--- a/lib/reactotron-core-ui/src/components/Modal/index.tsx
+++ b/lib/reactotron-core-ui/src/components/Modal/index.tsx
@@ -71,6 +71,7 @@ const Modal: FunctionComponent<React.PropsWithChildren<Props>> = ({
           position: "auto" as any, // TODO: Fix this!
           top: "auto",
           bottom: "auto",
+          fontFamily: theme.fontFamily,
         },
       }}
     >


### PR DESCRIPTION
The modals were not applying the font family from the theme. 
Small change but I think it looks much better.

**Before:**  
<img width="557" alt="Timeline Filter" src="https://github.com/infinitered/reactotron/assets/55307134/60138b6b-9b6a-4b6b-bf69-b1ab28081fe2">
<img width="574" alt="Add Subscription" src="https://github.com/infinitered/reactotron/assets/55307134/a0e1ef03-3c90-4156-9142-39eb3752427b">
<img width="627" alt="Rename Snapshot" src="https://github.com/infinitered/reactotron/assets/55307134/7456033e-a0df-4483-a8f7-9eb95125bb10">
<img width="578" alt="Dispatch Action" src="https://github.com/infinitered/reactotron/assets/55307134/2ef22b44-6c5f-48a9-82ed-2db607616f11">

**After**
<img width="935" alt="Timeline Filter" src="https://github.com/infinitered/reactotron/assets/55307134/00bc74d9-6955-44b8-8f4c-366e2128bea7">
<img width="568" alt="Add Subscription" src="https://github.com/infinitered/reactotron/assets/55307134/50366c7f-8534-4319-810d-c9cb04a787dd">
<img width="564" alt="Rename Snapshot" src="https://github.com/infinitered/reactotron/assets/55307134/36bfc353-aa30-45ca-8400-15e0f64c3dbb">
<img width="571" alt="Dispatch Action" src="https://github.com/infinitered/reactotron/assets/55307134/f5c5ac16-e2d0-4958-a838-7e17db685381">

