### PR TITLE
fix(docs): Omit AsyncStorage from basic ReactotronConfig.js

### DIFF
--- a/docs/quick-start/react-native.md
+++ b/docs/quick-start/react-native.md
@@ -33,10 +33,8 @@ Create a file in your root folder `ReactotronConfig.js` and paste this:
 
 ```js
 import Reactotron from "reactotron-react-native";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 
-Reactotron.setAsyncStorageHandler(AsyncStorage)
-  .configure() // controls connection & communication settings
+Reactotron.configure() // controls connection & communication settings
   .useReactNative() // add all built-in react native plugins
   .connect(); // let's connect!
 ```


### PR DESCRIPTION
## Please verify the following:

- [X ] `yarn build-and-test:local` passes
- [X ] I have added tests for any new features, if relevant
- [X ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

Without AsyncStorage dependency, the instruction in "Step 2 - Initialization" simply doesn´t work if the developer app doesn´t already use AsyncStorage, since it does ´Reactotron.setAsyncStorageHandler(AsyncStorage)´

Since AsyncStorage isn´t required for the base configuration, remove it.
