### PR TITLE
fix(reactotron-core-ui): Overlapping timeline layout

### DIFF
--- a/lib/reactotron-core-ui/src/components/TimelineCommand/index.tsx
+++ b/lib/reactotron-core-ui/src/components/TimelineCommand/index.tsx
@@ -80,6 +80,7 @@ const ChildrenContainer = styled.div`
   animation: fade-up 0.25s;
   will-change: transform opacity;
   padding: 0 40px 30px 40px;
+  word-break: break-word;
 `
 
 interface Props {


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [ ] I have added tests for any new features, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

When we have a long request parameter, it appears that the layout overlaps.

Please take a look at the following demo. 

Before:
![CleanShot 2024-03-21 at 6 19 25](https://github.com/infinitered/reactotron/assets/49778014/c1457bea-c3ad-488f-9b62-d53d788cc05d)


After:
![CleanShot 2024-03-21 at 6 39 19](https://github.com/infinitered/reactotron/assets/49778014/d25d4651-ca8b-41ee-a14d-0a70a6412203)
