### PR TITLE
fix(networking): require XHRInterceptor based on React Native version

### DIFF
--- a/lib/reactotron-react-native/src/plugins/networking.ts
+++ b/lib/reactotron-react-native/src/plugins/networking.ts
@@ -4,6 +4,7 @@ import type { ReactotronCore, Plugin } from "reactotron-core-client"
 let XHRInterceptorModule
 try {
   // Try the new path first (for RN >= 0.79)
+  // Yay breaking changes :( https://github.com/facebook/react-native/releases/tag/v0.79.0#:~:text=APIs%3A%20Move-,XHRInterceptor,-API%20to%20src
   XHRInterceptorModule = require("react-native/src/private/inspector/XHRInterceptor")
 } catch (e) {
   try {

--- a/lib/reactotron-react-native/src/plugins/networking.ts
+++ b/lib/reactotron-react-native/src/plugins/networking.ts
@@ -1,5 +1,64 @@
-import XHRInterceptor from "react-native/Libraries/Network/XHRInterceptor"
 import type { ReactotronCore, Plugin } from "reactotron-core-client"
+
+function getXhrInterceptorPath() {
+  const defaultPath = "react-native/Libraries/Network/XHRInterceptor"
+  const newPath = "react-native/src/private/inspector/XHRInterceptor"
+
+  try {
+    const reactNativeVersionString = require("react-native/package.json").version
+    const match = reactNativeVersionString.match(/^(\d+)\.(\d+)\./)
+
+    if (match) {
+      const major = parseInt(match[1], 10)
+      const minor = parseInt(match[2], 10)
+      // RN 0.79 introduced the change
+      if (major === 0 && minor < 79) {
+        return defaultPath
+      } else {
+        // >= 0.79 or future versions
+        return newPath
+      }
+    } else {
+      console.error(
+        "Reactotron: Could not parse React Native version string:",
+        reactNativeVersionString
+      )
+      console.error(`Reactotron: Defaulting to import XHRInterceptor from ${defaultPath}`)
+      return defaultPath // Default path on parse error
+    }
+  } catch (e) {
+    console.error("Reactotron: Failed to read React Native version from package.json.", e)
+    console.error(`Reactotron: Defaulting to import XHRInterceptor from ${defaultPath}`)
+    return defaultPath // Default path on require error
+  }
+}
+
+// Dynamically require XHRInterceptor
+let XHRInterceptor
+const xhrInterceptorPath = getXhrInterceptorPath()
+
+try {
+  XHRInterceptor = require(xhrInterceptorPath)
+  // Basic check to ensure the required module looks like the XHRInterceptor
+  if (
+    typeof XHRInterceptor?.setSendCallback !== "function" ||
+    typeof XHRInterceptor?.setResponseCallback !== "function" ||
+    typeof XHRInterceptor?.enableInterception !== "function"
+  ) {
+    throw new Error("Required XHRInterceptor module does not have expected methods.")
+  }
+} catch (e) {
+  console.error(`Reactotron: Failed to require XHRInterceptor from ${xhrInterceptorPath}.`, e)
+  console.warn(
+    "Reactotron: XHRInterceptor could not be loaded. Network monitoring will be disabled."
+  )
+  // Assign a dummy object to prevent crashes later when calling its methods
+  XHRInterceptor = {
+    setSendCallback: () => {},
+    setResponseCallback: () => {},
+    enableInterception: () => {},
+  }
+}
 
 /**
  * Don't include the response bodies for images by default.


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes

## Describe your PR

Resolves https://github.com/infinitered/reactotron/issues/420 https://github.com/infinitered/reactotron/issues/1554
- Now we try to require two different known paths for XHRInterceptor in React Native.
- Implemented error handling for loading the XHRInterceptor module, ensuring network monitoring is disabled gracefully if it fails to load.

## Test Plan

Install PR changes using [contributing guide](https://docs.infinite.red/reactotron/contributing/#bring-your-own-application)

- Install `reactotron-react-native` in a `"react-native": "^0.79.0"` app and verify that network calls are logged 

https://github.com/user-attachments/assets/47826a64-c498-4bc8-a69e-b2b464150552


- Install `reactotron-react-native` in a `"react-native": "0.78.0"` app and verify that network calls are logged

https://github.com/user-attachments/assets/1b5da333-5710-484f-a352-c1583f24c8d5

