### PR TITLE
fix: duplicate tooltips showing on header action buttons #1583

### DIFF
--- a/lib/reactotron-core-ui/src/components/ActionButton/index.tsx
+++ b/lib/reactotron-core-ui/src/components/ActionButton/index.tsx
@@ -17,10 +17,12 @@ interface Props {
 }
 
 function ActionButton({ icon: Icon, tip, tipProps = {}, onClick }: Props) {
+  const tooltipId = tipProps.id || "tooltip-default"
+
   return (
-    <Container data-tip={tip} onClick={onClick}>
+    <Container data-tip={tip} data-for={tooltipId} onClick={onClick}>
       <Icon size={24} />
-      <Tooltip {...tipProps} />
+      <Tooltip {...tipProps} id={tooltipId} />
     </Container>
   )
 }

--- a/lib/reactotron-core-ui/src/components/Header/index.tsx
+++ b/lib/reactotron-core-ui/src/components/Header/index.tsx
@@ -98,6 +98,7 @@ const Header: FunctionComponent<React.PropsWithChildren<HeaderComponentProps>> =
               <ActionButton
                 tip={a.tip}
                 tipProps={{
+                  id: `tip-${idx}`,
                   effect: "float",
                 }}
                 icon={a.icon}


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn build-and-test:local` passes
- [ ] I have added tests for any new features, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
This PR fixes the bug #1583 . 

### Problem  
When hovering over header action buttons (e.g. the “Reverse Order” icon), two identical tooltips appear (stacked). This is due to multiple `<ReactTooltip />` instances mounting for the same `data-tip` trigger.

### Fix Summary  
- Consolidate tooltip logic so that only **one** shared `<ReactTooltip />` is mounted (e.g. in the root or header component)  
- Use `data-for="tooltip-id"` on trigger elements to bind them to that shared tooltip instance  
