### PR TITLE
Fix: Handling console.log(null)

### DIFF
--- a/lib/reactotron-core-ui/src/timelineCommands/LogCommand/index.tsx
+++ b/lib/reactotron-core-ui/src/timelineCommands/LogCommand/index.tsx
@@ -174,37 +174,41 @@ function getLevelName(level: string) {
 
 // function getPreview(message: string | object | boolean | number) {
 function getPreview(message: any) {
-  if (typeof message === "string") {
-    return message.substr(0, 500)
-  } else if (typeof message === "object") {
-    const firstValues = {}
+  // Special case: typeof null === "object"
+  // Explanation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null
+  if (message === null) return "null"
 
-    Object.keys(message)
-      .slice(0, 5)
-      .forEach((key) => (firstValues[key] = message[key]))
+  switch (typeof message) {
+    case "string":
+      return message.slice(0, 500)
+    case "object": {
+      const firstValues = {}
 
-    const preview = stringifyObject(firstValues, {
-      transform: (obj, prop, originalResult) => {
-        const objType = typeof obj[prop]
+      Object.keys(message)
+        .slice(0, 5)
+        .forEach((key) => (firstValues[key] = message[key]))
 
-        if (objType === "object") {
-          return "{...}"
-        } else if (objType === "string") {
-          return originalResult.substr(0, 80)
-        } else {
-          return originalResult
-        }
-      },
-    })
+      const preview = stringifyObject(firstValues, {
+        transform: (obj, prop, originalResult) => {
+          const objType = typeof obj[prop]
 
-    return Object.keys(message).length > Object.keys(firstValues).length
-      ? preview.replace(/\s\}$/i, ", ...}")
-      : preview
-  } else if (message === null || typeof message === "boolean" || typeof message === "number") {
-    return String(message)
+          if (objType === "object") {
+            return "{...}"
+          } else if (objType === "string") {
+            return originalResult.slice(0, 80)
+          } else {
+            return originalResult
+          }
+        },
+      })
+
+      return Object.keys(message).length > Object.keys(firstValues).length
+        ? preview.replace(/\s\}$/i, ", ...}")
+        : preview
+    }
+    default:
+      return String(message)
   }
-
-  return message
 }
 
 function useFileSource(stack: LogPayload, readFile: (path: string) => Promise<string>) {

--- a/lib/reactotron-core-ui/src/timelineCommands/LogCommand/index.tsx
+++ b/lib/reactotron-core-ui/src/timelineCommands/LogCommand/index.tsx
@@ -190,14 +190,15 @@ function getPreview(message: any) {
 
       const preview = stringifyObject(firstValues, {
         transform: (obj, prop, originalResult) => {
-          const objType = typeof obj[prop]
+          if (obj[prop] === null) return "null"
 
-          if (objType === "object") {
-            return "{...}"
-          } else if (objType === "string") {
-            return originalResult.slice(0, 80)
-          } else {
-            return originalResult
+          switch (typeof obj[prop]) {
+            case "object":
+              return "{...}"
+            case "string":
+              return originalResult.slice(0, 80)
+            default:
+              return originalResult
           }
         },
       })


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [ ] ~I have added tests for any new features, if relevant!~
- [ ] ~`README.md` (or relevant documentation) has been updated with your changes~

## Describe your PR

Fixes #1517 where calling `console.log` with `null` resulted in a blank screen. Now the comments around the function say that it only handles `string`, `object`, `number`, and `boolean`; however, the function takes a `message` of type `any`. Seems like we could narrow that down a bit. I've checked with all of the possible return values for `typeof` and documented that in the code.

The reason the bug existed is because `typeof null` results in `object`. The code -- nor many people-- were expecting that. Here's the reference to the docs as to why: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null

It appears that we do some things to not return functions as strings and we don't handle `Symbol`. Not sure if that's a requirement based on what the comments around the function say that it should accept as a message type.

⚠️ I'm not sure why the `getPreview` function returned just the raw message if we didn't discern what type it was. That seems like a bug. If someone has context as to why that was the case, I'd love to understand why.

## Screenshot
This is what it looks like now:

<img width="598" alt="image" src="https://github.com/user-attachments/assets/93c937eb-04bb-47c1-a219-1c751379924f">

Here's another case where we didn't handle `null` correctly and now we do:

<img width="775" alt="image" src="https://github.com/user-attachments/assets/83184221-0a79-407d-80cf-2aaefa7d5e55">

Happy Debugging 😎 

