### PR TITLE
docs: update brew install commands

### DIFF
--- a/docs/quick-start/getting-started.md
+++ b/docs/quick-start/getting-started.md
@@ -16,6 +16,8 @@ Once installed, you need to add the Reactotron client to your project. Follow on
 - [**React Native**](./react-native.md#installing-reactotronapp)
 - [**React**](./react-js.md#installing-reactotronapp)
 
+If you run into an [issue](https://github.com/infinitered/reactotron/issues/1140) opening the application on Mac you can install with Homebrew instead: `brew install --cask reactotron`
+
 ## Where can I find more information?
 
 We recommend that you watch [Darin Wilson's](https://github.com/darinwilson) talk at [Chain React](https://chainreactconf.com/): [Chain React 2018: Debugging and Beyond with Reactotron](https://www.youtube.com/watch?v=UiPo9A9k7xc)!


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

This PR moves the change from https://github.com/infinitered/reactotron/pull/1316 into the new file where install docs are, and updates the command as per [the more up-to-date Homebrew instructions](https://github.com/infinitered/reactotron/issues/1140).

When we merge, let's please attribute the change to @allen-spicer-scoot since they originally wrote this. I just wanted to get it mergeable since docs locations changed out from under the original PR.