### PR TITLE
fix: PLUGIN_DEFAULTS type in asyncStorage.ts

### DIFF
--- a/lib/reactotron-react-native/src/plugins/asyncStorage.ts
+++ b/lib/reactotron-react-native/src/plugins/asyncStorage.ts
@@ -4,7 +4,7 @@ export interface AsyncStorageOptions {
   ignore?: string[]
 }
 
-const PLUGIN_DEFAULTS: AsyncStorageOptions = {
+const PLUGIN_DEFAULTS: Required<AsyncStorageOptions> = {
   ignore: [],
 }
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
This PR fixes a type issue where `ts` thinks ignore is possibly undefined due to `PLUGIN_DEFAULTS` type being incorrect.

`ignore` has a fallback to a blank array if user has not defined it, however the compiler thinks the fallback is undefined due to explicit type `AsyncStorageOptions`. 

`const ignore = config.ignore || PLUGIN_DEFAULTS.ignore`

Screenshot of issue in IDE
![image](https://github.com/user-attachments/assets/94051676-9ec4-41ed-ae59-5c10d2f7638d)

