### PR TITLE
chore(circleci): fix Windows build failures from node version bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,23 +398,23 @@ workflows:
           filters:
             branches:
               ignore: *release_branch_names
-      - build_app_macos:
-          context:
-            - ReactotronCerts
-            - infinitered-npm-package
-          requires:
-            - hold_for_app_builds
-          filters:
-            branches:
-              ignore: *release_branch_names
-      - build_app_linux:
-          context:
-            - infinitered-npm-package
-          requires:
-            - hold_for_app_builds
-          filters:
-            branches:
-              ignore: *release_branch_names
+      # - build_app_macos:
+      #     context:
+      #       - ReactotronCerts
+      #       - infinitered-npm-package
+      #     requires:
+      #       - hold_for_app_builds
+      #     filters:
+      #       branches:
+      #         ignore: *release_branch_names
+      # - build_app_linux:
+      #     context:
+      #       - infinitered-npm-package
+      #     requires:
+      #       - hold_for_app_builds
+      #     filters:
+      #       branches:
+      #         ignore: *release_branch_names
 
   # Allows for manual publishing of docs independent of deployment
   # Use the 'trigger pipeline' button in circle ci and set 'force-publish-docs' to 'true'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,9 +292,7 @@ jobs:
       SKIP_LIB_BUILD: "1"
     steps:
       - checkout
-      - run:
-          name: Install packages (skip postinstall)
-          command: YARN_ENABLE_SCRIPTS=0 yarn install --immutable
+      - install-packages
       - release-reactotron-app:
           os: Windows
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,9 @@ jobs:
       SKIP_LIB_BUILD: "1"
     steps:
       - checkout
-      - install-packages
+      - run:
+          name: Install packages (skip postinstall)
+          command: yarn install --immutable --ignore-scripts
       - release-reactotron-app:
           os: Windows
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ jobs:
       - checkout
       - run:
           name: Install packages (skip postinstall)
-          command: yarn install --immutable --ignore-scripts
+          command: YARN_ENABLE_SCRIPTS=0 yarn install --immutable
       - release-reactotron-app:
           os: Windows
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,23 +402,23 @@ workflows:
           filters:
             branches:
               ignore: *release_branch_names
-      # - build_app_macos:
-      #     context:
-      #       - ReactotronCerts
-      #       - infinitered-npm-package
-      #     requires:
-      #       - hold_for_app_builds
-      #     filters:
-      #       branches:
-      #         ignore: *release_branch_names
-      # - build_app_linux:
-      #     context:
-      #       - infinitered-npm-package
-      #     requires:
-      #       - hold_for_app_builds
-      #     filters:
-      #       branches:
-      #         ignore: *release_branch_names
+      - build_app_macos:
+          context:
+            - ReactotronCerts
+            - infinitered-npm-package
+          requires:
+            - hold_for_app_builds
+          filters:
+            branches:
+              ignore: *release_branch_names
+      - build_app_linux:
+          context:
+            - infinitered-npm-package
+          requires:
+            - hold_for_app_builds
+          filters:
+            branches:
+              ignore: *release_branch_names
 
   # Allows for manual publishing of docs independent of deployment
   # Use the 'trigger pipeline' button in circle ci and set 'force-publish-docs' to 'true'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,23 +285,13 @@ jobs:
   build_app_windows:
     <<: *defaults
     docker:
-      - image: electronuserland/builder:wine
+      - image: electronuserland/builder:20-wine-07.24
     resource_class: large
     environment:
       BUILD_TARGET: windows
       SKIP_LIB_BUILD: "1"
-      XDG_RUNTIME_DIR: /tmp/runtime-root
-      WINEDEBUG: -all
-      DISPLAY: :99
     steps:
       - checkout
-      - run:
-          name: Setup Wine environment
-          command: |
-            mkdir -p $XDG_RUNTIME_DIR
-            chmod 0700 $XDG_RUNTIME_DIR
-            Xvfb :99 -screen 0 1024x768x16 &
-            sleep 2
       - install-packages
       - release-reactotron-app:
           os: Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,12 @@ commands:
           command: yarn install --immutable
       - run:
           name: Build workspace packages
-          command: yarn build
+          command: |
+            if [ "$SKIP_LIB_BUILD" != "1" ]; then
+              yarn build
+            else
+              echo "Skipping workspace build (SKIP_LIB_BUILD=1)"
+            fi
       - save_cache:
           paths:
             - node_modules/
@@ -278,13 +283,13 @@ jobs:
             yarn release:artifacts $CIRCLE_TAG
 
   build_app_windows:
-    executor: *node_executor
     <<: *defaults
     docker:
-      - image: electronuserland/builder:wine-mono
+      - image: electronuserland/builder:wine
     resource_class: large
     environment:
       BUILD_TARGET: windows
+      SKIP_LIB_BUILD: "1"
       XDG_RUNTIME_DIR: /tmp/runtime-root
       WINEDEBUG: -all
       DISPLAY: :99

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,10 @@ jobs:
       - run:
           name: Typecheck
           command: yarn typecheck
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - lib/*/dist
   trust_check:
     executor: *node_executor
     steps:
@@ -292,6 +296,8 @@ jobs:
       SKIP_LIB_BUILD: "1"
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/repo
       - install-packages
       - release-reactotron-app:
           os: Windows

--- a/apps/reactotron-app/scripts/build.release.js
+++ b/apps/reactotron-app/scripts/build.release.js
@@ -45,7 +45,6 @@ if (skipSigning) {
  * @see https://www.electron.build/configuration/publish#githuboptions
  */
 const processVars = { macos: {}, windows: {}, linux: {} }
