### PR TITLE
Fix UI crash caused by unescaped regex symbols in the timeline search

### DIFF
--- a/apps/reactotron-app/src/renderer/pages/timeline/index.tsx
+++ b/apps/reactotron-app/src/renderer/pages/timeline/index.tsx
@@ -90,7 +90,13 @@ function Timeline() {
     setHiddenCommands,
   } = useContext(TimelineContext)
 
-  let filteredCommands = filterCommands(commands, search, hiddenCommands)
+  let filteredCommands
+  try {
+    filteredCommands = filterCommands(commands, search, hiddenCommands)
+  } catch (error) {
+    console.error(error)
+    filteredCommands = commands
+  }
 
   if (isReversed) {
     filteredCommands = filteredCommands.reverse()

--- a/lib/reactotron-core-ui/src/utils/escape-regex.test.ts
+++ b/lib/reactotron-core-ui/src/utils/escape-regex.test.ts
@@ -1,0 +1,19 @@
+import { escapeRegex } from "./escape-regex"
+
+it("should return same string when no special characters", () => {
+  expect(escapeRegex("hello")).toBe("hello")
+})
+it("should escape dot character", () => {
+  expect(escapeRegex("hello.world")).toBe("hello\\.world")
+})
+it("should escape multiple special characters", () => {
+  expect(escapeRegex("(test)*")).toBe("\\(test\\)\\*")
+})
+it("should escape all regex special characters", () => {
+  const specialChars = ".*+?^${}()|[]\\"
+  const expected = "\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\"
+  expect(escapeRegex(specialChars)).toBe(expected)
+})
+it("should handle empty string", () => {
+  expect(escapeRegex("")).toBe("")
+})

--- a/lib/reactotron-core-ui/src/utils/escape-regex.ts
+++ b/lib/reactotron-core-ui/src/utils/escape-regex.ts
@@ -1,0 +1,11 @@
+/**
+ * Escapes special characters in a string to be used in a regular expression.
+ *
+ * @param str The string in which to escape special regex characters.
+ * @returns A new string with special regex characters escaped.
+ * @example
+ * escapeRegex("foo.bar") // => "foo\.bar"
+ */
+export function escapeRegex(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}

--- a/lib/reactotron-core-ui/src/utils/filterCommands/filterCommands.test.ts
+++ b/lib/reactotron-core-ui/src/utils/filterCommands/filterCommands.test.ts
@@ -10,6 +10,9 @@ const TEST_COMMANDS = [
   { type: "ADUMMYOBJ", payload: { triggerType: "SEARCHTRIGGERTYPE" } },
   { type: "ADUMMYOBJ", payload: { description: "SEARCHDESCRIPTION" } },
   { type: "ADUMMYOBJ", payload: { request: { url: "SEARCHURL" } } },
+  { type: "REGEX", payload: { message: "[1234] Log text" } },
+  { type: "REGEX", payload: { message: "123 Log text" } },
+  { type: "REGEX", payload: { message: "Log text (123)" } },
   { type: "log", payload: { debug: "LOGDEBUG" } },
   { type: "client.intro", payload: { connection: "SEARCHCONNECTION" } },
   {
@@ -188,6 +191,16 @@ const TESTS = [
         },
       },
     ],
+  },
+  {
+    name: "search that results in a invalid regex",
+    search: "[123",
+    result: [{ type: "REGEX", payload: { message: "[1234] Log text" } }],
+  },
+  {
+    name: "another search that results in a invalid regex",
+    search: "123)",
+    result: [{ type: "REGEX", payload: { message: "Log text (123)" } }],
   },
 ]
 

--- a/lib/reactotron-core-ui/src/utils/filterCommands/index.ts
+++ b/lib/reactotron-core-ui/src/utils/filterCommands/index.ts
@@ -32,7 +32,8 @@ export function filterSearch(commands: any[], search: string) {
 
   if (trimmedSearch === "") return [...commands]
 
-  const searchRegex = new RegExp(trimmedSearch.replace(/\s/, "."), "i")
+  const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const searchRegex = new RegExp(escapeRegex(trimmedSearch).replace(/\s/, "."), "i")
 
   const matching = (value: string) => {
     if (!value) {

--- a/lib/reactotron-core-ui/src/utils/filterCommands/index.ts
+++ b/lib/reactotron-core-ui/src/utils/filterCommands/index.ts
@@ -1,5 +1,6 @@
 import { CommandType } from "reactotron-core-contract"
 import type { CommandTypeKey } from "reactotron-core-contract"
+import { escapeRegex } from "../escape-regex"
 
 function path(...searchPath) {
   return (obj) => {
@@ -32,7 +33,6 @@ export function filterSearch(commands: any[], search: string) {
 
   if (trimmedSearch === "") return [...commands]
 
-  const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
   const searchRegex = new RegExp(escapeRegex(trimmedSearch).replace(/\s/, "."), "i")
 
   const matching = (value: string) => {


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
This PR resolves a crash caused by unescaped regex symbols in the timeline search.
- Added a try/catch block to prevent rendering interruptions.
- Introduced a utility function to escape regex special characters and integrated it into the existing filter function.
- Now the filter function doesn't throw an error and is able to search using the special symbols.

Fixes #1541 

![Screenshot 2025-03-15 at 12 19 45](https://github.com/user-attachments/assets/b7317324-46c5-4082-b1c1-f6f453a60c5f)
