### PR TITLE
chore(reactotron-app): refactor electron-store to match docs

### DIFF
--- a/apps/reactotron-app/src/renderer/components/Footer/Stateless.tsx
+++ b/apps/reactotron-app/src/renderer/components/Footer/Stateless.tsx
@@ -85,7 +85,7 @@ function renderCollapsed(
   return (
     <>
       <ConnectionInfo>
-        port {config.get("serverPort") as string} | {connections.length} connections
+        port {config.get("serverPort")} | {connections.length} connections
       </ConnectionInfo>
       {serverStatus === "portUnavailable" && (
         <ConnectionInfo>Port 9090 unavailable.</ConnectionInfo>

--- a/apps/reactotron-app/src/renderer/config.ts
+++ b/apps/reactotron-app/src/renderer/config.ts
@@ -1,24 +1,29 @@
 import Store from "electron-store"
 
-const schema = {
-  serverPort: {
-    type: "number",
-    default: 9090,
-  },
-  commandHistory: {
-    type: "number",
-    default: 500,
-  },
+type StoreType = {
+  serverPort: number
+  commandHistory: number
 }
 
-const configStore = new Store({ schema } as any)
+const config = new Store<StoreType>({
+  schema: {
+    serverPort: {
+      type: "number",
+      default: 9090,
+    },
+    commandHistory: {
+      type: "number",
+      default: 500,
+    },
+  },
+})
 
 // Setup defaults
-if (!configStore.has("serverPort")) {
-  configStore.set("serverPort", 9090)
+if (!config.has("serverPort")) {
+  config.set("serverPort", 9090)
 }
-if (!configStore.has("commandHistory")) {
-  configStore.set("commandHistory", 500)
+if (!config.has("commandHistory")) {
+  config.set("commandHistory", 500)
 }
 
-export default configStore
+export default config


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes

## Describe your PR

This PR does a minor refactor to our electron-store usage to trigger a release for reactotron-app, to release this PR https://github.com/infinitered/reactotron/pull/1521