### PR TITLE
feat(asyncStorage):  support RegEx and add pattern string match to ignore async plugin key

### DIFF
--- a/docs/plugins/async-storage.md
+++ b/docs/plugins/async-storage.md
@@ -26,10 +26,12 @@ And you're done! Now you can see your AsyncStorage in Reactotron.
 
 ## Advanced Usage
 
-`asyncStorage()` also accepts an object with an `ignore` key. The value is an array of strings you would like to prevent sending to Reactotron.
+`asyncStorage()` also accepts an object with an `ignore` key to filter against. The value of `ignore` is an array of string or RegExp patterns that match against AsyncStorage keys you want to prevent from being sent to Reactotron.
+
+> String patterns match any key containing that text, while RegExp patterns use standard regex matching.
 
 ```js
 asyncStorage({
-  ignore: ["secret"],
+  ignore: ["secret", /^debug_/, "temp"],
 })
 ```

--- a/lib/reactotron-react-native/src/plugins/asyncStorage.ts
+++ b/lib/reactotron-react-native/src/plugins/asyncStorage.ts
@@ -8,6 +8,18 @@ const PLUGIN_DEFAULTS: AsyncStorageOptions = {
   ignore: [],
 }
 
+function shouldIgnore(key, ignore) {
+  for (const pattern of ignore) {
+    if (typeof pattern === "string") {
+      return key.includes(pattern)
+    }
+    if (pattern instanceof RegExp) {
+      return pattern.test(key)
+    }
+  }
+  return false
+}
+
 const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronCore) => {
   // setup configuration
   const config = Object.assign({}, PLUGIN_DEFAULTS, options || {})
@@ -28,7 +40,7 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
 
   const setItem: AsyncStorageStatic["setItem"] = async (key, value, callback) => {
     try {
-      if (ignore.indexOf(key) < 0) {
+      if (!shouldIgnore(key, ignore)) {
         sendToReactotron("setItem", { key, value })
       }
     } catch (e) {}
@@ -37,7 +49,7 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
 
   const removeItem: AsyncStorageStatic["removeItem"] = async (key, callback) => {
     try {
-      if (ignore.indexOf(key) < 0) {
+      if (!shouldIgnore(key, ignore)) {
         sendToReactotron("removeItem", { key })
       }
     } catch (e) {}
@@ -46,7 +58,7 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
 
   const mergeItem: AsyncStorageStatic["mergeItem"] = async (key, value, callback) => {
     try {
-      if (ignore.indexOf(key) < 0) {
+      if (!shouldIgnore(key, ignore)) {
         sendToReactotron("mergeItem", { key, value })
       }
     } catch (e) {}
@@ -63,7 +75,7 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
   const multiSet: AsyncStorageStatic["multiSet"] = async (pairs, callback) => {
     try {
       const shippablePairs = (pairs || []).filter(
-        (pair) => pair && pair[0] && ignore.indexOf(pair[0]) < 0
+        (pair) => pair && pair[0] && !shouldIgnore(pair[0], ignore)
       )
       if (shippablePairs.length > 0) {
         sendToReactotron("multiSet", { pairs: shippablePairs })
@@ -74,7 +86,7 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
 
   const multiRemove: AsyncStorageStatic["multiRemove"] = async (keys, callback) => {
     try {
-      const shippableKeys = (keys || []).filter((key) => ignore.indexOf(key) < 0)
+      const shippableKeys = (keys || []).filter((key) => !shouldIgnore(key, ignore))
       if (shippableKeys.length > 0) {
         sendToReactotron("multiRemove", { keys: shippableKeys })
       }
@@ -85,7 +97,7 @@ const asyncStorage = (options?: AsyncStorageOptions) => (reactotron: ReactotronC
   const multiMerge: AsyncStorageStatic["multiMerge"] = async (pairs, callback) => {
     try {
       const shippablePairs = (pairs || []).filter(
-        (pair) => pair && pair[0] && ignore.indexOf(pair[0]) < 0
+        (pair) => pair && pair[0] && !shouldIgnore(pair[0], ignore)
       )
       if (shippablePairs.length > 0) {
         sendToReactotron("multiMerge", { pairs: shippablePairs })

--- a/lib/reactotron-react-native/src/plugins/asyncStorage.ts
+++ b/lib/reactotron-react-native/src/plugins/asyncStorage.ts
@@ -1,7 +1,7 @@
 import type { ReactotronCore, Plugin } from "reactotron-core-client"
 import type { AsyncStorageStatic } from "@react-native-async-storage/async-storage"
 export interface AsyncStorageOptions {
-  ignore?: string[]
+  ignore?: (string | RegExp)[]
 }
 
 const PLUGIN_DEFAULTS: AsyncStorageOptions = {


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
This PR improves the asyncStorage() ignore functionality by adding support for regular expression patterns alongside existing string patterns. It also allows existing string patterns to get a partial match ignoring any keys that partially match. 

My personal use case was that aws amplify was storing tokens in AsyncStorage under key names I don't have control of this would be something like `@MemoryStorage:CognitoIdentityServiceProvider.4589348z&...` where I can now pattern match against `@MemoryStorage:CognitoIdentityServiceProvider.`