### PR TITLE
Fix non-null assertion issue in JavaScript sample code

### DIFF
--- a/docs/plugins/redux.md
+++ b/docs/plugins/redux.md
@@ -67,7 +67,11 @@ Using [Redux-Toolkit's `configureStore`](https://redux-toolkit.js.org/api/config
 ```
 export const store = configureStore({
   reducer: persistedReducer,
+  // TypeScript version:
   enhancers: __DEV__ ? [reactotron.createEnhancer!()] : [],
+
+   // JavaScript version:
+  enhancers: __DEV__ ? [Reactotron.createEnhancer?.()] : [],
 })
 ```
 


### PR DESCRIPTION
The sample code provided on the Redux integration page uses TypeScript-specific non-null assertion syntax (\!\) which causes errors in JavaScript environments. This commit updates the sample code to be compatible with JavaScript.

Changes:
- Removed TypeScript-specific \!\ from \
eactotron.createEnhancer!()\ in the sample code.
- Updated example to work properly in a JavaScript project.

Providing sample code for both TypeScript and JavaScript will enhance developer experience and support a broader range of projects.

## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
