### PR TITLE
fix: placekitten.com is returning HTTP 521 (origin dead)

### DIFF
--- a/lib/reactotron-core-client/README.md
+++ b/lib/reactotron-core-client/README.md
@@ -247,7 +247,7 @@ and is a `data-uri`. This means, an ordinary http link will work, but as will em
 
 ```json
 {
-  "uri": "http://placekitten.com/g/400/400",
+  "uri": "https://cataas.com/cat?width=400&height=400",
   "preview": "placekitten.com!",
   "filename": "cat.jpg",
   "width": 400,
@@ -423,7 +423,7 @@ Sent from the client to the server to provide a way to show "custom" commands.
     "salad": true
   },
   "image": {
-    "uri": "http://placekitten.com/g/400/400"
+    "uri": "https://cataas.com/cat?width=400&height=400"
   },
   "important": true,
   "preview": "What's in my appetizer?"


### PR DESCRIPTION
`lib/reactotron-core-client/README.md` references `placekitten.com` URLs. The origin has been returning HTTP 521 (Cloudflare origin unreachable) for months.

---

#### Why this is needed

`placekitten.com`'s origin is returning HTTP 521 (Cloudflare origin unreachable) and has been unreliable throughout 2025-2026. The service is effectively dead for programmatic use.

Verify in any shell:

```
curl -sI --max-time 3 https://placekitten.com/300/200 | head -1
# HTTP/2 521
```

#### What this PR changes

Fixes the 2 `uri` examples in the `reactotron-core-client` README so the image-log examples actually render a cat image for developers trying reactotron for the first time.

#### Replacement details

`cataas.com` ('Cat as a Service') is alive, returns a 200 cat image at any size via `?width=<W>&height=<H>`, and preserves the *kitten-ness* of the original placekitten URL — which seems to be the point of the example. Also upgrades `http:` → `https:`.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** introduced as a dependency by this PR — the diff uses the dependency-free canonical replacement domain. If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering the broader broken-placeholder landscape: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
