### PR TITLE
fix: added min width and height of electron window

### DIFF
--- a/apps/reactotron-app/src/main/index.ts
+++ b/apps/reactotron-app/src/main/index.ts
@@ -33,6 +33,8 @@ function createMainWindow() {
     y: mainWindowState.y,
     width: mainWindowState.width,
     height: mainWindowState.height,
+    minWidth: 800,
+    minHeight: 700,
     titleBarStyle: "hiddenInset",
     webPreferences: {
       nodeIntegration: true,


### PR DESCRIPTION
Added minWidth and minHeight property for electron BrowserWindow. Making sure all the sidebar buttons are visible and app has good amount of space. Previously electron window can be shrinked without any limitations.

I'm not entirely sure if this is the right way, maybe we can add a way to toggle the sidebar using a button and show a vertical scrollbar for sidebar whenever window height is too small 🤔 

Before:
[reactotron-before.webm](https://github.com/infinitered/reactotron/assets/76877078/422487cc-8f25-4db0-ae24-c8c1ae9d3c39)


After:
[reactotron-after.webm](https://github.com/infinitered/reactotron/assets/76877078/7f950b0a-abcc-4da2-86b2-81600137e49b)