### PR TITLE
fix(.circleci): electronuserland/builder:20-wine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,11 +340,6 @@ workflows:
           filters:
             branches:
               ignore: *release_branch_names
-        # DO NOT MERGE: TEMP CHANGE TO TEST PR
-      - build_app_windows:
-          filters:
-            branches:
-              ignore: *release_branch_names
       - publish-docs/build_docs:
           <<: *ir_docs_config
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,7 @@ jobs:
     <<: *defaults
     docker:
       - image: electronuserland/builder:20-wine
+    resource_class: large
     environment:
       BUILD_TARGET: windows
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
   build_app_windows:
     <<: *defaults
     docker:
-      - image: electronuserland/builder:16-wine
+      - image: electronuserland/builder:20-wine
     environment:
       BUILD_TARGET: windows
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,11 @@ workflows:
           filters:
             branches:
               ignore: *release_branch_names
+        # DO NOT MERGE: TEMP CHANGE TO TEST PR
+      - build_app_windows:
+          filters:
+            branches:
+              ignore: *release_branch_names
       - publish-docs/build_docs:
           <<: *ir_docs_config
           filters:


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
This PR to fix this [CircleCI failure](https://app.circleci.com/pipelines/github/infinitered/reactotron/2478/workflows/f652a467-1905-4cce-b184-35ade28a2c01/jobs/3326) by updating the docker image to a [more recent tag](https://hub.docker.com/r/electronuserland/builder/tags).

The reason why it was failing is that the docker image [electronuserland/builder:16-wine](https://hub.docker.com/layers/electronuserland/builder/16-wine/images/sha256-87efa4ff09eabc913094942a4f48d02ff6f27597155adef3f23fcc948106541b?context=explore) uses node 16, which yarn 4 is no longer compatable.

Bumping the docker image to [electronuserland/builder:20-wine](https://hub.docker.com/layers/electronuserland/builder/20-wine/images/sha256-d33a2fd3b3a86c773fec534df9cf215038180779303c6019a2964650e27e58d7?context=explore) makes use of Node 20.

This separate docker image is needed to compile the Reactotron Electron app on Windows. The default node orb appears to use [lts by default](https://circleci.com/developer/orbs/orb/circleci/node?version=5.2.0#executors-default), so that is likely why it hasn't been failing since it isn't pinned.