### PR TITLE
fix(reactotron-redux): Typescript fixes for reactotron-redux interface

### DIFF
--- a/lib/reactotron-redux/src/index.ts
+++ b/lib/reactotron-redux/src/index.ts
@@ -24,9 +24,13 @@ function reactotronRedux<Client extends ReactotronCore = ReactotronCore>(
     })
   }
 
-  return (reactotron: Client) => {
+  function plugin<Client extends Reactotron = Reactotron>(reactotron: Client) {
     return {
+      // Fires when we receive a command from the Reactotron app.
       onCommand: createCommandHander(reactotron, mergedPluginConfig, onReduxStoreCreation),
+
+      // All keys in this object will be attached to the main Reactotron instance
+      // and available to be called directly.
       features: {
         createEnhancer: createEnhancer(reactotron, mergedPluginConfig, handleStoreCreation),
         setReduxStore: (store) => {
@@ -37,8 +41,10 @@ function reactotronRedux<Client extends ReactotronCore = ReactotronCore>(
         },
         reportReduxAction: createSendAction(reactotron),
       },
-    } satisfies Plugin<Reactotron>
+    } satisfies Plugin<Client>
   }
+
+  return plugin
 }
 
 export type ReactotronReduxPlugin<Client extends ReactotronCore = ReactotronCore> = ReturnType<


### PR DESCRIPTION
Adding `reactotron-redux` to a new Ignite app was causing Typescript issues for
```
.use(reactotronRedux())
```

I noticed that `reactotron-mst` worked fine, and the two had similar compiled TS definitions, except for the placement of generics. 

`reactotron-redux - index.d.ts`: 
```
declare function reactotronRedux<Client extends ReactotronCore = ReactotronCore>(pluginConfig?: PluginConfig): (reactotron: Client) => {

```
vs
`reactotron-mst - index.d.ts`:
```
export declare function mst(opts?: MstPluginOptions): <Client extends ReactotronCore = ReactotronCore>(reactotron: Client) => {
```

So as a result, I copied a bit of `reactotron-mst`'s plugin function to help influence the compiled output. 

I tested by copying the compiled output over to my Ignite project's `node_modules/reactotron-redux` and it worked 👍 