### PR TITLE
feat(reactotron-app): Close the timeline search on 2nd “X” press

### DIFF
--- a/apps/reactotron-app/src/renderer/pages/timeline/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/timeline/index.tsx
@@ -49,6 +49,7 @@ const SearchInput = styled.input`
 `
 export const ButtonContainer = styled.div`
   padding: 10px;
+  cursor: pointer;
 `
 
 function Timeline() {
@@ -56,6 +57,7 @@ function Timeline() {
   const {
     isSearchOpen,
     toggleSearch,
+    closeSearch,
     setSearch,
     search,
     isReversed,
@@ -117,7 +119,15 @@ function Timeline() {
           <SearchContainer>
             <SearchLabel>Search</SearchLabel>
             <SearchInput autoFocus value={search} onChange={(e) => setSearch(e.target.value)} />
-            <ButtonContainer onClick={() => setSearch("")}>
+            <ButtonContainer
+              onClick={() => {
+                if (search === "") {
+                  closeSearch()
+                } else {
+                  setSearch("")
+                }
+              }}
+            >
               <FaTimes size={24} />
             </ButtonContainer>
           </SearchContainer>


### PR DESCRIPTION
The timeline search bar now closes when you click the "X" a second time, building on the functionality added in #1394.

Before:

![before](https://github.com/infinitered/reactotron/assets/139261/6007492c-9c2b-4482-aed1-e6780db15a66)

After:

![after](https://github.com/infinitered/reactotron/assets/139261/899ea721-6d04-4a7a-80fd-39c3deb6f5fc)
