### PR TITLE
feat(reactotron-react-native): re-export McpRedaction types for mcpRedaction config

### DIFF
--- a/lib/reactotron-react-native/package.json
+++ b/lib/reactotron-react-native/package.json
@@ -47,7 +47,8 @@
   },
   "dependencies": {
     "mitt": "^3.0.1",
-    "reactotron-core-client": "workspace:*"
+    "reactotron-core-client": "workspace:*",
+    "reactotron-core-contract": "workspace:*"
   },
   "resolutions": {
     "@types/react-native": "0.72.1"

--- a/lib/reactotron-react-native/src/reactotron-react-native.ts
+++ b/lib/reactotron-react-native/src/reactotron-react-native.ts
@@ -200,5 +200,6 @@ export {
 }
 
 export type { ClientOptions }
+export type { McpRedactionConfig, McpRedactionRules } from "reactotron-core-contract"
 
 export default reactotron

--- a/yarn.lock
+++ b/yarn.lock
@@ -27104,6 +27104,7 @@ __metadata:
     react-native: "npm:0.73.6"
     react-native-builder-bob: "npm:^0.40.13"
     reactotron-core-client: "workspace:*"
+    reactotron-core-contract: "workspace:*"
     rimraf: "npm:5.0.5"
     ts-jest: "npm:^29.1.1"
     typescript: "npm:^4.9.5"


### PR DESCRIPTION
The nx tasks didn't pick up reactotron-react-native for a new release with the latest changes, this forces a new release with the mcp redaction config changes via declaring reactotron-core-contract a direct dependency and re-exporting the redaction types
