### PR TITLE
feat(reactotron-mcp): expand redaction defaults and add form-urlencoded body support

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -57,10 +57,11 @@ By default, Reactotron redacts sensitive data from all MCP responses so that tok
 
 Out of the box, the following are replaced with `[REDACTED]`:
 
-- **HTTP headers** — `Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, `X-Auth-Token`, `Proxy-Authorization`
-- **Object keys** — `password`, `secret`, `api_key`, `access_token`, `refresh_token`, `private_key`, `credentials`, `ssn`, `creditcard`, and variants
-- **String values** matching common token formats — Bearer tokens, JWTs (`eyJ...`), OpenAI keys (`sk-...`), GitHub PATs (`ghp_...`), Slack tokens (`xoxb-...`)
+- **HTTP headers** — `Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, `X-Auth-Token`, `Proxy-Authorization`, `X-CSRF-Token`, `X-XSRF-Token`, `CSRF-Token`, `X-Forwarded-For`, `X-Real-IP`
+- **Object keys** — `password`, `passwd`, `pwd`, `secret`, `client_secret`, `api_key`, `token`, `bearer`, `jwt`, `access_token`, `refresh_token`, `id_token`, `session`, `sessionid`, `csrf`, `xsrf`, `private_key`, `credentials`, `ssn`, `creditcard`, and variants
+- **String values** matching common token formats — Bearer tokens, JWTs (`eyJ...`), OpenAI keys (`sk-...`), Anthropic keys (`sk-ant-...`), GitHub PATs/OAuth/user-to-server tokens (`ghp_/ghs_/gho_/ghu_/ghr_...`), Slack tokens (`xoxb-...`), AWS access key IDs (`AKIA...`), Google API keys (`AIza...`), Stripe keys (`sk_live_/pk_test_/...`), and PEM-encoded private key blocks
 - **URL query parameters** whose names match any sensitive key (e.g. `?api_key=abc` becomes `?api_key=[REDACTED]`)
+- **Form-urlencoded bodies** — strings shaped like `k=v&k=v` (e.g. `application/x-www-form-urlencoded` request bodies) get the same per-field redaction as URL query parameters
 
 ### Configuring redaction in Reactotron
 

--- a/lib/reactotron-mcp/src/redaction.ts
+++ b/lib/reactotron-mcp/src/redaction.ts
@@ -6,19 +6,44 @@ export const DEFAULT_REDACTION_RULES: McpRedactionRules = {
   headerNames: [
     "authorization", "cookie", "set-cookie",
     "x-api-key", "x-auth-token", "proxy-authorization",
+    "x-csrf-token", "x-xsrf-token", "csrf-token",
+    "x-forwarded-for", "x-real-ip",
   ],
   sensitiveKeys: [
-    "password", "secret", "apikey", "api_key", "accesstoken",
-    "access_token", "refreshtoken", "refresh_token", "privatekey",
-    "private_key", "credentials", "ssn", "creditcard",
+    "password", "passwd", "pwd",
+    "secret", "client_secret", "clientsecret",
+    "apikey", "api_key", "x-api-key",
+    "accesstoken", "access_token",
+    "refreshtoken", "refresh_token",
+    "idtoken", "id_token",
+    "token", "bearer", "jwt",
+    "session", "sessionid", "session_id",
+    "csrf", "xsrf", "csrf_token", "xsrf_token",
+    "privatekey", "private_key",
+    "credentials", "ssn", "creditcard",
   ],
   statePathPatterns: [],
   valuePatterns: [
+    // Bearer tokens
     "Bearer\\s+[A-Za-z0-9\\-._~+/]+=*",
+    // JWTs (header.payload[.signature])
     "eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
-    "sk-[a-zA-Z0-9]{20,}",
-    "ghp_[a-zA-Z0-9]{30,}",
+    // OpenAI-style keys (also matches our legacy "sk-..." pattern)
+    "sk-[a-zA-Z0-9_-]{20,}",
+    // Anthropic API keys
+    "sk-ant-[a-zA-Z0-9_-]{20,}",
+    // GitHub PATs / fine-grained tokens
+    "gh[pousr]_[A-Za-z0-9]{30,}",
+    // Slack tokens
     "xox[bpoas]-[a-zA-Z0-9\\-]{10,}",
+    // AWS access key IDs
+    "AKIA[0-9A-Z]{16}",
+    // Google API keys
+    "AIza[0-9A-Za-z\\-_]{35}",
+    // Stripe keys (live/test, secret/publishable/restricted)
+    "(?:sk|pk|rk)_(?:test|live)_[A-Za-z0-9]{24,}",
+    // PEM-encoded private key blocks (RSA, EC, DSA, OPENSSH, or generic)
+    "-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----[\\s\\S]+?-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----",
   ],
 }
 
