### PR TITLE
chore(ci): bump publish-docs orb to @0.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ anchors:
 
 orbs:
   node: circleci/node@5.2.0
-  publish-docs: infinitered/publish-docs@0.4
+  publish-docs: infinitered/publish-docs@0.5
 
 commands:
   install-packages:


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [ ] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

Bumps the `infinitered/publish-docs` orb from `@0.4` (resolves to v0.4.13) to `@0.5` (resolves to v0.5.1). This unbreaks `publish-docs/publish_docs` on master pushes when the merge commit body contains markdown / multi-line content.

### Why

The orb's v0.4.13 wrote unescaped multi-line shell content to `$BASH_ENV` via `echo "export VAR=\"$VAL\""`. When the merge commit's body had colons (e.g. inline JSON snippets) or newlines, bash interpreted each line as a command after sourcing `$BASH_ENV` at the start of the next step. Symptom on the master push for #1609:

```
/tmp/.bash_env-...-build: line 39: README.md: command not found
/tmp/.bash_env-...-build: line 39: NPM_TOKEN: command not found
... [40+ more]
Error: Not a GitHub URL.
Exited with code exit status 1
```

### Changes

- `.circleci/config.yml` — bump `publish-docs: infinitered/publish-docs@0.4` → `@0.5`.

### Notes

- Fix is upstream in [infinitered/orb-publish-docs#40](https://github.com/infinitered/orb-publish-docs/pull/40), released as `v0.5.1` today. Replaces the unsafe `echo "export VAR=\"$VAL\""` patterns with `printf 'export VAR=%q\n' "$VAL"` in 5 internal scripts.
- The `0.4 → 0.5` diff is internal only — no job, command, or parameter signatures change. All existing usage (`publish-docs/build_docs` and `publish-docs/publish_docs` with `ir_docs_config` params) remains compatible.
- Verified `npx nx affected --target=version --base=origin/master --head=HEAD` returns 0 projects, so this merge will not cascade-trigger any unintended package releases.
- Using `@0.5` (auto-resolves to latest 0.5.x) rather than pinned `@0.5.1` so future patch fixes apply automatically. Matches the prior `@0.4` style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)