### PR TITLE
chore: Changed installation instruction to be more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Reactotron on the left, demo React Native app on the right.
 
 ## Installation
 
-On the [Releases](https://github.com/infinitered/reactotron/releases?q=reactotron-app&expanded=true) page, you can find the latest version of:
+On the [Releases](https://github.com/infinitered/reactotron/releases?q=reactotron-app&expanded=true) page, navigate to the latest `reactotron-app` release to find the newest version of:
 
 - macOS (x64 & arm64)
 - Linux (32-bit & 64-bit)

--- a/docs/quick-start/getting-started.md
+++ b/docs/quick-start/getting-started.md
@@ -9,7 +9,7 @@ title: Getting Started
 
 Reactotron exists as a desktop application (written in electron) that communicates with your react or react-native app over websockets. It's available for macOS, Linux, and Windows.
 
-First, you'll need to install the Reactotron desktop application. You can find the latest version on the [Releases](https://github.com/infinitered/reactotron/releases?q=reactotron-app&expanded=true) page.
+First, you'll need to install the Reactotron desktop application. On the [Releases](https://github.com/infinitered/reactotron/releases?q=reactotron-app&expanded=true) page, you will find `reactotron-app` release where you can download the latest version.
 
 Once installed, you need to add the Reactotron client to your project. Follow one of these quick start guides to get Reactotron up and running in your project:
 

--- a/docs/quick-start/react-js.md
+++ b/docs/quick-start/react-js.md
@@ -6,7 +6,7 @@ title: react
 
 ## Installing Reactotron.app
 
-Let’s [download the desktop app](https://github.com/infinitered/reactotron/releases?q=reactotron-app&expanded=true) to start. You can download for Linux, Windows, and Mac.
+Let’s [download the desktop app](https://github.com/infinitered/reactotron/releases?q=reactotron-app&expanded=true) to start. Expand `reactotron-app` release to download the latest version for Linux, Windows, and Mac.
 
 Unzip & run.
 

--- a/docs/quick-start/react-native.md
+++ b/docs/quick-start/react-native.md
@@ -7,7 +7,7 @@ title: react-native
 
 ## Installing Reactotron.app
 
-Let’s [download the desktop app](https://github.com/infinitered/reactotron/releases?q=reactotron-app&expanded=true) to start. You can download for Linux, Windows, and Mac.
+Let’s [download the desktop app](https://github.com/infinitered/reactotron/releases?q=reactotron-app&expanded=true) to start. Expand `reactotron-app` release to download the latest version for Linux, Windows, and Mac.
 
 Unzip & run.
 


### PR DESCRIPTION
Updated installation instructions to point to "-app" release to make it less confusing when trying to find a downloadable asset