### PR TITLE
fix(architecture): Attempt to mitigate compiler error: `Error: Default condition should be last one`

### DIFF
--- a/lib/eslint-plugin-reactotron/package.json
+++ b/lib/eslint-plugin-reactotron/package.json
@@ -18,10 +18,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "types": "./dist/types/src/index.d.ts",
-    "react-native": "./src/index.ts"
+    "react-native": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest --passWithNoTests",

--- a/lib/reactotron-apisauce/package.json
+++ b/lib/reactotron-apisauce/package.json
@@ -18,10 +18,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "types": "./dist/types/src/index.d.ts",
-    "react-native": "./src/index.ts"
+    "react-native": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest",

--- a/lib/reactotron-core-client/package.json
+++ b/lib/reactotron-core-client/package.json
@@ -18,10 +18,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "react-native": "./src/index.ts",
-    "types": "./dist/types/src/index.d.ts"
+    "types": "./dist/types/src/index.d.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest",

--- a/lib/reactotron-core-contract/package.json
+++ b/lib/reactotron-core-contract/package.json
@@ -18,10 +18,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "types": "./dist/types/src/index.d.ts",
-    "react-native": "./src/index.ts"
+    "react-native": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest --passWithNoTests",

--- a/lib/reactotron-core-server/package.json
+++ b/lib/reactotron-core-server/package.json
@@ -18,10 +18,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "types": "./dist/types/src/index.d.ts",
-    "react-native": "./src/index.ts"
+    "react-native": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest",

--- a/lib/reactotron-core-ui/package.json
+++ b/lib/reactotron-core-ui/package.json
@@ -14,10 +14,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "types": "./dist/types/src/index.d.ts",
-    "react-native": "./src/index.ts"
+    "react-native": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "start": "start-storybook -p 6006",

--- a/lib/reactotron-mst/package.json
+++ b/lib/reactotron-mst/package.json
@@ -19,9 +19,9 @@
   "react-native": "src/index.ts",
   "exports": {
     "import": "./dist/index.esm.js",
-    "default": "./dist/index.js",
     "react-native": "./src/index.ts",
-    "types": "./dist/types/src/index.d.ts"
+    "types": "./dist/types/src/index.d.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest",

--- a/lib/reactotron-react-js/package.json
+++ b/lib/reactotron-react-js/package.json
@@ -18,10 +18,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "types": "./dist/types/src/index.d.ts",
-    "react-native": "./src/index.ts"
+    "react-native": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest",

--- a/lib/reactotron-react-native-mmkv/package.json
+++ b/lib/reactotron-react-native-mmkv/package.json
@@ -18,10 +18,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "types": "./dist/types/src/index.d.ts",
-    "react-native": "./src/index.ts"
+    "react-native": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest --passWithNoTests",

--- a/lib/reactotron-react-native/package.json
+++ b/lib/reactotron-react-native/package.json
@@ -18,10 +18,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "types": "./dist/types/src/index.d.ts",
-    "react-native": "./src/index.ts"
+    "react-native": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest",

--- a/lib/reactotron-redux/package.json
+++ b/lib/reactotron-redux/package.json
@@ -18,10 +18,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "types": "./dist/types/src/index.d.ts",
-    "react-native": "./src/index.ts"
+    "react-native": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest",

--- a/scripts/template/package.json
+++ b/scripts/template/package.json
@@ -18,10 +18,10 @@
   "types": "dist/types/src/index.d.ts",
   "react-native": "src/index.ts",
   "exports": {
-    "default": "./dist/index.js",
     "import": "./dist/index.esm.js",
     "types": "./dist/types/src/index.d.ts",
-    "react-native": "./src/index.ts"
+    "react-native": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "test": "jest --passWithNoTests",


### PR DESCRIPTION
In some of the more recent versions of Reactotron libraries, people have been seeing errors and crashes due to

> Module not found: Error: Default condition should be last one

This follows the advice of [this stackoverflow post](https://stackoverflow.com/a/76127619) and moves `default` to be at the very bottom of the package.json’s `exports` object.
