### PR TITLE
chore: switch role to type to display valid separator in view menu

### DIFF
--- a/apps/reactotron-app/src/main/menu.ts
+++ b/apps/reactotron-app/src/main/menu.ts
@@ -95,22 +95,24 @@ function buildViewMenu(window: Electron.BrowserWindow, isDevelopment: boolean) {
         ;(window as any).toggleDevTools()
       },
     },
-    { role: "separator" },
+    { type: "separator" },
     { role: "togglefullscreen" },
     { role: "resetZoom" },
     { role: "zoomIn" },
-    { role: "zoomOut" },
-    { role: "separator" }
+    { role: "zoomOut" }
   )
 
   if (isDevelopment) {
-    viewMenu.submenu.push({
-      label: isDarwin ? "Reload" : "&Reload",
-      accelerator: isDarwin ? "Command+R" : "Ctrl+R",
-      click: () => {
-        window.webContents.reload()
-      },
-    })
+    viewMenu.submenu.push(
+      { type: "separator" },
+      {
+        label: isDarwin ? "Reload" : "&Reload",
+        accelerator: isDarwin ? "Command+R" : "Ctrl+R",
+        click: () => {
+          window.webContents.reload()
+        },
+      }
+    )
   }
 
   return viewMenu


### PR DESCRIPTION
## Please verify the following:

- [X] `yarn build-and-test:local` passes
- [X] I have added tests for any new features, if relevant
- [X] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
This updates the menu to use a type of separator instead of the whitespace at the bottom of the View menu. It is also updated for developer mode to not have a space at the bottom when not developer mode.