-/** @type {any} */
 const env = {
   ...process.env,
   BUILD_TARGET,
@@ -57,23 +56,5 @@ const $ = (cmd) => {
   require("child_process").execSync(cmd, { env, stdio: "inherit" })
 }
 
-// Set Wine-friendly environment when running on Linux (CircleCI builder image)
-const isLinux = process.platform === "linux"
-if (isLinux) {
-  env.XDG_RUNTIME_DIR = env.XDG_RUNTIME_DIR || `/tmp/runtime-${process.getuid?.() || "1000"}`
-  env.WINEDEBUG = env.WINEDEBUG || "-all"
-  env.WINEDLLOVERRIDES = env.WINEDLLOVERRIDES || "mscoree,mshtml="
-  env.WINEARCH = env.WINEARCH || "win64"
-  // Additional Wine stability tweaks for WiX 4
-  env.WINEPREFIX = env.WINEPREFIX || "/tmp/wine-prefix"
-  env.WINEDLLPATH = env.WINEDLLPATH || ""
-}
-
 console.log(`Building app with flags: '${flags}'...`)
-const skipLibBuild = process.env.SKIP_LIB_BUILD === "1"
-if (skipLibBuild) {
-  console.log("SKIP_LIB_BUILD=1, skipping workspace build")
-  $(`electron-builder ${flags}`)
-} else {
-  $(`yarn build && electron-builder ${flags}`)
-}
+$(`yarn build && electron-builder ${flags}`)

--- a/apps/reactotron-app/scripts/build.release.js
+++ b/apps/reactotron-app/scripts/build.release.js
@@ -45,6 +45,7 @@ if (skipSigning) {
  * @see https://www.electron.build/configuration/publish#githuboptions
  */
 const processVars = { macos: {}, windows: {}, linux: {} }
+/** @type {any} */
 const env = {
   ...process.env,
   BUILD_TARGET,
@@ -56,5 +57,23 @@ const $ = (cmd) => {
   require("child_process").execSync(cmd, { env, stdio: "inherit" })
 }
 
+// Set Wine-friendly environment when running on Linux (CircleCI builder image)
+const isLinux = process.platform === "linux"
+if (isLinux) {
+  env.XDG_RUNTIME_DIR = env.XDG_RUNTIME_DIR || `/tmp/runtime-${process.getuid?.() || "1000"}`
+  env.WINEDEBUG = env.WINEDEBUG || "-all"
+  env.WINEDLLOVERRIDES = env.WINEDLLOVERRIDES || "mscoree,mshtml="
+  env.WINEARCH = env.WINEARCH || "win64"
+  // Additional Wine stability tweaks for WiX 4
+  env.WINEPREFIX = env.WINEPREFIX || "/tmp/wine-prefix"
+  env.WINEDLLPATH = env.WINEDLLPATH || ""
+}
+
 console.log(`Building app with flags: '${flags}'...`)
-$(`yarn build && electron-builder ${flags}`)
+const skipLibBuild = process.env.SKIP_LIB_BUILD === "1"
+if (skipLibBuild) {
+  console.log("SKIP_LIB_BUILD=1, skipping workspace build")
+  $(`electron-builder ${flags}`)
+} else {
+  $(`yarn build && electron-builder ${flags}`)
+}

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+NODE_VERSION=$(node -v | cut -d. -f1 | cut -dv -f2)
+if [ "$NODE_VERSION" -lt "21" ]; then
+  echo "Node $NODE_VERSION detected, skipping workspace build to avoid Bob/arktype ESM issues"
+  exit 0
+fi
+
 echo "Build all workspace packages to ensure all internal dependencies are up to date"
 yarn build

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 NODE_VERSION=$(node -v | cut -d. -f1 | cut -dv -f2)
-if [ "$NODE_VERSION" -lt "21" ]; then
+if [ "$NODE_VERSION" -lt "21" && "$CI" = "true" ]; then
   echo "Node $NODE_VERSION detected, skipping workspace build to avoid Bob/arktype ESM issues"
   exit 0
 fi


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn build-and-test:local` passes
- [ ] I have added tests for any new features, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

**Problem:** After switching to react-native-builder-bob, Windows packaging started failing because Bob depends on arktype (ESM-only), which broke on Node <21. Upgrading to Node 22 fixed library builds but caused WiX/Wine errors in CI.

**Solution:** Split the toolchain to use Node 22 for library builds and Node 20 for Windows packaging.

**Changes:**

- Modified scripts/postinstall.sh - Skip workspace build on Node <21 to avoid Bob/arktype ESM issues during package installation
- Updated Windows CI job - Use electronuserland/builder:20-wine-07.24 with SKIP_LIB_BUILD=1 and workspace persistence
- Added workspace persistence - Main build job (Node 22) builds libraries and persists lib/*/dist for packaging jobs

Result: Libraries build successfully with Node 22, Windows packaging works reliably with Node 20 + Wine, and MSI builds complete without WiX errors.