@@ -222,7 +247,11 @@ function redactStringValue(value: string, rules: McpRedactionRules): string {
   // Redact URL query parameters whose names match sensitiveKeys
   const sensitiveKeys = rules.sensitiveKeys ?? []
   if (sensitiveKeys.length > 0) {
-    result = redactUrlQueryParams(result, sensitiveKeys)
+    if (result.includes("?")) {
+      result = redactUrlQueryParams(result, sensitiveKeys)
+    } else if (looksLikeFormEncoded(result)) {
+      result = redactFormEncodedParams(result, sensitiveKeys)
+    }
   }
 
   // Redact value patterns
@@ -236,6 +265,30 @@ function redactStringValue(value: string, rules: McpRedactionRules): string {
     }
   }
   return result
+}
+
+/**
+ * Detect a form-urlencoded body string (e.g. "user=alice&password=x"). Must be the whole
+ * string — `foo=bar` mid-sentence won't match. We require at least one "=" and that the
+ * full string is `k=v(&k=v)*` shape to avoid false positives on casual strings.
+ */
+function looksLikeFormEncoded(value: string): boolean {
+  if (!value || value.length > 8192) return false
+  return /^[\w.\-[\]%]+=[^&]*(?:&[\w.\-[\]%]+=[^&]*)*$/.test(value)
+}
+
+/** Redact values in a form-urlencoded body where the param name matches sensitiveKeys. */
+function redactFormEncodedParams(value: string, sensitiveKeys: string[]): string {
+  const sensitiveSet = new Set(sensitiveKeys.map((k) => k.toLowerCase()))
+  return value.split("&").map((param) => {
+    const eqIndex = param.indexOf("=")
+    if (eqIndex === -1) return param
+    const name = param.slice(0, eqIndex)
+    if (sensitiveSet.has(name.toLowerCase())) {
+      return `${name}=${REDACTED}`
+    }
+    return param
+  }).join("&")
 }
 
 /** Redact query parameter values in URLs where the param name matches sensitiveKeys. */

--- a/lib/reactotron-mcp/test/redaction.test.ts
+++ b/lib/reactotron-mcp/test/redaction.test.ts
@@ -319,10 +319,50 @@ describe("DEFAULT_REDACTION_RULES", () => {
     expect(DEFAULT_REDACTION_RULES.headerNames).toContain("x-api-key")
   })
 
