### PR TITLE
fix: configureStore instructions for redux

### DIFF
--- a/docs/plugins/redux.md
+++ b/docs/plugins/redux.md
@@ -67,7 +67,7 @@ Using (Redux-Toolkit's `configureStore`)[https://redux-toolkit.js.org/api/config
 ```
 export const store = configureStore({
   reducer: persistedReducer,
-  enhancers: __DEV__ ? [Reactotron.createEnhancer!()] : [],
+  enhancers: __DEV__ ? [reactotron.createEnhancer!()] : [],
 })
 ```
 


### PR DESCRIPTION
fix docs to get `reactotron` from `ReactotronConfig` instead of `reactotron-react-native`