### PR TITLE
fix(reactotron-react-native): harden fetch interceptor error isolation and restore

### DIFF
--- a/docs/plugins/networking.md
+++ b/docs/plugins/networking.md
@@ -33,6 +33,7 @@ And you're done! Now you can see your XMLHttpRequests in Reactotron.
 - `ignoreContentTypes`: a regular expression which, when matched against the `Content-Type` response header, will prevent the data from being displayed in Reactotron. You typically want to do this for images (which is the default). `text/event-stream` response bodies are always skipped so streaming responses are not buffered.
 - `ignoreUrls`: a regular expression which, when matched against the URL of the request, will prevent the request from being tracked in Reactotron. Can be useful for ignoring noisy logging requests.
 - `ignoreExpoFetch`: set to `true` to skip instrumenting Expo's `expo/fetch` (the default `globalThis.fetch` on Expo SDK 56+). Has no effect on non-Expo runtimes, where the global fetch is XHR-backed and already covered by XHR tracking.
+- `fetch`: explicitly pass the fetch function to track; it is wrapped and installed as `globalThis.fetch` on connect, skipping the automatic `expo/fetch` detection. Takes precedence over `ignoreExpoFetch`.
 
 ```js
 networking({
@@ -40,3 +41,22 @@ networking({
   ignoreUrls: /\/(logs|symbolicate)$/,
 });
 ```
