### PR TITLE
chore(.circleci/config.yml): electronuserland/builder:20-wine-07.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ parameters:
 # Anchors define reusable sections of YAML
 # See: https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/
 anchors:
-
   ### Executors
   node_executor: &node_executor
     name: node/default
@@ -44,7 +43,6 @@ anchors:
     target_docs_dir: docs
     target_repo: git@github.com:infinitered/ir-docs.git
     target_repo_directory: ir-docs
-
 
 orbs:
   node: circleci/node@5.2.0
@@ -283,7 +281,7 @@ jobs:
     executor: *node_executor
     <<: *defaults
     docker:
-      - image: electronuserland/builder:20-wine
+      - image: electronuserland/builder:20-wine-chrome
     resource_class: large
     environment:
       BUILD_TARGET: windows
@@ -355,7 +353,7 @@ workflows:
     when:
       and:
         - not: << pipeline.parameters.force-publish-docs >>
-        - true  # Placeholder for correct YAML structure
+        - true # Placeholder for correct YAML structure
     jobs:
       - trust_check:
           filters:
@@ -387,7 +385,7 @@ workflows:
     when:
       and:
         - not: << pipeline.parameters.force-publish-docs >>
-        - true  # Placeholder for correct YAML structure
+        - true # Placeholder for correct YAML structure
     jobs:
       - build_and_test:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ jobs:
     executor: *node_executor
     <<: *defaults
     docker:
-      - image: electronuserland/builder:20-wine-chrome
+      - image: electronuserland/builder:20-wine-07.24
     resource_class: large
     environment:
       BUILD_TARGET: windows

--- a/apps/reactotron-app/src/renderer/App.tsx
+++ b/apps/reactotron-app/src/renderer/App.tsx
@@ -22,7 +22,6 @@ const AppContainer = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
-
   display: flex;
   flex-direction: column;
   background-color: ${(props) => props.theme.background};


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes

## Describe your PR

[This job passed with the same docker image tag](https://app.circleci.com/pipelines/github/infinitered/reactotron/2519/workflows/437dbf3c-a838-49b1-b7a9-59e7df52137d/jobs/3423) a few months ago. It appears the [electron-builder](https://www.electron.build/multi-platform-build.html#provided-docker-images) docs encourage pinning specific versions for this situation, because it appears the [image tag has changed in the latest run that failed](https://app.circleci.com/pipelines/github/infinitered/reactotron/2558/workflows/5c710dfe-c28b-47f9-b693-f5c59a6327c0/jobs/3499).

This PR attempt to address this by [pinning the docker image tag to a timestamped one](https://hubgw.docker.com/layers/electronuserland/builder/20-wine-07.24/images/sha256-d33a2fd3b3a86c773fec534df9cf215038180779303c6019a2964650e27e58d7) that will never change.

I confirmed that this is a CI issue by trying to do the build on my local windows machine and it passed.