### PR TITLE
fix(reactotron-redux): return empty keys for primitive state paths

### DIFF
--- a/lib/reactotron-redux/src/commandHandler.test.ts
+++ b/lib/reactotron-redux/src/commandHandler.test.ts
@@ -92,7 +92,24 @@ describe("commandHandler", () => {
 
     commandHandler({ type: "state.keys.request", payload: { path: "topLevel.here.nested" } })
 
-    expect(reactotronMock.stateKeysResponse).toHaveBeenCalledWith("topLevel.here.nested", undefined)
+    expect(reactotronMock.stateKeysResponse).toHaveBeenCalledWith("topLevel.here.nested", [])
+  })
+
+  it("should handle a 'state.keys.request' command type for a null path", () => {
+    const reactotronMock = {
+      ...defaultReactotronMock,
+      reduxStore: {
+        getState: jest.fn().mockReturnValue({ topLevel: { here: null } }),
+        subscribe: jest.fn(),
+      },
+      stateKeysResponse: jest.fn(),
+    }
+
+    const commandHandler = createCommandHandler(reactotronMock, defaultPluginConfig, () => {})
+
+    commandHandler({ type: "state.keys.request", payload: { path: "topLevel.here" } })
+
+    expect(reactotronMock.stateKeysResponse).toHaveBeenCalledWith("topLevel.here", [])
   })
 
   it("should handle a 'state.keys.request' command type for a path that is invalid", () => {
@@ -109,10 +126,7 @@ describe("commandHandler", () => {
 
     commandHandler({ type: "state.keys.request", payload: { path: "topLevel2.here.nested" } })
 
-    expect(reactotronMock.stateKeysResponse).toHaveBeenCalledWith(
-      "topLevel2.here.nested",
-      undefined
-    )
+    expect(reactotronMock.stateKeysResponse).toHaveBeenCalledWith("topLevel2.here.nested", [])
   })
 
   it("should handle a 'state.values.request' command type for a single level", () => {
@@ -166,6 +180,23 @@ describe("commandHandler", () => {
     commandHandler({ type: "state.values.request", payload: { path: "topLevel.here.nested" } })
 
     expect(reactotronMock.stateValuesResponse).toHaveBeenCalledWith("topLevel.here.nested", true)
+  })
+
+  it("should handle a 'state.values.request' command type for a null path", () => {
+    const reactotronMock = {
+      ...defaultReactotronMock,
+      reduxStore: {
+        getState: jest.fn().mockReturnValue({ topLevel: { here: null } }),
+        subscribe: jest.fn(),
+      },
+      stateValuesResponse: jest.fn(),
+    }
+
+    const commandHandler = createCommandHandler(reactotronMock, defaultPluginConfig, () => {})
+
+    commandHandler({ type: "state.values.request", payload: { path: "topLevel.here" } })
+
+    expect(reactotronMock.stateValuesResponse).toHaveBeenCalledWith("topLevel.here", null)
   })
 
   it("should handle a 'state.values.request' command type for a path that is invalid", () => {

--- a/lib/reactotron-redux/src/commandHandler.ts
+++ b/lib/reactotron-redux/src/commandHandler.ts
@@ -48,9 +48,9 @@ export default function createCommandHandler<Client extends ReactotronCore = Rea
             responseMethod(
               payload.path,
               type === "state.keys.request"
-                ? typeof filteredObj === "object"
+                ? filteredObj !== null && typeof filteredObj === "object"
                   ? Object.keys(filteredObj)
-                  : undefined
+                  : []
                 : filteredObj
             )
           }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn build-and-test:local` passes
- [x] I have added tests for any new features, if relevant
- [x] README/docs are not affected by this internal payload correction

## Describe your PR

`state.keys.request` currently forwards `undefined` when a requested Redux path resolves to a primitive or is invalid. That violates `StateKeysResponsePayload.keys: string[]` and can break desktop consumers that iterate the field.

This returns an empty key list for non-object paths. The null guard is intentional: `typeof null === "object"`, so checking only `typeof` would call `Object.keys(null)` and throw. Object paths still use `Object.keys`, while `state.values.request` keeps forwarding the original value unchanged.

Fixes #1599.

## Verification

- `yarn build-and-test:local`
- `yarn workspace reactotron-redux test --runInBand` — 8 suites, 53 passed, 3 todo
- Packed `reactotron-redux` and inspected the compiled CommonJS handler
- Ran the real Redux handler into the desktop `StateKeysResponseCommand`; a primitive path produced `keys: []` and rendered the empty-state message without entering the error boundary
- Counterfactual: reverting only the source fix with the final tests kept fails three cases (`undefined` for primitive and invalid paths, plus `Object.keys(null)`); restoring the fix passes
