### PR TITLE
chore(linter): Ignore Changelog files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,5 +55,6 @@ module.exports = {
     "**/build/**/*",
     "examples",
     "scripts",
+    "**/CHANGELOG.md",
   ],
 };


### PR DESCRIPTION
I noticed that the changelog file that gets created automatically during releases has been making packages fail the linter. We should ignore these auto-generated files.

See this commit for an example of what the linter autocorrected: https://github.com/infinitered/reactotron/commit/41a539c7e56e968a83ca61b100468f5267865ddd#diff-e76234a2ccf81f527051b0406a6719fa8e9b1687a2e46ae031556fee65199b3d

And [this CircleCI result](https://app.circleci.com/pipelines/github/infinitered/reactotron/2231/workflows/b3a4e492-be6a-4cd7-99d1-6a6c2d14857c/jobs/2872) for an example of the failure.