+  test("includes CSRF/XSRF header variants", () => {
+    expect(DEFAULT_REDACTION_RULES.headerNames).toContain("x-csrf-token")
+    expect(DEFAULT_REDACTION_RULES.headerNames).toContain("x-xsrf-token")
+    expect(DEFAULT_REDACTION_RULES.headerNames).toContain("csrf-token")
+  })
+
+  test("includes IP-forwarding PII headers", () => {
+    expect(DEFAULT_REDACTION_RULES.headerNames).toContain("x-forwarded-for")
+    expect(DEFAULT_REDACTION_RULES.headerNames).toContain("x-real-ip")
+  })
+
   test("has expected default sensitive keys", () => {
     expect(DEFAULT_REDACTION_RULES.sensitiveKeys).toContain("password")
     expect(DEFAULT_REDACTION_RULES.sensitiveKeys).toContain("secret")
     expect(DEFAULT_REDACTION_RULES.sensitiveKeys).toContain("access_token")
+  })
+
+  test("includes common auth-token key variants", () => {
+    const keys = DEFAULT_REDACTION_RULES.sensitiveKeys ?? []
+    expect(keys).toContain("token")
+    expect(keys).toContain("bearer")
+    expect(keys).toContain("jwt")
+    expect(keys).toContain("id_token")
+    expect(keys).toContain("idtoken")
+  })
+
+  test("includes session and CSRF key variants", () => {
+    const keys = DEFAULT_REDACTION_RULES.sensitiveKeys ?? []
+    expect(keys).toContain("session")
+    expect(keys).toContain("sessionid")
+    expect(keys).toContain("csrf")
+    expect(keys).toContain("xsrf")
+  })
+
+  test("includes password aliases", () => {
+    const keys = DEFAULT_REDACTION_RULES.sensitiveKeys ?? []
+    expect(keys).toContain("passwd")
+    expect(keys).toContain("pwd")
+  })
+
+  test("includes OAuth client_secret variants", () => {
+    const keys = DEFAULT_REDACTION_RULES.sensitiveKeys ?? []
+    expect(keys).toContain("client_secret")
+    expect(keys).toContain("clientsecret")
   })
 
   test("value patterns match common token formats", () => {
@@ -347,5 +387,123 @@ describe("DEFAULT_REDACTION_RULES", () => {
     // Non-matching string
     const plainResult = redact("hello world", rules)
     expect(plainResult).toBe("hello world")
+  })
+
+  test("value patterns match Anthropic API keys", () => {
+    const rules: McpRedactionRules = { valuePatterns: DEFAULT_REDACTION_RULES.valuePatterns }
+    // Built at runtime so GitHub secret scanning doesn't flag the test file.
+    const fakeKey = ["sk", "ant"].join("-") + "-" + "x".repeat(32)
+    expect(redact(fakeKey, rules)).toBe(REDACTED)
+  })
+
+  test("value patterns match AWS access key IDs", () => {
+    const rules: McpRedactionRules = { valuePatterns: DEFAULT_REDACTION_RULES.valuePatterns }
+    const fakeKey = "AKI" + "A" + "X".repeat(16)
+    expect(redact(fakeKey, rules)).toBe(REDACTED)
+  })
+
+  test("value patterns match Google API keys", () => {
+    const rules: McpRedactionRules = { valuePatterns: DEFAULT_REDACTION_RULES.valuePatterns }
+    // Google API keys are 39 chars: prefix + 35 more.
+    const fakeKey = "AIz" + "a" + "X".repeat(35)
+    expect(redact(fakeKey, rules)).toBe(REDACTED)
+  })
+
+  test("value patterns match Stripe keys", () => {
+    const rules: McpRedactionRules = { valuePatterns: DEFAULT_REDACTION_RULES.valuePatterns }
+    const body = "X".repeat(28)
+    expect(redact(["sk", "live", body].join("_"), rules)).toBe(REDACTED)
+    expect(redact(["pk", "test", body].join("_"), rules)).toBe(REDACTED)
+    expect(redact(["rk", "live", body].join("_"), rules)).toBe(REDACTED)
+  })
+
+  test("value patterns match PEM private key blocks", () => {
+    const rules: McpRedactionRules = { valuePatterns: DEFAULT_REDACTION_RULES.valuePatterns }
+    const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----"
+    const result = redact(pem, rules)
+    expect(result).toBe(REDACTED)
+
+    const openssh = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjE=\n-----END OPENSSH PRIVATE KEY-----"
+    expect(redact(openssh, rules)).toBe(REDACTED)
+
+    const generic = "-----BEGIN PRIVATE KEY-----\nMIIEv...\n-----END PRIVATE KEY-----"
+    expect(redact(generic, rules)).toBe(REDACTED)
+  })
+
+  test("GitHub PAT pattern covers all prefix variants", () => {
+    const rules: McpRedactionRules = { valuePatterns: DEFAULT_REDACTION_RULES.valuePatterns }
+    // Built at runtime so GitHub secret scanning doesn't flag the test file.
+    const body = "X".repeat(36)
+    for (const prefix of ["ghp", "ghs", "gho", "ghu", "ghr"]) {
+      expect(redact(`${prefix}_${body}`, rules)).toBe(REDACTED)
+    }
+  })
+})
+
+describe("form-urlencoded body redaction", () => {
+  test("redacts sensitive values in form-encoded body strings", () => {
+    const rules: McpRedactionRules = {
+      sensitiveKeys: ["password", "token"],
+      valuePatterns: [],
+    }
+    const body = "username=alice&password=s3cret&token=abc123&remember=1"
+    const result = redact(body, rules)
+    expect(result).toBe(`username=alice&password=${REDACTED}&token=${REDACTED}&remember=1`)
+  })
+
+  test("redacts form-encoded inside a request.data string", () => {
+    const rules: McpRedactionRules = {
+      sensitiveKeys: ["password"],
+      valuePatterns: [],
+    }
+    const data = {
+      request: {
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        data: "user=alice&password=hunter2",
+      },
+    }
+    const result = redact(data, rules) as any
+    expect(result.request.data).toBe(`user=alice&password=${REDACTED}`)
+  })
+
+  test("does not false-positive on casual strings with '=' ", () => {
+    const rules: McpRedactionRules = {
+      sensitiveKeys: ["password"],
+      valuePatterns: [],
+    }
+    // Must NOT be treated as form-encoded — it's just prose with an equals sign.
+    const data = { note: "The setting x=5 was applied, and the count is 3" }
+    const result = redact(data, rules) as any
+    expect(result.note).toBe("The setting x=5 was applied, and the count is 3")
+  })
+
+  test("does not alter form-encoded strings when no sensitive key matches", () => {
+    const rules: McpRedactionRules = {
+      sensitiveKeys: ["password"],
+      valuePatterns: [],
+    }
+    const body = "page=1&limit=10&sort=desc"
+    expect(redact(body, rules)).toBe(body)
+  })
+
+  test("URL with query params still uses URL path, not form-encoded path", () => {
+    // Regression guard: a string containing '?' should go through the URL branch,
+    // not the form-encoded branch.
+    const rules: McpRedactionRules = {
+      sensitiveKeys: ["token"],
+      valuePatterns: [],
+    }
+    const url = "https://api.example.com/x?token=abc&page=1"
+    expect(redact(url, rules)).toBe(`https://api.example.com/x?token=${REDACTED}&page=1`)
+  })
+
+  test("handles bracketed and percent-encoded keys", () => {
+    const rules: McpRedactionRules = {
+      sensitiveKeys: ["password"],
+      valuePatterns: [],
+    }
+    const body = "user[name]=alice&password=hunter2"
+    const result = redact(body, rules)
+    expect(result).toBe(`user[name]=alice&password=${REDACTED}`)
   })
 })


