### PR TITLE
feat(reactotron-app): Timeline deep-search

### DIFF
--- a/apps/example-app/app/i18n/en.ts
+++ b/apps/example-app/app/i18n/en.ts
@@ -44,6 +44,7 @@ const en = {
   networkingScreen: {
     title: "Reactotron automatically intercepts and logs network requests!",
     makeApiCall: "Make an API Call",
+    makeFailingApiCall: "Make a failing API Call",
   },
 
   repos: {

--- a/apps/example-app/app/screens/NetworkingScreen.tsx
+++ b/apps/example-app/app/screens/NetworkingScreen.tsx
@@ -25,6 +25,20 @@ export const NetworkingScreen: React.FC<NetworkingScreenProps> = function Networ
               .then((json) => console.log(json))
           }}
         />
+        <Button
+          tx="networkingScreen.makeFailingApiCall"
+          textStyle={$darkText}
+          style={$button}
+          onPress={() => {
+            try {
+              fetch("https://google.com/404")
+                .then((response) => response.json())
+                .then((json) => console.log(json))
+            } catch (error) {
+              console.log(error)
+            }
+          }}
+        />
       </View>
     </ScrollView>
   )

--- a/apps/reactotron-app/package.json
+++ b/apps/reactotron-app/package.json
@@ -56,6 +56,7 @@
     "electron-updater": "^6.1.7",
     "electron-window-state": "^5.0.3",
     "immer": "^10.0.3",
+    "lodash.debounce": "^4.0.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hotkeys": "^2.0.0",

--- a/lib/reactotron-core-ui/src/utils/filterCommands/filterCommands.test.ts
+++ b/lib/reactotron-core-ui/src/utils/filterCommands/filterCommands.test.ts
@@ -84,6 +84,49 @@ const TESTS = [
       { type: "ADUMMYOBJ", payload: { request: { url: "SEARCHURL" } } },
     ],
   },
+  {
+    name: "deep search results",
+    search: "SEARCH",
+    result: [
+      { type: "SEARCHTYPE" },
+      { type: "ADUMMYOBJ", payload: { message: "SEARCHMESSAGE" } },
+      { type: "ADUMMYOBJ", payload: { preview: "SEARCHPREVIEW" } },
+      { type: "ADUMMYOBJ", payload: { name: "SEARCHNAME" } },
+      { type: "ADUMMYOBJ", payload: { path: "SEARCHPATH" } },
+      { type: "ADUMMYOBJ", payload: { triggerType: "SEARCHTRIGGERTYPE" } },
+      { type: "ADUMMYOBJ", payload: { description: "SEARCHDESCRIPTION" } },
+      { type: "ADUMMYOBJ", payload: { request: { url: "SEARCHURL" } } },
+    ],
+  },
+  {
+    name: "deep search results - even deeper",
+    search: "ME",
+    result: [
+      { type: "ADUMMYOBJ", payload: { message: "SEARCHMESSAGE" } },
+      { type: "ADUMMYOBJ", payload: { name: "SEARCHNAME" } },
+    ],
+  },
+  {
+    name: "deep search results - case insensitive",
+    search: "me",
+    result: [
+      { type: "ADUMMYOBJ", payload: { message: "SEARCHMESSAGE" } },
+      { type: "ADUMMYOBJ", payload: { name: "SEARCHNAME" } },
+    ],
+  },
+  {
+    name: "deep search results - type case insensitive",
+    search: "myobj",
+    result: [
+      { type: "ADUMMYOBJ", payload: { message: "SEARCHMESSAGE" } },
+      { type: "ADUMMYOBJ", payload: { preview: "SEARCHPREVIEW" } },
+      { type: "ADUMMYOBJ", payload: { name: "SEARCHNAME" } },
+      { type: "ADUMMYOBJ", payload: { path: "SEARCHPATH" } },
+      { type: "ADUMMYOBJ", payload: { triggerType: "SEARCHTRIGGERTYPE" } },
+      { type: "ADUMMYOBJ", payload: { description: "SEARCHDESCRIPTION" } },
+      { type: "ADUMMYOBJ", payload: { request: { url: "SEARCHURL" } } },
+    ],
+  },
 ]
 
 describe("utils/filterCommands", () => {

--- a/lib/reactotron-core-ui/src/utils/filterCommands/index.ts
+++ b/lib/reactotron-core-ui/src/utils/filterCommands/index.ts
@@ -33,7 +33,23 @@ export function filterSearch(commands: any[], search: string) {
 
   const searchRegex = new RegExp(trimmedSearch.replace(/\s/, "."), "i")
 
-  const matching = (value: string) => value && typeof value === "string" && searchRegex.test(value)
+  const matching = (value: string) => {
+    if(!value) {
+      return false
+    }
+
+    if (typeof value === "string") {
+      return searchRegex.test(value)
+    } else {
+      try {
+        const stringifiedValue = JSON.stringify(value)
+        return searchRegex.test(stringifiedValue)
+      } catch (error) {
+        // console.log("Error stringifying value", value, error)
+        return false
+      }
+    }
+  }
 
   return commands.filter(
     (command) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -23453,6 +23453,7 @@ __metadata:
     immer: ^10.0.3
     jest: ^29.7.0
     jest-environment-jsdom: ^29.7.0
+    lodash.debounce: ^4.0.8
     mime: ^3.0.0
     prettier: ^3.0.3
     react: 18.2.0


### PR DESCRIPTION
This PR adapts @maxkomarychev's pull request #1181. 

The codebase has changed significantly since the PR was opened so this is a reimplementation of that same idea: if it's a string, search it. if it's not, try to stringify the object and search that string for whatever the user has typed into the timeline search box.

Can I get a couple reviewers to try this out with like an hours worth of reactotron timeline logs to see if this adversely affects performance in a real-world environment with lots of logs to search?

Before: 

![before](https://github.com/infinitered/reactotron/assets/139261/3350197c-4417-427b-ae9a-78d2fd322d6c)

After:

![after](https://github.com/infinitered/reactotron/assets/139261/9cc4a2e2-6d47-4891-b97e-0992cca6e7d6)
