### PR TITLE
chore(package.json): remove --notify from "test:watch" script

### DIFF
--- a/apps/reactotron-app/package.json
+++ b/apps/reactotron-app/package.json
@@ -26,7 +26,7 @@
     "build:release": "node scripts/build.release.js",
     "release:artifacts": "node scripts/release.artifacts.js",
     "test": "jest",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",

--- a/lib/eslint-plugin-reactotron/package.json
+++ b/lib/eslint-plugin-reactotron/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest --passWithNoTests",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",

--- a/lib/reactotron-apisauce/package.json
+++ b/lib/reactotron-apisauce/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:write": "yarn format --write",
     "format:check": "yarn format --check",

--- a/lib/reactotron-core-client/package.json
+++ b/lib/reactotron-core-client/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",

--- a/lib/reactotron-core-contract/package.json
+++ b/lib/reactotron-core-contract/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest --passWithNoTests",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",

--- a/lib/reactotron-core-server/package.json
+++ b/lib/reactotron-core-server/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",

--- a/lib/reactotron-mst/package.json
+++ b/lib/reactotron-mst/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",

--- a/lib/reactotron-react-js/package.json
+++ b/lib/reactotron-react-js/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,css,yml}|**/*.{js,ts,tsx,json,css,yml}'",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",

--- a/lib/reactotron-react-native-mmkv/package.json
+++ b/lib/reactotron-react-native-mmkv/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest --passWithNoTests",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",

--- a/lib/reactotron-react-native/package.json
+++ b/lib/reactotron-react-native/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",

--- a/lib/reactotron-redux/package.json
+++ b/lib/reactotron-redux/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",

--- a/scripts/template/package.json
+++ b/scripts/template/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "jest --passWithNoTests",
-    "test:watch": "jest --watch --notify",
+    "test:watch": "jest --watch",
     "format": "prettier '*.{js,ts,tsx,json,md,css,yml}|**/*.{js,ts,tsx,json,md,css,yml}' --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "format:check": "yarn format --check",
     "format:write": "yarn format --write",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes

## Describe your PR

This PR removes the `--notify` flag from all of the `test:watch` scripts due to a failing dependency on [node-notifier](https://www.npmjs.com/package/node-notifier). I personally would not want my tests results to be notified in my computer notifications, so I see removing this as a good behavior.

## Before
1. `yarn workspace reactotron-mst test:watch`
2. See error:
<img width="794" alt="Screenshot 2024-07-03 at 2 57 45 PM" src="https://github.com/infinitered/reactotron/assets/37849890/2768375d-0fd6-4e52-88d0-21d6d035b364">

## After
1. `yarn workspace reactotron-mst test:watch`
2. See that test suite passes and goes into watch mode
<img width="426" alt="Screenshot 2024-07-03 at 3 00 15 PM" src="https://github.com/infinitered/reactotron/assets/37849890/af7ac14d-ce5d-4ec8-8c96-b55d1e0bf66c">

