### PR TITLE
docs: resolve image and warning formating

### DIFF
--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -10,7 +10,7 @@ There are three main parties:
 2. The Electron app with Reactotron's UI, which subscribes to app updates
 3. The app client that we are debugging, which sends commands with information about the app to the server
 
-<img src="./images/architecture-app-mobile-diagram.png" alt="Diagram of the Reactotron Electron app, reactotron-core-server, and the app client" />
+![Diagram of the Reactotron Electron app, reactotron-core-server, and the app client.](./images/architecture-app-mobile-diagram.png)
 
 Websockets are used to sends "commands", which are JSON objects with information about the app we are debugging. The payloads are sent to the server, which then publishes them to all subscribers (like the Electron app).
 
@@ -18,7 +18,7 @@ Websockets are used to sends "commands", which are JSON objects with information
 
 This repository is broken into different workspaces:
 
-<img src="./images/architecture-workspace-chart.png" alt="Diagram of the Reactotron electron app and client, and which workspaces they correspond to." />
+![Diagram of the Reactotron electron app and client, and which workspaces they correspond to.](./images/architecture-workspace-chart.png)
 
 ### Reactotron app
 

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -16,13 +16,13 @@ For PRs from untrusted forks, to run the CI scripts, we need to:
 ## How to run the CI scripts on untrusted forks:
 
 1. Copy the name of the branch from the PR.
-   <img src="./images/ci-copy-fork-branch.png" alt="ci-copy-fork-branch" width="400"/>
+   ![Copy Fork Branch](./images/ci-copy-fork-branch.png)
 2. From your local clone of the main repository, run the `ci:trust` script.
-    ```bash
-    yarn ci:trust <branch-name>
-    ```
+   ```bash
+   yarn ci:trust <branch-name>
+   ```
 3. The branch will be pushed and the tests will run
-   <img src="./images/ci-tests-running.png" alt="ci-tests-running" width="400"/>
+   ![CI Tests Running](./images/ci-tests-running.png)
 
 ## What does ci:trust do?
 
@@ -38,7 +38,7 @@ The `ci:trust` script does the following:
 1. The ci:trust script will only work if you have write access to the main repository. This prevents malicious users from running the script on the main repository.
 2. The ci:trust script pushes the commits to a branch called `temp-ci-trusted-fork`.
 
-::: warning
+:::warning
 
 The `temp-ci-trusted-fork` branch will be deleted and recreated if it already exists. This allows the script to
 clean up its own temporary branches.


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
This PR resolves some image formatting issues in the Reactotron docs: https://docs.infinite.red/reactotron/contributing/architecture/

### Before
<img width="1362" alt="Screenshot 2024-10-28 at 11 35 43 AM" src="https://github.com/user-attachments/assets/ed98c989-2d89-4f7c-99cd-2c978eb7bd6b">

<img width="1359" alt="Screenshot 2024-10-28 at 11 34 09 AM" src="https://github.com/user-attachments/assets/951ccf46-ccca-44f5-9cf6-d62fb318b2f1">

### After
<img width="1355" alt="Screenshot 2024-10-28 at 11 34 54 AM" src="https://github.com/user-attachments/assets/e7c49a04-73dd-4372-a836-ef20ce803888">

<img width="1529" alt="Screenshot 2024-10-28 at 11 35 30 AM" src="https://github.com/user-attachments/assets/266ccb12-bbff-4453-9f9b-e0c52fb19b24">
