### PR TITLE
feat(reactotron-app): JSON view of `AsyncStorage` values

### DIFF
--- a/lib/reactotron-core-ui/src/components/ContentView/index.tsx
+++ b/lib/reactotron-core-ui/src/components/ContentView/index.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import styled from "styled-components"
-import makeTable from "../../utils/makeTable"
+import makeTable, { RowContainer, KeyContainer, ValueContainer } from "../../utils/makeTable"
 import isShallow from "../../utils/isShallow"
 import TreeView from "../TreeView"
 
@@ -59,4 +59,26 @@ export default function ContentView({ value, treeLevel }: Props) {
   }
 
   return <StringContainer>{String(checkValue)}</StringContainer>
+}
+
+export const makeTableWithContentView = (obj: unknown) => {
+  const input = obj !== null && typeof obj === "object" ? obj : {}
+  const keys = Object.keys(input) ?? []
+
+  return (
+    <div>
+      {keys.map((key) => {
+        const value = input[key]
+
+        return (
+          <RowContainer key={key}>
+            <KeyContainer>{key}</KeyContainer>
+            <ValueContainer $value={value}>
+              <ContentView value={value} />
+            </ValueContainer>
+          </RowContainer>
+        )
+      })}
+    </div>
+  )
 }

--- a/lib/reactotron-core-ui/src/timelineCommands/AsyncStorageMutationCommand/index.tsx
+++ b/lib/reactotron-core-ui/src/timelineCommands/AsyncStorageMutationCommand/index.tsx
@@ -1,8 +1,9 @@
 import React, { FunctionComponent } from "react"
 
 import TimelineCommand from "../../components/TimelineCommand"
-import makeTable from "../../utils/makeTable"
+import { KeyContainer, RowContainer, ValueContainer } from "../../utils/makeTable"
 import { TimelineCommandProps, buildTimelineCommand } from "../BaseCommand"
+import { makeTableWithContentView } from "../../components/ContentView"
 
 interface AsyncStorageMutationPayload {
   action: string
@@ -29,7 +30,11 @@ const AsyncStorageMutationCommand: FunctionComponent<Props> = ({ command, isOpen
       isOpen={isOpen}
       setIsOpen={setIsOpen}
     >
-      {makeTable(payload.data)}
+      <RowContainer key={"action"}>
+        <KeyContainer>action</KeyContainer>
+        <ValueContainer $value={payload.action}>{payload.action}</ValueContainer>
+      </RowContainer>
+      {makeTableWithContentView(payload.data)}
     </TimelineCommand>
   )
 }

--- a/lib/reactotron-core-ui/src/timelineCommands/AsyncStorageMutationCommand/index.tsx
+++ b/lib/reactotron-core-ui/src/timelineCommands/AsyncStorageMutationCommand/index.tsx
@@ -30,10 +30,12 @@ const AsyncStorageMutationCommand: FunctionComponent<Props> = ({ command, isOpen
       isOpen={isOpen}
       setIsOpen={setIsOpen}
     >
-      <RowContainer key={"action"}>
-        <KeyContainer>action</KeyContainer>
-        <ValueContainer $value={payload.action}>{payload.action}</ValueContainer>
-      </RowContainer>
+      {payload.action && (
+        <RowContainer key={"action"}>
+          <KeyContainer>action</KeyContainer>
+          <ValueContainer $value={payload.action}>{payload.action}</ValueContainer>
+        </RowContainer>
+      )}
       {makeTableWithContentView(payload.data)}
     </TimelineCommand>
   )

--- a/lib/reactotron-core-ui/src/utils/makeTable.tsx
+++ b/lib/reactotron-core-ui/src/utils/makeTable.tsx
@@ -1,13 +1,13 @@
 import React from "react"
 import styled from "styled-components"
 
-const RowContainer = styled.div`
+export const RowContainer = styled.div`
   display: flex;
   justify-content: space-between;
   user-select: all;
   padding: 2px 0;
 `
-const KeyContainer = styled.div`
+export const KeyContainer = styled.div`
   width: 210px;
   padding-right: 10px;
   word-break: break-all;
@@ -19,7 +19,7 @@ const KeyContainer = styled.div`
 interface ValueContainerProps {
   $value: any
 }
-const ValueContainer = styled.div.attrs(() => ({}))<ValueContainerProps>`
+export const ValueContainer = styled.div.attrs(() => ({}))<ValueContainerProps>`
   flex: 1;
   word-break: break-all;
   user-select: text;


### PR DESCRIPTION
This PR Closes #947

`AsyncStorage` timeline events now show a collapsible tree view for objects that can be parsed as `JSON` values coming from localstorage instead of just a string.

The code I used to generate these screenshots is:

```tsx
<Button
  text="Save to AsyncStorage"
  onPress={() => {
    try {
      AsyncStorage.setItem(
        "@stringified_object",
        JSON.stringify({
          name: "reactotron-stringified deep object",
          deepObject: { a: 1, b: { three: () => {}, five: "infinitered" } },
        }),
      )
      AsyncStorage.setItem("@plain_string", "Just a string")
    } catch (e) {
      // saving error
    }
  }}
/>
```

Before:

![Screenshot 2024-01-23 at 8 11 26 PM](https://github.com/infinitered/reactotron/assets/139261/3d0a1a78-5f97-41b0-99e9-50b32e5a8d48)

After:

![Screenshot 2024-01-23 at 8 04 14 PM](https://github.com/infinitered/reactotron/assets/139261/e6f04971-7495-47f9-8d43-654fd8c03410)

As a followup, I'd like to do something where I could right-click the JSONTree object and copy the value to the clipboard.