### PR DESCRIPTION
## Summary

Stacks on top of #1607. Expands the MCP redactor's default denylists to match the cross-tool industry consensus and adds per-field redaction for `application/x-www-form-urlencoded` request bodies. Research comparing how other developer tools handle this is below — the short version: the closest analogs (Proxyman MCP, Sentry MCP, GitHub MCP, Postman) all redact at the server boundary by default, and their built-in denylists are broader than what #1607 currently ships.

## Changes

### Default rules — additions

**Header names**
- CSRF / XSRF variants: `x-csrf-token`, `x-xsrf-token`, `csrf-token`
- IP-forwarding PII headers: `x-forwarded-for`, `x-real-ip`

**Sensitive keys**
- Password aliases: `passwd`, `pwd`
- Generic auth-token names: `token`, `bearer`, `jwt`, `id_token`, `idtoken`
- Session & CSRF: `session`, `sessionid`, `session_id`, `csrf`, `xsrf`, `csrf_token`, `xsrf_token`
- OAuth: `client_secret`, `clientsecret`, `x-api-key`

**Value patterns**
- Anthropic API keys (`sk-ant-…`)
- AWS access key IDs (`AKIA…`)
- Google API keys (`AIza…` + 35 chars)
- Stripe secret/publishable/restricted keys, live + test (`(?:sk|pk|rk)_(?:test|live)_…`)
- PEM-encoded private key blocks (RSA, EC, DSA, OPENSSH, PGP, generic)
- GitHub PAT regex broadened from `ghp_` only to `gh[pousr]_` — covers classic, server-to-server, OAuth, user-to-server, and refresh tokens

