### PR TITLE
chore(docs): Update types for reactotron-react-native-mmkv documentation

### DIFF
--- a/docs/plugins/react-native-mmkv.md
+++ b/docs/plugins/react-native-mmkv.md
@@ -10,20 +10,25 @@ The `react-native-mmkv` plugin allows you to track [MMKV](https://github.com/mro
 
 Import your mmkv storage instance:
 
-```js
+```tsx
 import { MMKV } from "react-native-mmkv";
 export const storage = new MMKV();
 ```
 
 To use the `mmkvPlugin`, add the additional plugin on the `import` line.
 
-```js
+```tsx
 import Reactotron from "reactotron-react-native"
+// success-line
+import type { ReactotronReactNative } from "reactotron-react-native"
+// success-line
 import mmkvPlugin from "reactotron-react-native-mmkv"
-import { storage } from "./mmkv/storage/instance/location" // <--- update this location
+// success-line
+import { storage } from "./mmkv/storage/instance/location" // <--- update this to your mmkv instance.
 ...
 Reactotron.configure()
-  .use(mmkvPlugin({ storage })) // <--- here we go!
+  // success-line
+  .use(mmkvPlugin<ReactotronReactNative>({ storage }))
   .connect()
 ```
 
@@ -33,8 +38,8 @@ And you're done! Now you can see your MMKV in Reactotron.
 
 `mmkvPlugin()` accepts an object with an `ignore` key. The value is an array of strings you would like to prevent sending to Reactotron.
 
-```js
-mmkvPlugin({
+```tsx
+mmkvPlugin<ReactotronReactNative>({
   storage,
   ignore: ["secret"],
 });

--- a/lib/reactotron-react-native-mmkv/README.md
+++ b/lib/reactotron-react-native-mmkv/README.md
@@ -14,20 +14,21 @@ yarn add -D reactotron-react-native-mmkv
 
 Import your mmkv storage instance:
 
-```js
+```tsx
 import { MMKV } from "react-native-mmkv"
 export const storage = new MMKV()
 ```
 
 To use the `mmkvPlugin`, add the additional plugin on the `import` line.
 
-```js
+```tsx
 import Reactotron from "reactotron-react-native"
+import type { ReactotronReactNative } from "reactotron-react-native"
 import mmkvPlugin from "reactotron-react-native-mmkv"
 import { storage } from "./mmkv/storage/instance/location" // <--- update this location
 ...
 Reactotron.configure()
-  .use(mmkvPlugin({ storage })) // <--- here we go!
+  .use(mmkvPlugin<ReactotronReactNative>({ storage })) // <--- here we go!
   .connect()
 ```
 
@@ -37,8 +38,8 @@ And you're done! Now you can see your MMKV in Reactotron.
 
 `mmkvPlugin()` accepts an object with an `ignore` key. The value is an array of strings you would like to prevent sending to Reactotron.
 
-```js
-mmkvPlugin({
+```tsx
+mmkvPlugin<ReactotronReactNative>({
   storage,
   ignore: ["secret"],
 })

--- a/lib/reactotron-react-native-mmkv/src/reactotron-react-native-mmkv.ts
+++ b/lib/reactotron-react-native-mmkv/src/reactotron-react-native-mmkv.ts
@@ -22,11 +22,12 @@ interface Listener {
  *
  * @example
  * import { MMKV } from 'react-native-mmkv'
+ * import type { ReactotronReactNative } from 'reactotron-react-native'
  * // create your storage instance
  * const storage = new MMKV()
  *
  * // pass your instance to the plugin
- * Reactotron.use(mmkvPlugin({ storage }))
+ * Reactotron.use(mmkvPlugin<ReactotronReactNative>({ storage }))
  */
 export default function mmkvPlugin<Client extends ReactotronCore = ReactotronCore>(
   config: MmkvPluginConfig


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

This adds types to the documentation for `reactotron-react-native-mmkv` to solve an issue where `tsc` was complaining about the object sent to `mmkvPlugin()`

![image](https://github.com/infinitered/reactotron/assets/139261/f6081157-02a3-4408-811c-b3a18a7b4c89)

![image](https://github.com/infinitered/reactotron/assets/139261/42b9ac16-4747-4a51-a5ed-a1984a589919)

Related: #1391