+
+### Tracking fetch in expo-router apps
+
+Expo Router (the default `create-expo-app` template) re-wraps `globalThis.fetch` at startup with its `window.location` polyfill, which drops the marker the automatic `expo/fetch` detection looks for — so on expo-router apps fetch requests are silently not tracked. Automatic detection for expo-router apps is in the works (tracked in [#1612](https://github.com/infinitered/reactotron/issues/1612)); until then, use the `fetch` option to track them:
+
+```js
+Reactotron.configure()
+  .useReactNative({
+    networking: { fetch: globalThis.fetch },
+  })
+  .connect();
+```
+
+Two caveats:
+
+- **Ordering**: capture `globalThis.fetch` in code that runs _after_ `expo-router/entry` has set up its wrapper (any module imported from your app code qualifies — the router entry runs first). Capturing it too early passes the pre-router fetch, and the router's wrapper will be bypassed or clobbered.
+- **No XHR-backed fetch**: only pass a fetch that does _not_ go through `XMLHttpRequest` (e.g. don't use this with `EXPO_PUBLIC_USE_RN_FETCH=1`). XHR-backed fetch is already tracked by the XHR interceptor, so wrapping it here would double-report every request.
+
+Also note: Expo SDK 56 releases before 56.0.19 have a `Response.clone()` bug ([expo#46397](https://github.com/expo/expo/pull/46397)) where cloning a response twice can throw a spurious "body already used" error. Reactotron reads response bodies off a clone while tracking is active, so if your app also clones responses, upgrade to expo 56.0.19+ (or SDK 57).

--- a/lib/reactotron-react-native/src/fetch-interceptor.test.ts
+++ b/lib/reactotron-react-native/src/fetch-interceptor.test.ts
@@ -141,4 +141,105 @@ describe("FetchInterceptor", () => {
     expect(globalThis.fetch).toBe(original)
     expect(FetchInterceptor.isInterceptorEnabled()).toBe(false)
   })
+
+  it("does not break the caller's fetch when the open callback throws", async () => {
+    const response = makeResponse(200, {})
+    globalThis.fetch = makeExpoFetch(() => Promise.resolve(response))
+    FetchInterceptor.setOpenCallback(() => {
+      throw new Error("reactotron bug")
+    })
+    FetchInterceptor.enableInterception()
+
+    const result = await (globalThis.fetch as any)("https://x.test/?q=%E0%A4%A")
+    expect(result).toBe(response)
+  })
+
+  it("does not reject a successful response when the response callback throws", async () => {
+    const response = makeResponse(200, {})
+    globalThis.fetch = makeExpoFetch(() => Promise.resolve(response))
+    FetchInterceptor.setResponseCallback(() => {
+      throw new Error("reactotron bug")
+    })
+    FetchInterceptor.enableInterception()
+
+    const result = await (globalThis.fetch as any)("https://x.test")
+    expect(result).toBe(response)
+  })
+
+  it("propagates the app's own network error even when the response callback throws", async () => {
+    const boom = new Error("offline")
+    globalThis.fetch = makeExpoFetch(() => Promise.reject(boom))
+    FetchInterceptor.setResponseCallback(() => {
+      throw new Error("reactotron bug")
+    })
+    FetchInterceptor.enableInterception()
+
+    await expect((globalThis.fetch as any)("https://x.test")).rejects.toBe(boom)
+  })
+
+  it("leaves the global alone on disable when a third party wrapped fetch after us", async () => {
+    const response = makeResponse(200, {})
+    const original = makeExpoFetch(() => Promise.resolve(response))
+    globalThis.fetch = original
+    FetchInterceptor.enableInterception()
+    const ours = globalThis.fetch
+
+    // a third party wraps on top of us
+    const thirdParty: any = (...args: any[]) => (ours as any)(...args)
+    globalThis.fetch = thirdParty
+
+    FetchInterceptor.disableInterception()
+
+    // the third party's wrapper must survive, and ours must pass through inert
+    expect(globalThis.fetch).toBe(thirdParty)
+    const open = jest.fn()
+    FetchInterceptor.setOpenCallback(open)
+    const result = await (globalThis.fetch as any)("https://x.test")
+    expect(result).toBe(response)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it("does not install an explicit non-global fetch onto the global on disable", () => {
+    const globalBefore: any = jest.fn()
+    globalThis.fetch = globalBefore
+    const explicit: any = jest.fn(() => Promise.resolve(makeResponse(200, {})))
+
+    FetchInterceptor.enableInterception(explicit)
+    expect(globalThis.fetch).not.toBe(globalBefore)
+
+    FetchInterceptor.disableInterception()
+    // restore what was global when we wrapped — never the explicit function
+    expect(globalThis.fetch).toBe(globalBefore)
+  })
+
+  it("extracts method and url from Request-object input", async () => {
+    const response = makeResponse(200, {})
+    globalThis.fetch = makeExpoFetch(() => Promise.resolve(response))
+    const open = jest.fn()
+    FetchInterceptor.setOpenCallback(open)
+    FetchInterceptor.enableInterception()
+
+    const request = new Request("https://example.com/req", { method: "PUT" })
+    await (globalThis.fetch as any)(request)
+
+    expect(open).toHaveBeenCalledTimes(1)
+    const [method, url] = open.mock.calls[0]
+    expect(method).toBe("PUT")
+    expect(url).toBe("https://example.com/req")
+  })
+
+  it("extracts the url from URL-object input", async () => {
+    const response = makeResponse(200, {})
+    globalThis.fetch = makeExpoFetch(() => Promise.resolve(response))
+    const open = jest.fn()
+    FetchInterceptor.setOpenCallback(open)
+    FetchInterceptor.enableInterception()
+
+    await (globalThis.fetch as any)(new URL("https://example.com/from-url"))
+
+    expect(open).toHaveBeenCalledTimes(1)
+    const [method, url] = open.mock.calls[0]
+    expect(method).toBe("GET")
+    expect(url).toBe("https://example.com/from-url")
+  })
 })

--- a/lib/reactotron-react-native/src/fetch-interceptor.ts
+++ b/lib/reactotron-react-native/src/fetch-interceptor.ts
@@ -49,6 +49,9 @@ interface ReactotronFetch {
 let openCallback: FetchInterceptorOpenCallback | null
 let responseCallback: FetchInterceptorResponseCallback | null
 let originalFetch: typeof fetch | null = null
+let wrappedFetch: ReactotronFetch | null = null
+let previousGlobalFetch: typeof fetch | null = null
+let wrapperState: { stopped: boolean } | null = null
 let requestId = 0
 
 function isExpoFetch(fn: unknown): boolean {
@@ -140,35 +143,65 @@ export const FetchInterceptor = {
     }
 
     originalFetch = current as typeof fetch
+    previousGlobalFetch = globalThis.fetch
+
+    // Closed over (rather than reading module state) so the wrapper keeps
+    // working as a plain pass-through even after disableInterception, when a
+    // third party has wrapped fetch on top of us and we can't restore the global.
+    const original = current as typeof fetch
+    const state = { stopped: false }
 
     const wrapped: ReactotronFetch = function (input: any, init?: any) {
-      const id = (requestId += 1)
-      const requestHeaders = headersToObject(
-        (init && init.headers) || (isRequest(input) ? input.headers : null)
-      )
-      const data =
-        init && typeof init.body === "string"
-          ? init.body
-          : init && init.body
-            ? "[non-string body]"
-            : null
-
-      if (openCallback) {
-        openCallback(getMethod(input, init), getUrl(input), requestHeaders, data, id)
+      if (state.stopped) {
+        return original(input, init)
       }
 
-      return (originalFetch as typeof fetch)(input, init).then(
+      const id = (requestId += 1)
+      // Reactotron-internal failures must never alter the app's fetch — parse
+      // and report inside try/catch, and always defer to the real fetch.
+      try {
+        if (openCallback) {
+          const requestHeaders = headersToObject(
+            (init && init.headers) || (isRequest(input) ? input.headers : null)
+          )
+          const data =
+            init && typeof init.body === "string"
+              ? init.body
+              : init && init.body
+                ? "[non-string body]"
+                : null
+          openCallback(getMethod(input, init), getUrl(input), requestHeaders, data, id)
+        }
+      } catch (instrumentationError) {
+        // swallow: reporting is best-effort, the request itself must proceed
+      }
+
+      return original(input, init).then(
         (response) => {
           // Fire synchronously and return the original response untouched, so
           // the caller is never blocked and streaming bodies stay intact.
-          if (responseCallback) {
-            responseCallback(id, response.status, headersToObject(response.headers), response, null)
+          try {
+            if (responseCallback) {
+              responseCallback(
+                id,
+                response.status,
+                headersToObject(response.headers),
+                response,
+                null
+              )
+            }
+          } catch (instrumentationError) {
+            // swallow: a reporting failure must not reject a successful response
           }
           return response
         },
         (error) => {
-          if (responseCallback) {
-            responseCallback(id, -1, null, null, error)
+          try {
+            if (responseCallback) {
+              responseCallback(id, -1, null, null, error)
+            }
+          } catch (instrumentationError) {
+            // swallow: the app's own network error must propagate unchanged
           }
           throw error
         }
@@ -180,16 +213,30 @@ export const FetchInterceptor = {
     if (isExpoFetch(current)) {
       wrapped[EXPO_BUILTIN] = true
     }
+    wrappedFetch = wrapped
+    wrapperState = state
     globalThis.fetch = wrapped
   },
 
-  // Unpatch the global fetch and remove the callbacks.
+  // Unpatch the global fetch and remove the callbacks. If something else has
+  // wrapped fetch on top of us since, the global is left alone and our wrapper
+  // just goes inert (pass-through) — ripping out a later wrapper isn't ours to do.
   disableInterception() {
     if (!originalFetch) {
       return
     }
-    globalThis.fetch = originalFetch
+    if (wrapperState) {
+      wrapperState.stopped = true
+    }
+    if (globalThis.fetch === wrappedFetch && previousGlobalFetch) {
+      // Restore what was global when we wrapped — not necessarily the wrapped
+      // function itself (an explicitly passed fetch may never have been global).
+      globalThis.fetch = previousGlobalFetch
+    }
     originalFetch = null
+    wrappedFetch = null
+    previousGlobalFetch = null
+    wrapperState = null
     openCallback = null
     responseCallback = null
   },

--- a/lib/reactotron-react-native/src/plugins/networking.test.ts
+++ b/lib/reactotron-react-native/src/plugins/networking.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Plugin-level tests for the expo/fetch side of the networking plugin
+ * (onFetchOpen / onFetchResponse), driven through the real FetchInterceptor.
+ */
+
+// xhr-interceptor captures XMLHttpRequest.prototype methods at module load, so
+// a stub must exist before the plugin (which imports it) is required.
+/* eslint-disable @typescript-eslint/no-empty-function */
+class FakeXMLHttpRequest {
+  open() {}
+
+  send() {}
+
+  setRequestHeader() {}
+}
+/* eslint-enable @typescript-eslint/no-empty-function */
+;(globalThis as any).XMLHttpRequest = FakeXMLHttpRequest
+
+// Disable reason: must require after the XMLHttpRequest stub is installed.
+/* eslint-disable @typescript-eslint/no-var-requires */
+const networking = require("./networking").default
+const { FetchInterceptor } = require("../fetch-interceptor")
+const { XHRInterceptor } = require("../xhr-interceptor")
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+function makeResponse(
+  status: number,
+  headersObj: Record<string, string>,
+  bodyText = "",
+  cloneThrows = false
+) {
+  return {
+    status,
+    headers: {
+      get: (k: string) => headersObj[k.toLowerCase()] ?? null,
+      forEach: (cb: (v: string, k: string) => void) =>
+        Object.entries(headersObj).forEach(([k, v]) => cb(v, k)),
+    },
+    clone() {
+      if (cloneThrows) throw new TypeError("Response body is already used")
+      return this
+    },
+    text: () => Promise.resolve(bodyText),
+  }
+}
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe("networking plugin (expo/fetch path)", () => {
+  const realFetch = globalThis.fetch
+  let reactotron: { startTimer: () => () => number; apiResponse: jest.Mock }
+
+  function connect(response: any, options: Record<string, unknown> = {}) {
+    const fetchImpl: any = jest.fn(() => Promise.resolve(response))
+    reactotron = { startTimer: () => () => 42, apiResponse: jest.fn() }
+    const plugin = networking({ fetch: fetchImpl, ...options })(reactotron as any)
+    plugin.onConnect()
+    return fetchImpl
+  }
+
+  afterEach(() => {
+    FetchInterceptor.disableInterception()
+    XHRInterceptor.disableInterception()
+    globalThis.fetch = realFetch
+  })
+
+  it("reports request and response through apiResponse", async () => {
+    connect(makeResponse(200, { "content-type": "application/json" }, '{"ok":true}'))
+
+    await (globalThis.fetch as any)("https://example.com/x?a=1&b=two+words", { method: "POST" })
+    await flushPromises()
+
+    expect(reactotron.apiResponse).toHaveBeenCalledTimes(1)
+    const [tronRequest, tronResponse, duration] = reactotron.apiResponse.mock.calls[0]
+    expect(tronRequest.url).toBe("https://example.com/x?a=1&b=two+words")
+    expect(tronRequest.method).toBe("POST")
+    expect(tronRequest.params).toEqual({ a: "1", b: "two words" })
+    expect(tronResponse.status).toBe(200)
+    expect(tronResponse.body).toEqual({ ok: true })
+    expect(duration).toBe(42)
+  })
+
+  it("does not throw on malformed percent-encoding in query params", async () => {
+    connect(makeResponse(200, { "content-type": "application/json" }, "{}"))
+
+    // %E0%A4%A is malformed — decodeURIComponent would throw
+    await expect(
+      (globalThis.fetch as any)("https://example.com/x?q=%E0%A4%A&ok=1")
+    ).resolves.toBeDefined()
+    await flushPromises()
+
+    expect(reactotron.apiResponse).toHaveBeenCalledTimes(1)
+    const [tronRequest] = reactotron.apiResponse.mock.calls[0]
+    // malformed value falls back to the raw string; valid values still decode
+    expect(tronRequest.params).toEqual({ q: "%E0%A4%A", ok: "1" })
+  })
+
+  it("reports ~~~ unreadable ~~~ when clone() throws", async () => {
+    connect(makeResponse(200, { "content-type": "application/json" }, "", true))
+
+    await (globalThis.fetch as any)("https://example.com/x")
+    await flushPromises()
+
+    expect(reactotron.apiResponse).toHaveBeenCalledTimes(1)
+    const [, tronResponse] = reactotron.apiResponse.mock.calls[0]
+    expect(tronResponse.body).toBe("~~~ unreadable ~~~")
+  })
+
+  it("skips bodies for streaming content types without touching the response", async () => {
+    const response = makeResponse(200, { "content-type": "text/event-stream" })
+    const cloneSpy = jest.spyOn(response, "clone")
+    connect(response)
+
+    await (globalThis.fetch as any)("https://example.com/stream")
+    await flushPromises()
+
+    expect(cloneSpy).not.toHaveBeenCalled()
+    const [, tronResponse] = reactotron.apiResponse.mock.calls[0]
+    expect(tronResponse.body).toBe("~~~ skipped ~~~")
+  })
+
+  it("does not report requests matching ignoreUrls", async () => {
+    connect(makeResponse(200, { "content-type": "application/json" }, "{}"), {
+      ignoreUrls: /\/logs$/,
+    })
+
+    await (globalThis.fetch as any)("https://example.com/logs")
+    await flushPromises()
+
+    expect(reactotron.apiResponse).not.toHaveBeenCalled()
+  })
+})

--- a/lib/reactotron-react-native/src/plugins/networking.ts
+++ b/lib/reactotron-react-native/src/plugins/networking.ts
@@ -38,6 +38,18 @@ export interface NetworkingOptions {
 
 const DEFAULTS: NetworkingOptions = {}
 
+/**
+ * decodeURIComponent that falls back to the raw string on malformed
+ * percent-encoding (e.g. `?q=%E0%A4%A`) instead of throwing.
+ */
+function tryDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch (malformedUri) {
+    return value
+  }
+}
+
 const networking =
   (pluginConfig: NetworkingOptions = {}) =>
   (reactotron: ReactotronCore) => {
@@ -203,7 +215,7 @@ const networking =
           .forEach((pair) => {
             const [key, value] = pair.split("=")
             if (key && value !== undefined) {
-              params[key] = decodeURIComponent(value.replace(/\+/g, " "))
+              params[key] = tryDecodeURIComponent(value.replace(/\+/g, " "))
             }
           })
       }
@@ -249,9 +261,16 @@ const networking =
       }
 
       // Clone synchronously (before the caller consumes the body), then read
-      // asynchronously so we don't block the request.
-      response
-        .clone()
+      // asynchronously so we don't block the request. clone() itself can throw
+      // if the body is already disturbed (e.g. another tool consumed it first).
+      let clone: Response
+      try {
+        clone = response.clone()
+      } catch (cloneError) {
+        report("~~~ unreadable ~~~")
+        return
+      }
+      clone
         .text()
         .then((text) => {
           let body


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

> **Stacked on #1613 — do not merge first.** This branch contains #1613's two commits plus one hardening commit (`171bbc6e`). Once #1613 merges, this rebases down to just the fix commit.

Follow-up hardening for the expo/fetch interceptor from #1613, aligning it with how mainstream fetch instrumentors (Sentry, Datadog RUM, OpenTelemetry) guard the monkey-patching boundary:

### Error isolation
All reactotron-internal work inside the wrapped fetch (request parsing, open/response callbacks) now runs in try/catch, so an instrumentation bug can never make the app's own `fetch` throw, reject a successful response, or replace a network error. Previously `fetch("https://x.test/?q=%E0%A4%A")` threw a synchronous `URIError` out of the app's own call via `decodeURIComponent`; query-param decoding now falls back to the raw string on malformed percent-encoding.

### Guarded restore ("good citizen" unpatching)
`disableInterception` only reassigns `globalThis.fetch` when it is still our wrapper. If a third party (Sentry, MSW, a polyfill) wrapped fetch after us, the global is left alone and our wrapper goes inert (pass-through) — matching Datadog's documented instrumentation etiquette. It also restores what was global at enable time, so disabling after wrapping an explicitly passed non-global fetch no longer installs that function onto the global.

### Safe clone
`response.clone()` failures (disturbed body — possible on expo < 56.0.19 due to expo#46397) report `~~~ unreadable ~~~` instead of throwing.

### Docs
`docs/plugins/networking.md` now documents the `fetch` option (the expo-router escape hatch), including the ordering caveat (capture `globalThis.fetch` after `expo-router/entry` has run), the no-XHR-backed-fetch warning, and the expo < 56.0.19 clone `bodyUsed` bug.

### Tests
+7 interceptor tests (throwing callbacks on all three paths, third-party-wrap-then-disable, explicit-non-global disable, `Request`/`URL` input forms) and a new plugin-level suite for `onFetchOpen`/`onFetchResponse` (malformed query params, clone failure, event-stream skip, ignoreUrls suppression). 31 tests pass; lint/typecheck/format green across the monorepo.

Deliberately out of scope (better discussed separately): a `Proxy`-based wrapper instead of symbol re-stamping, a response body size cap, and detecting expo-router's `Symbol.for('expo.polyfillFetchWithWindowLocation')` wrapper (the auto-detection gap on router apps — needs a double-reporting guard design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
