### PR TITLE
chore(github): Adds Contributing guide, issue template, and pull request templates.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing Guide
+
+Our current contributing guide can be found here: https://docs.infinite.red/reactotron/contributing/

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,28 @@
+name: Bug report
+description: For issues with running reactotron on your computer
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Before creating a **bug report**, please check the following:
+          * Ensure you're running the latest version release of both the Reactotron app and any Reactotron npm packages you are using.
+          * Ensure there isn't an existing issue for your bug. If there is, leave a comment on the existing issue.
+
+        If you're unsure whether you've hit a bug, check out the #react-native and #reactotron channels in our [Slack Community](https://community.infinite.red).
+
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: Also include a description of how to reproduce the bug
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Reactotron version
+      description: If you're not on release, provide the commit hash
+      placeholder: 3.5.1
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/infinitered/reactotron/discussions
+    about: For questions and discussion about Reactotron
+  - name: Slack Community
+    url: https://community.infinite.red/
+    about: Check out our community for more real-time discussion
+  - name: Twitter Community
+    url: https://twitter.com/i/communities/1509407040095068166
+    about: We post news, tips, requests for help, and other discussions.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Please verify the following:
+
+- [ ] `yarn build-and-test:local` passes
+- [ ] I have added tests for any new features, if relevant
+- [ ] `README.md` (or relevant documentation) has been updated with your changes
+
+## Describe your PR


### PR DESCRIPTION
I used the `.github` folder on `ignite` as a template for this.