### PR TITLE
docs(tips): escape angle bracket for MDX 3.0 compatibility 

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -38,7 +38,7 @@ if (__DEV__) {
 
 This means you'll need to be careful to use `require()` instead of `import` as `import` in ES6 are hoisted!
 
-**Flip Flop Alert!** Technically it's possible just to NPM `--save`. Maybe you want to do some debugging on a production build on a local device? That's cool. Just please, don't ship without conditionally shutting off `Reactotron.connect()`. <3
+**Flip Flop Alert!** Technically it's possible just to NPM `--save`. Maybe you want to do some debugging on a production build on a local device? That's cool. Just please, don't ship without conditionally shutting off `Reactotron.connect()`. \<3
 
 #### React JS
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

### Problem
1. `ir-docs` is upgrading to MDX 3.0
2. MDX 3.0 requires angle brackets to be escaped. 
3. there was a single bracket in the `tips.md` file

### Solution
1. I have escaped it, by adding a single backslash.

### Notes
* This has easily smashed my personal pr-description-to-length ratio record.
