### PR TITLE
chore(docs): update reactotron-redux docs to include redux-toolkit

### DIFF
--- a/docs/plugins/redux.md
+++ b/docs/plugins/redux.md
@@ -55,10 +55,12 @@ ReactotronConfig, you'll need to add `reactotron-redux` as plugin
 + .use(reactotronRedux()) //  <- here i am!
   .connect() //Don't forget about me!
 
-+ export default reactotron
++ export default reactotron // also: export me so I can be referenced by Redux store
 ```
 
-Then, add enhancer from `Reactotron.createEnhancer()` to `createStore` as last parameter
+Then, add enhancer from `Reactotron.createEnhancer()`
+
+## Using Redux createStore
 
 ```diff
 import { createStore } from 'redux'
@@ -71,7 +73,7 @@ import { createStore } from 'redux'
 
 Note: passing enhancer as last argument requires redux@>=3.1.0
 
-## If you have middleware
+### If you have middleware
 
 ```diff
 import { createStore } from 'redux'
@@ -79,6 +81,18 @@ import { createStore } from 'redux'
 
 - const store = createStore(rootReducer, compose(middleware))
 + const store = createStore(rootReducer, compose(middleware, Reactotron.createEnhancer()))
+```
+
+## Using Redux-Toolkit configureStore
+
+Using (Redux-Toolkit's `configureStore`)[https://redux-toolkit.js.org/api/configureStore], add as an `enhancer`.
+
+```
+export const store = configureStore({
+  reducer: persistedReducer,
+  enhancers: (getDefaultEnhancers) => getDefaultEnhancers().concat(Reactotron.createEnhancer()),
+})
+
 ```
 
 # Options

--- a/docs/plugins/redux.md
+++ b/docs/plugins/redux.md
@@ -60,6 +60,17 @@ ReactotronConfig, you'll need to add `reactotron-redux` as plugin
 
 Then, add enhancer from `Reactotron.createEnhancer()`
 
+## Using Redux-Toolkit configureStore
+
+Using (Redux-Toolkit's `configureStore`)[https://redux-toolkit.js.org/api/configureStore], add as an `enhancer`.
+
+```
+export const store = configureStore({
+  reducer: persistedReducer,
+  enhancers: __DEV__ ? [Reactotron.createEnhancer!()] : [],
+})
+```
+
 ## Using Redux createStore
 
 ```diff
@@ -81,18 +92,6 @@ import { createStore } from 'redux'
 
 - const store = createStore(rootReducer, compose(middleware))
 + const store = createStore(rootReducer, compose(middleware, Reactotron.createEnhancer()))
-```
-
-## Using Redux-Toolkit configureStore
-
-Using (Redux-Toolkit's `configureStore`)[https://redux-toolkit.js.org/api/configureStore], add as an `enhancer`.
-
-```
-export const store = configureStore({
-  reducer: persistedReducer,
-  enhancers: (getDefaultEnhancers) => getDefaultEnhancers().concat(Reactotron.createEnhancer()),
-})
-
 ```
 
 # Options


### PR DESCRIPTION
It took some time for me to figure out how to properly integrate `reactotron-redux` with Redux Toolkit's `configureStore`. Since Redux Toolkit is the recommended method now, we should include in docs. 