### PR TITLE
docs: fix mardown link in redux plugin docs

### DIFF
--- a/docs/plugins/redux.md
+++ b/docs/plugins/redux.md
@@ -62,7 +62,7 @@ Then, add enhancer from `Reactotron.createEnhancer()`
 
 ## Using Redux-Toolkit configureStore
 
-Using (Redux-Toolkit's `configureStore`)[https://redux-toolkit.js.org/api/configureStore], add as an `enhancer`.
+Using [Redux-Toolkit's `configureStore`](https://redux-toolkit.js.org/api/configureStore), add as an `enhancer`.
 
 ```
 export const store = configureStore({


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

Fixes a markdown syntax error on the redux plugin docs page.