### PR TITLE
fix(reactotron-react-native): new arch support

### DIFF
--- a/apps/example-app/app/devtools/ReactotronConfig.ts
+++ b/apps/example-app/app/devtools/ReactotronConfig.ts
@@ -17,6 +17,11 @@ import { goBack, resetRoot, navigate } from "app/navigators/navigationUtilities"
 import { Reactotron } from "./ReactotronClient"
 
 let DevMenu = null
+/**
+ * This Platform.OS iOS restriction can be lifted in React Native 0.77
+ * The `DevMenu` module was missing in Android for the New Architecture
+ * See this PR for more details: https://github.com/facebook/react-native/pull/46723
+ */
 if (Platform.OS === "ios") {
   DevMenu = require("react-native/Libraries/NativeModules/specs/NativeDevMenu")
 }

--- a/apps/example-app/app/devtools/ReactotronConfig.ts
+++ b/apps/example-app/app/devtools/ReactotronConfig.ts
@@ -3,7 +3,9 @@
  * free desktop app for inspecting and debugging your React Native app.
  * @see https://github.com/infinitered/reactotron
  */
-import { Platform, NativeModules } from "react-native"
+import { Platform, TurboModuleRegistry } from "react-native"
+// eslint-disable-next-line
+import DevMenuSpec from "react-native/src/private/specs/modules/NativeDevMenu"
 
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import { ArgType } from "reactotron-core-client"
@@ -29,7 +31,7 @@ const reactotron = Reactotron.configure({
     mst({
       /** ignore some chatty `mobx-state-tree` actions  */
       filter: (event) => /postProcessSnapshot|@APPLY_SNAPSHOT/.test(event.name) === false,
-    }),
+    })
   )
 
 if (Platform.OS !== "web") {
@@ -59,7 +61,7 @@ reactotron.onCustomCommand({
   command: "showDevMenu",
   handler: () => {
     Reactotron.log("Showing React Native dev menu")
-    NativeModules.DevMenu.show()
+    TurboModuleRegistry.getEnforcing<DevMenuSpec>("DevMenu")?.show()
   },
 })
 

--- a/apps/example-app/app/devtools/ReactotronConfig.ts
+++ b/apps/example-app/app/devtools/ReactotronConfig.ts
@@ -3,9 +3,9 @@
  * free desktop app for inspecting and debugging your React Native app.
  * @see https://github.com/infinitered/reactotron
  */
-import { Platform, TurboModuleRegistry } from "react-native"
-// eslint-disable-next-line
-import DevMenuSpec from "react-native/src/private/specs/modules/NativeDevMenu"
+import { Platform } from "react-native"
+// @ts-ignore
+import DevMenu from "react-native/Libraries/NativeModules/specs/NativeDevMenu"
 
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import { ArgType } from "reactotron-core-client"
@@ -61,7 +61,7 @@ reactotron.onCustomCommand({
   command: "showDevMenu",
   handler: () => {
     Reactotron.log("Showing React Native dev menu")
-    TurboModuleRegistry.getEnforcing<DevMenuSpec>("DevMenu")?.show()
+    DevMenu.show()
   },
 })
 

--- a/apps/example-app/app/devtools/ReactotronConfig.ts
+++ b/apps/example-app/app/devtools/ReactotronConfig.ts
@@ -4,8 +4,6 @@
  * @see https://github.com/infinitered/reactotron
  */
 import { Platform } from "react-native"
-// @ts-ignore
-import DevMenu from "react-native/Libraries/NativeModules/specs/NativeDevMenu"
 
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import { ArgType } from "reactotron-core-client"
@@ -17,6 +15,11 @@ import { clear } from "app/utils/storage"
 import { goBack, resetRoot, navigate } from "app/navigators/navigationUtilities"
 
 import { Reactotron } from "./ReactotronClient"
+
+let DevMenu = null
+if (Platform.OS === "ios") {
+  DevMenu = require("react-native/Libraries/NativeModules/specs/NativeDevMenu")
+}
 
 const reactotron = Reactotron.configure({
   name: require("../../package.json").name,
@@ -55,15 +58,18 @@ if (Platform.OS !== "web") {
  * NOTE: If you edit this file while running the app, you will need to do a full refresh
  * or else your custom commands won't be registered correctly.
  */
-reactotron.onCustomCommand({
-  title: "Show Dev Menu",
-  description: "Opens the React Native dev menu",
-  command: "showDevMenu",
-  handler: () => {
-    Reactotron.log("Showing React Native dev menu")
-    DevMenu.show()
-  },
-})
+
+if (Platform.OS === "ios") {
+  reactotron.onCustomCommand({
+    title: "Show Dev Menu",
+    description: "Opens the React Native dev menu",
+    command: "showDevMenu",
+    handler: () => {
+      Reactotron.log("Showing React Native dev menu")
+      DevMenu.show()
+    },
+  })
+}
 
 reactotron.onCustomCommand({
   title: "Reset Root Store",

--- a/lib/reactotron-react-native/src/helpers/getReactNativePlatformConstants.ts
+++ b/lib/reactotron-react-native/src/helpers/getReactNativePlatformConstants.ts
@@ -1,10 +1,33 @@
 import { Platform, PlatformIOSStatic, PlatformAndroidStatic } from "react-native"
 
-export default function getReactNativePlatformConstants(): any {
+interface PlatformConstants {
+  osRelease: string
+  model: string
+  serverHost: string
+  uiMode: string
+  serial: string
+  forceTouch: boolean
+  interfaceIdiom: string
+  systemName: string
+}
+
+export default function getReactNativePlatformConstants(): PlatformConstants {
+  const defaults: PlatformConstants = {
+    osRelease: "",
+    model: "",
+    serverHost: "",
+    uiMode: "",
+    serial: "",
+    forceTouch: false,
+    interfaceIdiom: "",
+    systemName: "",
+  }
+
   if (Platform.OS === "android") {
     const constants = Platform.constants as PlatformAndroidStatic["constants"]
 
     return {
+      ...defaults,
       osRelease: constants.Release,
       model: constants.Model,
       serverHost: constants.ServerHost,
@@ -14,11 +37,12 @@ export default function getReactNativePlatformConstants(): any {
   } else if (Platform.OS === "ios") {
     const constants = Platform.constants as PlatformIOSStatic["constants"]
     return {
+      ...defaults,
       forceTouch: constants.forceTouchAvailable || false,
       interfaceIdiom: constants.interfaceIdiom,
       systemName: constants.systemName,
     }
   }
 
-  return {}
+  return defaults
 }

--- a/lib/reactotron-react-native/src/helpers/getReactNativePlatformConstants.ts
+++ b/lib/reactotron-react-native/src/helpers/getReactNativePlatformConstants.ts
@@ -1,0 +1,24 @@
+import { Platform, PlatformIOSStatic, PlatformAndroidStatic } from "react-native"
+
+export default function getReactNativePlatformConstants(): any {
+  if (Platform.OS === "android") {
+    const constants = Platform.constants as PlatformAndroidStatic["constants"]
+
+    return {
+      osRelease: constants.Release,
+      model: constants.Model,
+      serverHost: constants.ServerHost,
+      uiMode: constants.uiMode,
+      serial: constants.Serial,
+    }
+  } else if (Platform.OS === "ios") {
+    const constants = Platform.constants as PlatformIOSStatic["constants"]
+    return {
+      forceTouch: constants.forceTouchAvailable || false,
+      interfaceIdiom: constants.interfaceIdiom,
+      systemName: constants.systemName,
+    }
+  }
+
+  return {}
+}

--- a/lib/reactotron-react-native/src/helpers/getReactNativeVersion.test.ts
+++ b/lib/reactotron-react-native/src/helpers/getReactNativeVersion.test.ts
@@ -7,23 +7,15 @@ describe("getReactNativeVersion", () => {
     expect(result).toBe(null)
   })
 
-  it("should return null if there is no reactNativeVersion on platform constants", () => {
-    const result = getReactNativeVersionWithModules({ PlatformConstants: {} })
-
-    expect(result).toBe(null)
-  })
-
   it("should return null if the major version is not a number", () => {
-    const result = getReactNativeVersionWithModules({
-      PlatformConstants: { reactNativeVersion: { major: "Hello" } },
-    })
+    const result = getReactNativeVersionWithModules({ reactNativeVersion: { major: "Hello" } })
 
     expect(result).toBe(null)
   })
 
   it("should return a version", () => {
     const result = getReactNativeVersionWithModules({
-      PlatformConstants: { reactNativeVersion: { major: 0, minor: 59, patch: 8, prerelease: 5 } },
+      reactNativeVersion: { major: 0, minor: 59, patch: 8, prerelease: 5 },
     })
 
     expect(result).toEqual("0.59.8-5")

--- a/lib/reactotron-react-native/src/helpers/getReactNativeVersion.ts
+++ b/lib/reactotron-react-native/src/helpers/getReactNativeVersion.ts
@@ -1,6 +1,14 @@
-import { NativeModules } from "react-native"
+/* eslint-disable */
+import PlatformConstantsIOSSpec from "react-native/src/private/specs/modules/NativePlatformConstantsIOS"
+import PlatformConstantsAndroidSpec from "react-native/src/private/specs/modules/NativePlatformConstantsAndroid"
+/* eslint-enable */
 import { getReactNativeVersionWithModules } from "./getReactNativeVersionWithModules"
+import { TurboModuleRegistry } from "react-native"
 
 export default function getReactNativeVersion(): string | null {
-  return getReactNativeVersionWithModules(NativeModules)
+  const constants =
+    TurboModuleRegistry.getEnforcing<PlatformConstantsIOSSpec | PlatformConstantsAndroidSpec>(
+      "PlatformConstants"
+    ).getConstants() || {}
+  return getReactNativeVersionWithModules(constants)
 }

--- a/lib/reactotron-react-native/src/helpers/getReactNativeVersion.ts
+++ b/lib/reactotron-react-native/src/helpers/getReactNativeVersion.ts
@@ -1,14 +1,6 @@
-/* eslint-disable */
-import PlatformConstantsIOSSpec from "react-native/src/private/specs/modules/NativePlatformConstantsIOS"
-import PlatformConstantsAndroidSpec from "react-native/src/private/specs/modules/NativePlatformConstantsAndroid"
-/* eslint-enable */
 import { getReactNativeVersionWithModules } from "./getReactNativeVersionWithModules"
-import { TurboModuleRegistry } from "react-native"
+import { Platform } from "react-native"
 
 export default function getReactNativeVersion(): string | null {
-  const constants =
-    TurboModuleRegistry.getEnforcing<PlatformConstantsIOSSpec | PlatformConstantsAndroidSpec>(
-      "PlatformConstants"
-    ).getConstants() || {}
-  return getReactNativeVersionWithModules(constants)
+  return getReactNativeVersionWithModules(Platform.constants)
 }

--- a/lib/reactotron-react-native/src/helpers/getReactNativeVersionWithModules.ts
+++ b/lib/reactotron-react-native/src/helpers/getReactNativeVersionWithModules.ts
@@ -1,14 +1,14 @@
-export function getReactNativeVersionWithModules(nativeModules: any): string | null {
+export function getReactNativeVersionWithModules(constants: any): string | null {
   try {
     // dodge some bullets
-    if (!nativeModules.PlatformConstants) return null
-    if (!nativeModules.PlatformConstants.reactNativeVersion) return null
+    if (!constants) return null
+    if (!constants.reactNativeVersion) return null
 
     // grab the raw numbers
-    const major = nativeModules.PlatformConstants.reactNativeVersion.major
-    const minor = nativeModules.PlatformConstants.reactNativeVersion.minor
-    const patch = nativeModules.PlatformConstants.reactNativeVersion.patch
-    const prerelease = nativeModules.PlatformConstants.reactNativeVersion.prerelease
+    const major = constants.reactNativeVersion.major
+    const minor = constants.reactNativeVersion.minor
+    const patch = constants.reactNativeVersion.patch
+    const prerelease = constants.reactNativeVersion.prerelease
 
     // check the major or jet
     if (typeof major !== "number") return null

--- a/lib/reactotron-react-native/src/plugins/devTools.ts
+++ b/lib/reactotron-react-native/src/plugins/devTools.ts
@@ -1,17 +1,20 @@
+import { TurboModuleRegistry } from "react-native"
 import type { ReactotronCore, Plugin } from "reactotron-core-client"
-import { NativeModules } from "react-native"
+// eslint-disable-next-line
+import DevMenuSpec from "react-native/src/private/specs/modules/NativeDevMenu"
 
 const devTools = () => () => {
+  const DevMenu = TurboModuleRegistry.getEnforcing<DevMenuSpec>("DevMenu").show()
   return {
     onCommand: (command) => {
       if (command.type !== "devtools.open" && command.type !== "devtools.reload") return
 
       if (command.type === "devtools.open") {
-        NativeModules.DevMenu.show()
+        DevMenu.show()
       }
 
       if (command.type === "devtools.reload") {
-        NativeModules.DevMenu.reload()
+        DevMenu.reload()
       }
     },
   } satisfies Plugin<ReactotronCore>

--- a/lib/reactotron-react-native/src/plugins/devTools.ts
+++ b/lib/reactotron-react-native/src/plugins/devTools.ts
@@ -1,6 +1,10 @@
+import { Platform } from "react-native"
 import type { ReactotronCore, Plugin } from "reactotron-core-client"
-// eslint-disable-next-line import/namespace, import/default
-import DevMenu from "react-native/Libraries/NativeModules/specs/NativeDevMenu"
+
+let DevMenu = { show: () => {}, reload: () => {} }
+if (Platform.OS === "ios") {
+  DevMenu = require("react-native/Libraries/NativeModules/specs/NativeDevMenu")
+}
 
 const devTools = () => () => {
   return {

--- a/lib/reactotron-react-native/src/plugins/devTools.ts
+++ b/lib/reactotron-react-native/src/plugins/devTools.ts
@@ -1,10 +1,8 @@
-import { TurboModuleRegistry } from "react-native"
 import type { ReactotronCore, Plugin } from "reactotron-core-client"
-// eslint-disable-next-line
-import DevMenuSpec from "react-native/src/private/specs/modules/NativeDevMenu"
+// eslint-disable-next-line import/namespace, import/default
+import DevMenu from "react-native/Libraries/NativeModules/specs/NativeDevMenu"
 
 const devTools = () => () => {
-  const DevMenu = TurboModuleRegistry.getEnforcing<DevMenuSpec>("DevMenu").show()
   return {
     onCommand: (command) => {
       if (command.type !== "devtools.open" && command.type !== "devtools.reload") return

--- a/lib/reactotron-react-native/src/reactotron-react-native.ts
+++ b/lib/reactotron-react-native/src/reactotron-react-native.ts
@@ -1,4 +1,4 @@
-import { Platform, NativeModules } from "react-native"
+import { Platform, TurboModuleRegistry } from "react-native"
 import { createClient } from "reactotron-core-client"
 import type {
   ClientOptions,
@@ -8,6 +8,12 @@ import type {
   ReactotronCore,
 } from "reactotron-core-client"
 import type { AsyncStorageStatic } from "@react-native-async-storage/async-storage"
+
+/* eslint-disable */
+import SourceCodeSpec from "react-native/src/private/specs/modules/NativeSourceCode"
+import PlatformConstantsIOSSpec from "react-native/src/private/specs/modules/NativePlatformConstantsIOS"
+import PlatformConstantsAndroidSpec from "react-native/src/private/specs/modules/NativePlatformConstantsAndroid"
+/* eslint-enable */
 
 import getReactNativeVersion from "./helpers/getReactNativeVersion"
 import getReactNativeDimensions from "./helpers/getReactNativeDimensions"
@@ -21,7 +27,10 @@ import devTools from "./plugins/devTools"
 import trackGlobalLogs from "./plugins/trackGlobalLogs"
 import { getHostFromUrl } from "./helpers/parseURL"
 
-const constants = NativeModules.PlatformConstants || {}
+const constants =
+  TurboModuleRegistry.getEnforcing<PlatformConstantsIOSSpec | PlatformConstantsAndroidSpec>(
+    "PlatformConstants"
+  ).getConstants() || {}
 
 const REACTOTRON_ASYNC_CLIENT_ID = "@REACTOTRON/clientId"
 
@@ -37,7 +46,8 @@ let tempClientId: string | null = null
 const getHost = (defaultHost = "localhost") => {
   try {
     // RN Reference: https://github.com/facebook/react-native/blob/main/packages/react-native/src/private/specs/modules/NativeSourceCode.js
-    const scriptURL = NativeModules?.SourceCode?.getConstants().scriptURL
+    const scriptURL =
+      TurboModuleRegistry.getEnforcing<SourceCodeSpec>("SourceCode").getConstants().scriptURL
     if (typeof scriptURL !== "string") throw new Error("Invalid non-string URL")
 
     return getHostFromUrl(scriptURL)

--- a/lib/reactotron-react-native/src/reactotron-react-native.ts
+++ b/lib/reactotron-react-native/src/reactotron-react-native.ts
@@ -1,4 +1,4 @@
-import { Platform, TurboModuleRegistry } from "react-native"
+import { Platform } from "react-native"
 import { createClient } from "reactotron-core-client"
 import type {
   ClientOptions,
@@ -8,13 +8,8 @@ import type {
   ReactotronCore,
 } from "reactotron-core-client"
 import type { AsyncStorageStatic } from "@react-native-async-storage/async-storage"
-
-/* eslint-disable */
-import SourceCodeSpec from "react-native/src/private/specs/modules/NativeSourceCode"
-import PlatformConstantsIOSSpec from "react-native/src/private/specs/modules/NativePlatformConstantsIOS"
-import PlatformConstantsAndroidSpec from "react-native/src/private/specs/modules/NativePlatformConstantsAndroid"
-/* eslint-enable */
-
+// eslint-disable-next-line import/namespace, import/default
+import NativeSourceCode from "react-native/Libraries/NativeModules/specs/NativeSourceCode"
 import getReactNativeVersion from "./helpers/getReactNativeVersion"
 import getReactNativeDimensions from "./helpers/getReactNativeDimensions"
 import asyncStorage, { AsyncStorageOptions } from "./plugins/asyncStorage"
@@ -26,11 +21,7 @@ import storybook from "./plugins/storybook"
 import devTools from "./plugins/devTools"
 import trackGlobalLogs from "./plugins/trackGlobalLogs"
 import { getHostFromUrl } from "./helpers/parseURL"
-
-const constants =
-  TurboModuleRegistry.getEnforcing<PlatformConstantsIOSSpec | PlatformConstantsAndroidSpec>(
-    "PlatformConstants"
-  ).getConstants() || {}
+import getReactNativePlatformConstants from "./helpers/getReactNativePlatformConstants"
 
 const REACTOTRON_ASYNC_CLIENT_ID = "@REACTOTRON/clientId"
 
@@ -46,8 +37,8 @@ let tempClientId: string | null = null
 const getHost = (defaultHost = "localhost") => {
   try {
     // RN Reference: https://github.com/facebook/react-native/blob/main/packages/react-native/src/private/specs/modules/NativeSourceCode.js
-    const scriptURL =
-      TurboModuleRegistry.getEnforcing<SourceCodeSpec>("SourceCode").getConstants().scriptURL
+    const scriptURL = NativeSourceCode.getConstants().scriptURL
+
     if (typeof scriptURL !== "string") throw new Error("Invalid non-string URL")
 
     return getHostFromUrl(scriptURL)
@@ -68,15 +59,7 @@ const DEFAULTS: ClientOptions<ReactotronReactNative> = {
     reactotronLibraryVersion: "REACTOTRON_REACT_NATIVE_VERSION",
     platform: Platform.OS,
     platformVersion: Platform.Version,
-    osRelease: constants.Release,
-    model: constants.Model,
-    serverHost: constants.ServerHost,
-    forceTouch: constants.forceTouchAvailable || false,
-    interfaceIdiom: constants.interfaceIdiom,
-    systemName: constants.systemName,
-    uiMode: constants.uiMode,
-    serial: constants.Serial,
-    androidId: constants.androidID,
+    ...getReactNativePlatformConstants(),
     reactNativeVersion: getReactNativeVersion(),
     ...getReactNativeDimensions(),
   },
@@ -96,8 +79,8 @@ const DEFAULTS: ClientOptions<ReactotronReactNative> = {
       name,
       Platform.OS,
       Platform.Version,
-      constants.systemName,
-      constants.Model,
+      getReactNativePlatformConstants().systemName,
+      getReactNativePlatformConstants().Model,
       dimensions,
       screenScale,
     ]

--- a/lib/reactotron-react-native/src/reactotron-react-native.ts
+++ b/lib/reactotron-react-native/src/reactotron-react-native.ts
@@ -48,6 +48,9 @@ const getHost = (defaultHost = "localhost") => {
   }
 }
 
+const { osRelease, model, serverHost, forceTouch, interfaceIdiom, systemName, uiMode, serial } =
+  getReactNativePlatformConstants()
+
 const DEFAULTS: ClientOptions<ReactotronReactNative> = {
   createSocket: (path: string) => new WebSocket(path), // eslint-disable-line
   host: getHost("localhost"),
@@ -59,7 +62,14 @@ const DEFAULTS: ClientOptions<ReactotronReactNative> = {
     reactotronLibraryVersion: "REACTOTRON_REACT_NATIVE_VERSION",
     platform: Platform.OS,
     platformVersion: Platform.Version,
-    ...getReactNativePlatformConstants(),
+    osRelease,
+    model,
+    serverHost,
+    forceTouch,
+    interfaceIdiom,
+    systemName,
+    uiMode,
+    serial,
     reactNativeVersion: getReactNativeVersion(),
     ...getReactNativeDimensions(),
   },
@@ -75,15 +85,13 @@ const DEFAULTS: ClientOptions<ReactotronReactNative> = {
     // Accounting for screen rotation
     const dimensions = [screenWidth, screenHeight].sort().join("-")
 
-    tempClientId = [
-      name,
-      Platform.OS,
-      Platform.Version,
-      getReactNativePlatformConstants().systemName,
-      getReactNativePlatformConstants().Model,
-      dimensions,
-      screenScale,
-    ]
+    const additionalInfo = Platform.select({
+      ios: systemName,
+      android: model,
+      default: "",
+    })
+
+    tempClientId = [name, Platform.OS, Platform.Version, additionalInfo, dimensions, screenScale]
       .filter(Boolean)
       .join("-")
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [ ] I have added tests for any new features, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Closes #1486 
- `NativeModules` aren't available in bridgeless, so we utilize the `TurboModuleRegistry` to dig up the same calls we were using (this is backwards compatible)
- [ ] Maybe want to do better TSing over `eslint-disable` but I'll leave that up to @morganick's review 😅 

> [!WARNING]  
> The `DevMenu` change is not Expo Go compatible. This will never work in Expo Go as documented in https://github.com/infinitered/ignite/issues/2678. This would only impact the client devtools code, which they could remove the custom command from the Reactotron configuration (in this repo, it's just in the example app, hence the CNG change)


```bash
ERROR  Invariant Violation: TurboModuleRegistry.getEnforcing(...): 'DevMenu' could not be found. Verify that a module by this name is registered in the native binary.Bridgeless mode: false. TurboModule interop: false.

Modules loaded: {"NativeModules":["PlatformConstants","LogBox","BlobModule","PlatformConstants","SourceCode","PlatformConstants","DeviceInfo"],"TurboModules":[],"NotFound":["DevMenu"]}, js engine: hermes
```