### Form-urlencoded body redaction

A new code path catches strings shaped like `k=v&k=v` with no URL prefix (typical `application/x-www-form-urlencoded` POST bodies). If any key matches `sensitiveKeys`, just that value is redacted — the same semantics already used for URL query params. A strict full-match regex prevents false positives on prose that happens to contain `=`.

### Tests

105 tests passing. New coverage:
- Each category of new default rule
- Each new value pattern, with test literals constructed at runtime so GitHub secret-scanning doesn't flag the test file
- Form-urlencoded body redaction, including negative tests for casual strings and URL-containing strings

### Docs

`docs/mcp.md` updated to reflect the expanded default list and call out form-body handling.

---

## Research — how other tools handle this

We spawned parallel research on how similar developer tools handle sensitive-data redaction. Full notes kept in the PR discussion; the convergent findings:

### 1. Redact at the server/MCP boundary — unanimous
Every closest analog does it at the MCP serialization layer, not in the UI and not in the model:
- **Proxyman MCP** — *"Sensitive data (auth tokens, passwords, API keys) is automatically redacted in responses"* ([docs](https://docs.proxyman.com/mcp))
- **Sentry MCP** — inherits Sentry's server-side scrubber
- **GitHub MCP** — scans inputs for secrets and blocks by default ([changelog](https://github.blog/changelog/2025-08-13-github-mcp-server-secret-scanning-push-protection-and-more/))
- **Postman Repro** — case-insensitive default-key redaction
- **mitmproxy `FilteredDumper` pattern** — redact at display/egress, not on the wire

**OWASP MCP Top 10 — MCP01:2025** explicitly mandates: *"redact or sanitize inputs and outputs before logging… redact or mask secrets before writing to logs or telemetry."* ([link](https://owasp.org/www-project-mcp-top-10/2025/MCP01-2025-Token-Mismanagement-and-Secret-Exposure))

### 2. No `sensitive` / `secretHint` annotation exists in the MCP spec today
The 2025-03-26 spec adds `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` — but the maintainers are explicit: *"clients MUST NOT rely solely on these for security decisions."* ([MCP blog](https://blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/)) Treat server-side redaction as the hard boundary; don't wait for an annotation.

### 3. The de-facto default denylist
Union across **Sentry**, **Bugsnag**, **google/har-sanitizer**, **Postman**, **Chrome DevTools sanitized HAR**, **Presidio**:

- Headers: `Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `X-Api-Key`, `X-CSRF-Token`, `X-XSRF-Token`, `X-Forwarded-For`
- Keys: `password`/`passwd`/`pwd`, `secret`, `token`, `bearer`, `jwt`, `auth`, `authorization`, `api_key`/`apikey`, `credentials`, `session`/`sessionid`, `csrf`/`xsrf`, `access_token`, `refresh_token`, `id_token`, `client_secret`, `private_key`
- Value patterns: AWS (`AKIA…`), Google (`AIza…`), JWT (`eyJ…`), Stripe, GitHub PATs (all prefixes), PEM private key blocks, Anthropic (`sk-ant-…`)

This PR brings our defaults in line with that union.

### 4. Tool-by-tool highlights

| Tool | Redaction approach | What we took / avoided |
|---|---|---|
| **Charles Proxy** | None built-in; user-written Rewrite rules only | Avoid its "bring your own regex" UX — ship opinionated defaults |
| **Wireshark** | `editcap` + third-party TraceWrangler; fail-closed pattern | Noted `strictMode` allowlist as future work |
| **Postman** | "Secret" variable type masks UI only; still exfiltrated in analytics URLs — cautionary tale | Redact the fully-rendered payload at MCP boundary, not at display |
| **mitmproxy / Proxyman** | `modify_headers`, Python addons; Proxyman MCP auto-redacts but rules are opaque/non-tunable | Keep user-tunable config; don't ship an opaque rule set |
| **Chrome DevTools** | `Export HAR (sanitized)` strips `Authorization`, `Cookie`, `Set-Cookie` only (Chrome 130, Oct 2024) | That's the floor. We already go beyond. |
| **google/har-sanitizer** | Public [wordlist](https://github.com/google/har-sanitizer/blob/master/harsanitizer/static/wordlist.json) — `state`, `token`, `access_token`, `client_secret`, `SAMLRequest`, etc. | Directly informed our expanded default key list |
| **Cloudflare HAR sanitizer** | Conditional, not denylist — strips JWT signature but keeps claims for debugging | Filed as a future enhancement (partial/format-preserving redaction) |
| **Sentry / Bugsnag / Datadog / LogRocket** | Opinionated server-side defaults + user-extendable via `beforeSend`-style hook; Datadog offers partial redaction & Luhn-validated card detection | Union of their default lists → our new defaults. Partial redaction & Luhn are follow-ups. |

### Key canonical incident
**Okta support breach (Oct 2023)** — attacker stole HAR files from 134 customer support tickets; the HARs contained live session tokens that were used to hijack sessions at BeyondTrust, Cloudflare, and 1Password. The PR's default-on posture is the right response to this class of leak.

---

## What is intentionally NOT in this PR

Tracked as follow-ups so the review stays focused:

- **Substring matching on keys.** Sentry JS and Bugsnag match substrings; that catches `sessionToken`/`userPassword` automatically but false-positives on `author`/`authored_by` when `auth` is in the list. Would need a separate denylist/pattern split.
- **Typed redaction markers** (`[REDACTED:jwt]`) and a `_redacted` summary sibling field. Useful for LLM reasoning and defensive-sandwich logging but changes the public output shape.
- **Luhn-validated credit-card detection.** A bare 13–19 digit regex produces too many false positives on random IDs and unix timestamps; needs Luhn to be safe.
- **Cookie-value parsing within the `Cookie` header.** Currently the whole header is blunt-redacted. Cloudflare's per-cookie approach (keep names, redact values) would preserve more debug info.
- **Partial / format-preserving masking** (keep last 4 of card, keep JWT claims but strip signature) — the strongest idea from Cloudflare/Datadog, worth a dedicated PR.
- **`strictMode` allowlist** (à la TraceWrangler's "drop unknown layers" / mitmproxy's `FilteredDumper`) — only forward known-safe headers, redact the rest.

## Test plan

- [x] `yarn test` in `lib/reactotron-mcp` — 105 tests pass
- [x] `yarn typecheck` clean
- [x] `yarn build` succeeds
- [ ] Reviewer sanity-check: no new default key is an obvious false-positive trigger for any team's app-specific field names
- [ ] Reviewer sanity-check: form-encoded regex doesn't false-positive on real-world payloads in your apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)